### PR TITLE
Completion fade cascade and "Show completed" toggle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,10 @@ There is **no test runner and no linter** configured. `typecheck` is the only st
 - **The schema intentionally has no zod `.default()` values** (`src/data/schema.ts`). Defaults make zod's inferred input type optional, which collides with TanStack DB's schema-typed collection overload. Always build complete nodes via `makeNode()` in `tree.ts`; don't add `.default()` to the schema.
 - **Mutations operate on the live `TreeIndex`.** Every function in `mutations.ts` takes the current index (so it can find siblings/order) and mutates `nodesCollection` directly. The editor holds the live-derived index in a ref (`focusIndex`) and passes `focusIndex.current` into command handlers, because the `commands` object is recreated each render but closures capture stale values otherwise.
 
+## Styling
+
+Going forward all styles will be inline Tailwind classes instead of a separate CSS file.
+
 ## Editor internals (OutlineEditor + OutlineNode)
 
 These two files have a few coupled patterns worth knowing before touching them:

--- a/docs/adr/0002-completion-fade-and-show-completed.md
+++ b/docs/adr/0002-completion-fade-and-show-completed.md
@@ -1,0 +1,74 @@
+# ADR 0002: Completion fade cascade and "Show completed" toggle
+
+Status: accepted (2026-06-21)
+
+Builds on [ADR 0001](./0001-completion-is-independent-of-task.md): `completed` is an
+independent boolean on every bullet.
+
+## Glossary
+
+- **Faded** — a bullet rendered at reduced opacity (more transparent), the visual
+  signal that it is done or lives under something done. The whole row fades as one
+  unit: bullet dot, checkbox, and text together. Not to be confused with *opaque*
+  (the opposite — fully solid).
+- **Strikethrough** — line-through on the text. Distinct from *faded*: strikethrough
+  marks a bullet that is itself completed; fading can also be inherited.
+- **Completed subtree** — a completed bullet plus all its descendants, regardless of
+  each descendant's own `completed` value.
+- **Show completed** — a single global, persisted UI toggle. When off, every
+  completed subtree is hidden from the outline.
+
+## Decisions
+
+### 1. The fade is visual-only. It never mutates child data.
+
+Completing a parent does **not** set `completed: true` on its descendants. Each
+bullet keeps its own done-status. Uncompleting the parent restores the children's
+individual appearance untouched. (Considered and rejected: cascading the boolean
+into descendants — it destroys real per-child state.)
+
+### 2. A bullet is faded iff itself, or any ancestor *within the current view*, is completed.
+
+Computed at render by walking down from the current root, carrying a single
+"an ancestor is completed" flag. No data, no derived field.
+
+### 3. No compounding. One fade level, any depth.
+
+A completed child under a completed parent looks identical to a single completed
+bullet — one opacity step, not stacked. The implementation must avoid nesting CSS
+`opacity` (which multiplies down the DOM); apply the fade per-row, gated by the
+inherited flag, not on the container.
+
+### 4. Faded bullets stay fully interactive.
+
+Editable, focusable, zoomable, collapsible. Fade is appearance only; it changes
+nothing about behavior.
+
+### 5. Strikethrough is self-only and text-only.
+
+- Completed bullet: faded row **and** strikethrough text.
+- Faded-by-ancestor child (not itself completed): faded row, **no** strikethrough.
+
+### 6. The fade cascade stops at the zoom root.
+
+When zoomed in, the root is the whole world. Its children are evaluated on their
+own `completed` state only — a completed ancestor *above* the root (now off-screen)
+contributes nothing. The root's title shows completed styling only if the root
+itself is completed.
+
+### 7. "Show completed" is one global, persisted boolean.
+
+- Lives in the app header (alongside the theme toggle), like Workflowy.
+- Persisted to `localStorage`; survives reload; applies to every view and zoom level.
+- When **off**, any completed bullet and its entire subtree are hidden — including
+  *incomplete* children of a completed parent (they vanish with the parent).
+- Stored under its own key, separate from the nodes collection. It is UI state, not
+  document data.
+
+## Why
+
+Completion fading is how an outline shows "done without deleting." Making it a pure
+render concern (decisions 1, 2) keeps the data model honest and reversible. The
+single-level, whole-row fade (3, 5) reads as one clear "done" state instead of a
+murky depth gradient. Stopping at the zoom root (6) keeps a zoomed branch usable.
+"Show completed" (7) is the escape hatch for when even faded clutter is too much.

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { ModeToggle } from "./mode-toggle";
+import { ShowCompletedToggle } from "./show-completed-toggle";
 
 /**
  * App header row: breadcrumb trail on the left (passed as children, since it's
@@ -17,7 +18,8 @@ export function Header({ children }: { children?: ReactNode }) {
           720px outline content below. */}
       <div className="mx-auto flex max-w-[720px] items-center justify-between gap-3 px-6 py-3">
         <div className="min-w-0 flex-1">{children}</div>
-        <div className="shrink-0">
+        <div className="flex shrink-0 items-center gap-1">
+          <ShowCompletedToggle />
           <ModeToggle />
         </div>
       </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from "react";
+import { ModeToggle } from "./mode-toggle";
+
+/**
+ * App header row: breadcrumb trail on the left (passed as children, since it's
+ * owned by OutlineEditor's zoom logic), theme switcher on the right. The
+ * breadcrumb still renders its Home button at the top level, so the header is
+ * present on every view including the home page.
+ *
+ * Horizontal padding matches the outline content's `p-6` so the row aligns
+ * with the bullets below it.
+ */
+export function Header({ children }: { children?: ReactNode }) {
+  return (
+    <header className="border-b">
+      {/* Border spans the full viewport; inner row is centered to match the
+          720px outline content below. */}
+      <div className="mx-auto flex max-w-[720px] items-center justify-between gap-3 px-6 py-3">
+        <div className="min-w-0 flex-1">{children}</div>
+        <div className="shrink-0">
+          <ModeToggle />
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/components/OutlineEditor.tsx
+++ b/src/components/OutlineEditor.tsx
@@ -19,6 +19,7 @@ import { seedIfEmpty } from "../data/seed";
 import { capture, drop, undo } from "../data/history";
 import { OutlineNode, type NodeCommands } from "./OutlineNode";
 import { Header } from "./Header";
+import { useShowCompleted } from "./show-completed-provider";
 import { Button } from "./ui/button";
 
 // Carry the zoom "pivot" (the node morphing between title and list-item) in
@@ -49,6 +50,7 @@ interface OutlineEditorProps {
 export function OutlineEditor({ rootId }: OutlineEditorProps) {
   const { index } = useTree();
   const navigate = useNavigate();
+  const { showCompleted } = useShowCompleted();
 
   // Refs registry: id -> contentEditable span. Lets us move focus
   // between bullets after structural mutations. The zoomed title also
@@ -247,7 +249,12 @@ export function OutlineEditor({ rootId }: OutlineEditorProps) {
     onZoom: (id) => navigateZoom(id, id),
   };
 
-  const topLevel = childrenOf(index, rootId);
+  // Top-level roots start the fade cascade fresh: a completed ancestor above
+  // the current view (when zoomed) contributes nothing. Hide completed roots
+  // when the toggle is off. See docs/adr/0002.
+  const topLevel = childrenOf(index, rootId).filter(
+    (n) => showCompleted || !n.completed,
+  );
   const zoomedNode = rootId ? (index.byId.get(rootId) ?? null) : null;
   const trail = buildTrail(index, rootId);
 
@@ -298,6 +305,8 @@ export function OutlineEditor({ rootId }: OutlineEditorProps) {
               commands={commands}
               registerRef={registerRef}
               pivotId={pivotId}
+              ancestorCompleted={false}
+              showCompleted={showCompleted}
             />
           ))}
         </ul>

--- a/src/components/OutlineEditor.tsx
+++ b/src/components/OutlineEditor.tsx
@@ -18,6 +18,7 @@ import {
 import { seedIfEmpty } from "../data/seed";
 import { capture, drop, undo } from "../data/history";
 import { OutlineNode, type NodeCommands } from "./OutlineNode";
+import { Header } from "./Header";
 import { Button } from "./ui/button";
 
 // Carry the zoom "pivot" (the node morphing between title and list-item) in
@@ -253,7 +254,7 @@ export function OutlineEditor({ rootId }: OutlineEditorProps) {
   // Deep-linked to a node that no longer exists (and the store has loaded).
   if (rootId !== null && zoomedNode === null && index.byId.size > 0) {
     return (
-      <div className="outline-root">
+      <div className="mx-auto max-w-[720px] p-6">
         <div className="outline-empty">
           That bullet doesn't exist. <Link to="/">Back to top</Link>.
         </div>
@@ -262,61 +263,67 @@ export function OutlineEditor({ rootId }: OutlineEditorProps) {
   }
 
   return (
-    <div className="outline-root">
-      <BreadcrumbTrail
-        trail={trail}
-        rootId={rootId || null}
-        onNavigate={navigateZoom}
-      />
+    <>
+      <Header>
+        <BreadcrumbTrail
+          trail={trail}
+          rootId={rootId || null}
+          onNavigate={navigateZoom}
+        />
+      </Header>
+      <div className="mx-auto max-w-[720px] p-6">
+        {zoomedNode && (
+          <ZoomedTitle
+            node={zoomedNode}
+            isPivot={pivotId === zoomedNode.id}
+            registerRef={registerRef}
+            onTextChange={(text) => setText(zoomedNode.id, text)}
+            onAddChild={() => {
+              const newId = insertChildAtStart(
+                focusIndex.current,
+                zoomedNode.id,
+              );
+              pendingFocus.current = newId;
+            }}
+            onArrowDown={() => commands.onMoveFocus(zoomedNode.id, "down")}
+          />
+        )}
 
-      {zoomedNode && (
-        <ZoomedTitle
-          node={zoomedNode}
-          isPivot={pivotId === zoomedNode.id}
-          registerRef={registerRef}
-          onTextChange={(text) => setText(zoomedNode.id, text)}
-          onAddChild={() => {
-            const newId = insertChildAtStart(focusIndex.current, zoomedNode.id);
+        <ul className="outline-list">
+          {topLevel.map((node) => (
+            <OutlineNode
+              key={node.id}
+              node={node}
+              index={index}
+              commands={commands}
+              registerRef={registerRef}
+              pivotId={pivotId}
+            />
+          ))}
+        </ul>
+        {topLevel.length === 0 && (
+          <div className="outline-empty">
+            Empty. Click below to add your first bullet.
+          </div>
+        )}
+        {/* Click anywhere in the whitespace below the list adds a new top-level bullet. */}
+        <Button
+          type="button"
+          size="icon-sm"
+          variant="outline"
+          onClick={() => {
+            const siblings = childrenOf(focusIndex.current, rootId);
+            const afterId = siblings.length
+              ? siblings[siblings.length - 1]!.id
+              : null;
+            const newId = insertSibling(focusIndex.current, rootId, afterId);
             pendingFocus.current = newId;
           }}
-          onArrowDown={() => commands.onMoveFocus(zoomedNode.id, "down")}
-        />
-      )}
-
-      <ul className="outline-list">
-        {topLevel.map((node) => (
-          <OutlineNode
-            key={node.id}
-            node={node}
-            index={index}
-            commands={commands}
-            registerRef={registerRef}
-            pivotId={pivotId}
-          />
-        ))}
-      </ul>
-      {topLevel.length === 0 && (
-        <div className="outline-empty">
-          Empty. Click below to add your first bullet.
-        </div>
-      )}
-      {/* Click anywhere in the whitespace below the list adds a new top-level bullet. */}
-      <Button
-        type="button"
-        size="icon-sm"
-        variant="outline"
-        onClick={() => {
-          const siblings = childrenOf(focusIndex.current, rootId);
-          const afterId = siblings.length
-            ? siblings[siblings.length - 1]!.id
-            : null;
-          const newId = insertSibling(focusIndex.current, rootId, afterId);
-          pendingFocus.current = newId;
-        }}
-      >
-        <PlusIcon />
-      </Button>
-    </div>
+        >
+          <PlusIcon />
+        </Button>
+      </div>
+    </>
   );
 }
 

--- a/src/components/OutlineNode.tsx
+++ b/src/components/OutlineNode.tsx
@@ -18,6 +18,13 @@ interface OutlineNodeProps {
   // The node currently morphing across a zoom navigation, if any. When this
   // node is the pivot, its text claims the shared view-transition-name.
   pivotId: string | null;
+  // True when an ancestor *within the current view* is completed, so this row
+  // renders faded even if it isn't itself completed. Visual-only inheritance;
+  // never written to data. Resets to false at each zoom root. See docs/adr/0002.
+  ancestorCompleted: boolean;
+  // Whether completed bullets are shown at all. When false, completed nodes and
+  // their whole subtrees are filtered out of the render.
+  showCompleted: boolean;
 }
 
 export interface NodeCommands {
@@ -42,11 +49,20 @@ export const OutlineNode = memo(function OutlineNode({
   commands,
   registerRef,
   pivotId,
+  ancestorCompleted,
+  showCompleted,
 }: OutlineNodeProps) {
   const textRef = useRef<HTMLSpanElement | null>(null);
-  const children = childrenOf(index, node.id);
+  // Hide completed subtrees when the toggle is off. Filtering here (where
+  // children are listed) means a hidden completed node takes its whole subtree
+  // with it for free.
+  const children = childrenOf(index, node.id).filter(
+    (c) => showCompleted || !c.completed,
+  );
   const hasChildren = children.length > 0;
   const isPivot = node.id === pivotId;
+  // Faded when this bullet is done, or sits anywhere under one that is.
+  const faded = node.completed || ancestorCompleted;
 
   // The "/" command menu for this bullet. Only the focused bullet ever has a
   // caret, so at most one menu is open across the whole outline.
@@ -159,7 +175,7 @@ export const OutlineNode = memo(function OutlineNode({
 
   return (
     <li className="outline-node" data-node-id={node.id}>
-      <div className="outline-row">
+      <div className="outline-row" data-faded={faded}>
         <button
           type="button"
           className="collapse-toggle"
@@ -234,6 +250,8 @@ export const OutlineNode = memo(function OutlineNode({
               commands={commands}
               registerRef={registerRef}
               pivotId={pivotId}
+              ancestorCompleted={faded}
+              showCompleted={showCompleted}
             />
           ))}
         </ul>

--- a/src/components/mode-toggle.tsx
+++ b/src/components/mode-toggle.tsx
@@ -1,0 +1,45 @@
+import { MoonIcon, SunIcon } from "lucide-react";
+import { Button } from "./ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "./ui/dropdown-menu";
+import { useTheme } from "./theme-provider";
+
+/**
+ * Light/dark/system theme switcher. Base UI trigger uses `render` (not
+ * `asChild`) to wrap the Button. The Sun/Moon swap via the `dark:` variant.
+ */
+export function ModeToggle() {
+  const { setTheme } = useTheme();
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={
+          <Button variant="ghost" size="icon-sm">
+            <SunIcon className="scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" />
+            <MoonIcon className="absolute scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0" />
+            <span className="sr-only">Toggle theme</span>
+          </Button>
+        }
+      />
+      <DropdownMenuContent align="end">
+        <DropdownMenuGroup>
+          <DropdownMenuItem onClick={() => setTheme("light")}>
+            Light
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={() => setTheme("dark")}>
+            Dark
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={() => setTheme("system")}>
+            System
+          </DropdownMenuItem>
+        </DropdownMenuGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/components/show-completed-provider.tsx
+++ b/src/components/show-completed-provider.tsx
@@ -1,0 +1,53 @@
+import { createContext, useContext, useEffect, useState } from "react";
+
+interface ShowCompletedState {
+  showCompleted: boolean;
+  setShowCompleted: (next: boolean) => void;
+}
+
+const STORAGE_KEY = "dotflowy-oss:show-completed";
+
+const ShowCompletedContext = createContext<ShowCompletedState | null>(null);
+
+/**
+ * Global "Show completed" preference (Workflowy's header toggle). When false,
+ * completed bullets and their entire subtrees are hidden from the outline. This
+ * is UI state, not document data, so it lives in its own localStorage key
+ * separate from the nodes collection. See docs/adr/0002.
+ *
+ * Mirrors ThemeProvider: defaults during the SPA's server render pass (no
+ * localStorage there) and reads the stored value on mount. Default is `true`
+ * (show everything) so a first-run user sees their completed items.
+ */
+export function ShowCompletedProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [showCompleted, setShowCompletedState] = useState(true);
+
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored !== null) setShowCompletedState(stored === "true");
+  }, []);
+
+  const setShowCompleted = (next: boolean) => {
+    localStorage.setItem(STORAGE_KEY, String(next));
+    setShowCompletedState(next);
+  };
+
+  return (
+    <ShowCompletedContext.Provider value={{ showCompleted, setShowCompleted }}>
+      {children}
+    </ShowCompletedContext.Provider>
+  );
+}
+
+export function useShowCompleted() {
+  const ctx = useContext(ShowCompletedContext);
+  if (!ctx)
+    throw new Error(
+      "useShowCompleted must be used within a ShowCompletedProvider",
+    );
+  return ctx;
+}

--- a/src/components/show-completed-toggle.tsx
+++ b/src/components/show-completed-toggle.tsx
@@ -1,0 +1,47 @@
+import { CheckIcon } from "lucide-react";
+import { Button } from "./ui/button";
+import { HoverCard, HoverCardContent, HoverCardTrigger } from "./ui/hover-card";
+import { Switch } from "./ui/switch";
+import { useShowCompleted } from "./show-completed-provider";
+
+/**
+ * Header control mirroring Workflowy's completed-items toggle. Clicking the
+ * check button flips "show completed" directly. Hovering reveals a small card
+ * with the switch -- that's a visual readout of the current state, not the
+ * primary control. State is global and persisted (see show-completed-provider).
+ */
+export function ShowCompletedToggle() {
+  const { showCompleted, setShowCompleted } = useShowCompleted();
+
+  return (
+    <HoverCard>
+      <HoverCardTrigger
+        render={
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            data-state={showCompleted ? "on" : "off"}
+            className="data-[state=on]:bg-muted data-[state=on]:text-foreground"
+            onClick={() => setShowCompleted(!showCompleted)}
+            aria-pressed={showCompleted}
+          >
+            <CheckIcon />
+            <span className="sr-only">
+              {showCompleted ? "Hide completed" : "Show completed"}
+            </span>
+          </Button>
+        }
+      />
+      <HoverCardContent align="end" className="w-auto">
+        <label className="flex cursor-pointer items-center gap-2 font-medium select-none">
+          <Switch
+            size="sm"
+            checked={showCompleted}
+            onCheckedChange={setShowCompleted}
+          />
+          Show completed
+        </label>
+      </HoverCardContent>
+    </HoverCard>
+  );
+}

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,0 +1,72 @@
+import { createContext, useContext, useEffect, useState } from "react";
+
+type Theme = "dark" | "light" | "system";
+
+interface ThemeProviderState {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+}
+
+const STORAGE_KEY = "dotflowy-oss:theme";
+
+const ThemeProviderContext = createContext<ThemeProviderState | null>(null);
+
+/**
+ * Applies the resolved theme to <html>. "system" follows the OS preference.
+ * Kept in sync with the inline no-flash script in __root.tsx (same storage key
+ * and resolution logic) so first paint never flashes the wrong theme.
+ */
+function applyTheme(theme: Theme) {
+  const root = document.documentElement;
+  const resolved =
+    theme === "system"
+      ? window.matchMedia("(prefers-color-scheme: dark)").matches
+        ? "dark"
+        : "light"
+      : theme;
+  root.classList.toggle("dark", resolved === "dark");
+}
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  // SPA mode still does a server render pass for the shell, where localStorage
+  // is undefined. So we default to "system" during render and read the stored
+  // value on mount. The inline no-flash script in __root.tsx applies the right
+  // theme to <html> before hydration, so there's no visible flash.
+  const [theme, setThemeState] = useState<Theme>("system");
+
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY) as Theme | null;
+    if (stored && stored !== theme) setThemeState(stored);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    applyTheme(theme);
+  }, [theme]);
+
+  // When on "system", react to OS theme changes live.
+  useEffect(() => {
+    if (theme !== "system") return;
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    const onChange = () => applyTheme("system");
+    mq.addEventListener("change", onChange);
+    return () => mq.removeEventListener("change", onChange);
+  }, [theme]);
+
+  const setTheme = (next: Theme) => {
+    localStorage.setItem(STORAGE_KEY, next);
+    setThemeState(next);
+  };
+
+  return (
+    <ThemeProviderContext.Provider value={{ theme, setTheme }}>
+      {children}
+    </ThemeProviderContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const ctx = useContext(ThemeProviderContext);
+  if (!ctx) throw new Error("useTheme must be used within a ThemeProvider");
+  return ctx;
+}

--- a/src/routes/$nodeId.tsx
+++ b/src/routes/$nodeId.tsx
@@ -8,7 +8,7 @@ export const Route = createFileRoute("/$nodeId")({
 function ZoomedPage() {
   const { nodeId } = Route.useParams();
   return (
-    <main className="app">
+    <main>
       {/* Key by node id so each zoom view mounts a fresh title element;
           prevents a suppressed view-transition-name from leaking between
           consecutive zooms. */}

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -5,7 +5,21 @@ import {
   HeadContent,
   Scripts,
 } from '@tanstack/react-router'
+import { ThemeProvider } from '../components/theme-provider'
 import '../styles.css'
+
+// Runs before first paint so the page never flashes the wrong theme. Mirrors
+// the resolution logic in theme-provider.tsx (same storage key).
+const noFlashThemeScript = `
+(function () {
+  try {
+    var t = localStorage.getItem('dotflowy-oss:theme') || 'system';
+    var dark = t === 'dark' || (t === 'system' &&
+      window.matchMedia('(prefers-color-scheme: dark)').matches);
+    if (dark) document.documentElement.classList.add('dark');
+  } catch (e) {}
+})();
+`
 
 export const Route = createRootRoute({
   head: () => ({
@@ -21,7 +35,9 @@ export const Route = createRootRoute({
 function RootComponent() {
   return (
     <RootDocument>
-      <Outlet />
+      <ThemeProvider>
+        <Outlet />
+      </ThemeProvider>
     </RootDocument>
   )
 }
@@ -30,6 +46,7 @@ function RootDocument({ children }: Readonly<{ children: ReactNode }>) {
   return (
     <html lang="en">
       <head>
+        <script dangerouslySetInnerHTML={{ __html: noFlashThemeScript }} />
         <HeadContent />
       </head>
       <body>

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -6,6 +6,7 @@ import {
   Scripts,
 } from '@tanstack/react-router'
 import { ThemeProvider } from '../components/theme-provider'
+import { ShowCompletedProvider } from '../components/show-completed-provider'
 import '../styles.css'
 
 // Runs before first paint so the page never flashes the wrong theme. Mirrors
@@ -36,7 +37,9 @@ function RootComponent() {
   return (
     <RootDocument>
       <ThemeProvider>
-        <Outlet />
+        <ShowCompletedProvider>
+          <Outlet />
+        </ShowCompletedProvider>
       </ThemeProvider>
     </RootDocument>
   )

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -7,7 +7,7 @@ export const Route = createFileRoute("/")({
 
 function HomePage() {
   return (
-    <main className="app">
+    <main>
       <OutlineEditor rootId={null} />
     </main>
   );

--- a/src/styles.css
+++ b/src/styles.css
@@ -49,12 +49,12 @@
 }
 
 :root {
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
+  --background: oklch(0.98 0 0);
+  --foreground: oklch(0.27 0 0);
+  --card: oklch(0.99 0 0);
+  --card-foreground: oklch(0.27 0 0);
+  --popover: oklch(0.99 0 0);
+  --popover-foreground: oklch(0.27 0 0);
   --primary: oklch(0.205 0 0);
   --primary-foreground: oklch(0.985 0 0);
   --secondary: oklch(0.97 0 0);
@@ -84,12 +84,12 @@
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
+  --background: oklch(0.205 0 0);
+  --foreground: oklch(0.92 0 0);
+  --card: oklch(0.25 0 0);
+  --card-foreground: oklch(0.92 0 0);
+  --popover: oklch(0.25 0 0);
+  --popover-foreground: oklch(0.92 0 0);
   --primary: oklch(0.922 0 0);
   --primary-foreground: oklch(0.205 0 0);
   --secondary: oklch(0.269 0 0);

--- a/src/styles.css
+++ b/src/styles.css
@@ -130,18 +130,6 @@
   }
 }
 
-.app {
-  max-width: 720px;
-  margin: 0 auto;
-  padding: 24px;
-}
-
-.app-header h1 {
-  font-size: 18px;
-  font-weight: 600;
-  margin: 0 0 4px;
-}
-
 .subtitle {
   @apply text-muted-foreground;
   font-size: 13px;
@@ -294,7 +282,6 @@
   align-items: center;
   gap: 4px;
   font-size: 12px;
-  margin-bottom: 10px;
   min-width: 0;
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -165,6 +165,16 @@
 }
 
 /*
+ * Completion fade. A row is faded when it's completed or sits under something
+ * completed (data-faded set in OutlineNode). Opacity lives on the row, NOT on
+ * .outline-node, so it never nests with descendant rows -- one uniform fade
+ * level at any depth, never compounding. See docs/adr/0002.
+ */
+.outline-row[data-faded="true"] {
+  opacity: 0.4;
+}
+
+/*
  * Collapse/expand chevron. Sits in the left gutter (absolute, so toggling
  * it never reflows the bullet) and only shows on row hover, except when the
  * row is collapsed, where it stays visible so the hidden subtree is
@@ -244,8 +254,13 @@
   word-break: break-word;
 }
 
+/*
+ * Strikethrough marks a bullet that is itself completed (self-only). The
+ * row-level fade above handles dimming, so we don't also mute the text color
+ * here -- that would double-dim. Faded-by-ancestor children get no strikethrough.
+ */
 .node-text[data-completed="true"] {
-  @apply text-muted-foreground/60 line-through;
+  @apply line-through;
 }
 
 .node-text:empty::before {
@@ -419,6 +434,13 @@
      morph name itself is applied dynamically (.vt-morph) to whichever node
      is the zoom pivot, so it works for both zoom-in and zoom-out. */
   display: inline-block;
+}
+
+/* A completed zoom root shows full completed styling: line-through (from the
+   shared .node-text rule) plus the fade. The title is an <h2>, not an
+   .outline-row, so it needs its own fade. See docs/adr/0002 decision 6. */
+.zoomed-title-text[data-completed="true"] {
+  opacity: 0.4;
 }
 
 /* During a zoom, the pivot's text box wraps its text tightly so the title


### PR DESCRIPTION
## What

Completed bullets now render **faded** (reduced opacity), and so does any bullet sitting under a completed one. Adds a global **"Show completed"** toggle in the header to hide completed subtrees entirely. Maps Workflowy's behavior.

## Behavior

- **Fade is visual-only.** Completing a parent fades its whole subtree on screen but never mutates each child's `completed` value. Uncomplete the parent and children snap back to their own state.
- **Single fade level**, no compounding at depth. Opacity lives on the row, not the container.
- **Cascade stops at the zoom root** — a zoomed branch stays fully legible.
- **Faded bullets stay interactive** (editable, focusable, zoomable).
- **Strikethrough is self-only and text-only** — inherited-fade children aren't struck through.
- **"Show completed"**: a check button in the header that toggles directly; hovering reveals a card with the switch as a state readout. Global, persisted to localStorage. Off hides every completed subtree (incomplete children of a completed parent included).

## Docs

`docs/adr/0002-completion-fade-and-show-completed.md` — glossary (faded vs opaque vs strikethrough) and the 7 decisions behind this.

## Notes

`bun run typecheck` passes (the only static gate). No test runner in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added theme switcher (light, dark, system) with persistent preference.
  * Added "Show Completed" toggle to hide/reveal completed items.
  * Implemented visual completion fade effect for completed items.
  * Added header with breadcrumb navigation and control toggles.

* **Documentation**
  * Added architecture decision record for completion fade and show completed behavior.

* **Style**
  * Updated color palette and refined completion item styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->