### PR TITLE
Keyboard expand/collapse + column-preserving caret nav

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,8 @@ These two files have a few coupled patterns worth knowing before touching them:
 
 - **contentEditable text sync is manual.** The `node-text` / title spans are `contentEditable`, not controlled React values. Stored text is written to the DOM (`el.textContent = node.text`) only when it differs, to avoid clobbering the caret mid-typing; `onInput` pushes changes to the store. Don't convert these to React-controlled text.
 - **The `refs` registry maps node id → contentEditable span.** It unifies focus and animation: list-item bullets register under their own id, and the zoomed **title registers under `rootId`**. So `refs.current.get(someId)` returns the right element whether that node is currently a title or a list item — focus movement, pending-focus-after-mutation, and the zoom morph all rely on this.
+- **Keyboard expand/collapse is directional, not a toggle.** `Cmd+↓` only opens a closed bullet; `Cmd+↑` only closes an open one; every other cell is a silent no-op. Both always `preventDefault` (so the caret never jumps), one level only, focus stays on the parent. Why: [ADR 0007](./docs/adr/0007-keyboard-expand-collapse.md).
+- **Arrow Up/Down crosses bullets from the edge *visual line* and preserves the caret column.** The cross test (`atLineStart`/`atLineEnd` in `OutlineNode.tsx`) compares the caret's rect to the element's rect, not text offset — so a single-line bullet crosses at any offset while a wrapped bullet still moves line-by-line internally. Landing uses `caretPositionFromPoint` to hit the same x; don't reach for a text-measurement library (the DOM already has the layout). Why: [ADR 0008](./docs/adr/0008-column-preserving-caret-nav.md).
 
 ## Zoom + view transitions
 

--- a/docs/adr/0007-keyboard-expand-collapse.md
+++ b/docs/adr/0007-keyboard-expand-collapse.md
@@ -1,0 +1,66 @@
+# ADR 0007: Directional keyboard expand/collapse (Cmd+↓ / Cmd+↑)
+
+Status: accepted (2026-06-21)
+
+## Glossary
+
+- **Collapsed** — a bullet whose subtree is hidden (`node.collapsed === true`). "Closed"
+  in user-facing terms. "Open"/"expanded" means `collapsed === false`.
+- **Has children** — the bullet has at least one visible child (`hasChildren` in
+  `OutlineNode`, which already respects the "show completed" filter).
+- **No-op** — the shortcut matched and its default was prevented, but no state changed.
+
+## Decision
+
+`Cmd/Ctrl+↓` and `Cmd/Ctrl+↑` expand and collapse the focused bullet. The binding is
+**directional, not a toggle**: the key direction encodes the intent.
+
+- **Cmd+↓** opens (reveals children of) a bullet that is *closed and has children*.
+- **Cmd+↑** closes a bullet that is *open and has children*.
+- Every other cell is a silent no-op (open+↓, closed+↑, childless either way).
+
+It always acts **regardless of caret position**, and **one level only** (no recursive
+deep-expand). Focus **stays on the parent** after expanding — you opened it to look, not
+to edit the first child.
+
+### The truth table
+
+| State                  | Cmd+↓        | Cmd+↑        |
+| ---------------------- | ------------ | ------------ |
+| Closed, has children   | **open**     | no-op        |
+| Open, has children     | no-op        | **close**    |
+| No children            | no-op        | no-op        |
+
+### The shortcut never moves the caret
+
+Both combos **always `preventDefault`** inside the outline (they use the hotkey
+manager's default options, unlike the bare arrows which opt out). The *action* is what's
+conditional. So Cmd+↓/↑ never jump the caret to the end of the line the way macOS would
+by default — they only ever expand, collapse, or do nothing.
+
+## Why
+
+- **Directional beats toggle under repeat-press.** Intent lives in the key, so holding
+  Cmd+↓ can never accidentally re-collapse something. You never have to read current
+  state to predict the result.
+- **Always-preventDefault removes a footgun.** If the no-op cells fell through, the same
+  key would sometimes expand and sometimes yank the caret to end-of-line — inconsistent
+  and jarring. Overriding the macOS Cmd+↑/↓ caret-nav inside the outline is acceptable
+  because Workflowy does the same and the whole app *is* the outline.
+- **One level, focus-stays** matches the existing chevron click
+  (`onToggleCollapsed(node.id, !node.collapsed)`), so keyboard and mouse agree.
+
+## What changed
+
+- Added `Mod+ArrowDown` and `Mod+ArrowUp` to the per-node `useHotkeys` array in
+  `OutlineNode.tsx`, scoped to the bullet's contentEditable (`target: textRef`,
+  disabled while the slash menu is open) like every other outline shortcut.
+- Both reuse the existing `commands.onToggleCollapsed(id, collapsed)` mutation — no new
+  command or state. `collapsed === false` opens, `collapsed === true` closes.
+
+## Note
+
+`Cmd+↑/↓` is the natural binding for a future *move-node-up/down* feature. This ADR
+claims it for expand/collapse; if move-node lands, it supersedes this and collapse moves
+to another key (e.g. `Cmd+Shift+↑/↓`). A future recursive deep-expand would similarly
+take `Cmd+Shift+↓`.

--- a/docs/adr/0008-column-preserving-caret-nav.md
+++ b/docs/adr/0008-column-preserving-caret-nav.md
@@ -1,0 +1,60 @@
+# ADR 0008: Column-preserving cross-node caret navigation
+
+Status: accepted (2026-06-21)
+
+## Glossary
+
+- **Visual line** — one rendered row of a bullet. A short bullet is one visual line; a
+  long one wraps to several. Distinct from text offset: caret offset 0 can sit on the
+  last visual line (a single-line bullet) or the first (a wrapped one).
+- **Column** — the caret's horizontal position, measured as a viewport **x** pixel, not a
+  character index. "Preserve the column" means land at the same x in the neighbor.
+- **Cross / crossing** — Up/Down moving the caret out of one bullet and into a neighbor,
+  as opposed to moving between visual lines inside the same wrapped bullet.
+
+## Decision
+
+Arrow Up/Down crosses to a neighbor bullet only from the **edge visual line**, and the
+landing caret **preserves the column**.
+
+1. **Cross from the edge line, not the text edge.** Up crosses when the caret is on the
+   *first* visual line; Down crosses when it's on the *last*. On a single-line bullet
+   that's true at any offset, so a single press always crosses. Inside a wrapped bullet,
+   line-1 ↔ line-2 movement is left to the browser default. (Detected by comparing the
+   caret's rect to the element's rect, not by text offset — see `atLineStart`/`atLineEnd`
+   in `OutlineNode.tsx`.)
+
+2. **Preserve the column on landing.** The caret lands at the same viewport x it left,
+   on the line nearest the entry side: the **top** line coming Down, the **bottom** line
+   coming Up. Column-0 → column-0 is just the common case of this rule.
+
+3. **Read the layout from the DOM, no measurement library.** The bullets are real
+   `contentEditable` DOM, so the browser has already laid the text out. We capture the
+   caret's x from its `Range` rect on keydown, then ask the browser which character sits
+   at `(x, edge-line-y)` in the neighbor via `caretPositionFromPoint`
+   (`caretRangeFromPoint` fallback on WebKit). Missing x (e.g. the zoom title) or a probe
+   that misses the text falls back to start/end.
+
+## Why
+
+- **Matches Workflowy.** Column preservation is the behavior users expect from an
+  outliner; landing at start-of-node (the previous behavior) felt like a teleport,
+  especially pressing Up.
+- **Visual-line, not text-offset, is the correct cross test.** The old offset test
+  (`offset === length`) made Down a no-op-then-browser-default on a single-line bullet
+  whose caret sat at offset 0 — the caret slid to end-of-line instead of crossing. The
+  rect test fixes that without breaking intra-bullet line movement on wrapped text.
+
+## Rejected: a text-layout library (`@chenglou/pretext`)
+
+`pretext` measures and lays out multiline text in pure JS **without the DOM** — built for
+canvas/virtualized/custom text engines. Wrong fit here:
+
+- Our text is already in `contentEditable` DOM; the browser has the authoritative layout.
+  `pretext` would re-derive it, with a real risk its wrapping doesn't match the browser's
+  pixel-for-pixel — and a mismatch puts the caret in the wrong place.
+- `caretPositionFromPoint` answers exactly the question we have ("what offset is at this
+  x/y") natively, with zero dependency.
+
+It would earn its place only if we stopped using `contentEditable` and rendered the
+outline ourselves (canvas, virtualization). We don't.

--- a/src/components/OutlineEditor.tsx
+++ b/src/components/OutlineEditor.tsx
@@ -229,7 +229,7 @@ export function OutlineEditor({ rootId }: OutlineEditorProps) {
       toggleCollapsed(id, collapsed);
     },
 
-    onMoveFocus: (id, direction) => {
+    onMoveFocus: (id, direction, x) => {
       const target = findVisibleNeighbor(
         focusIndex.current,
         rootIdRef.current,
@@ -240,7 +240,8 @@ export function OutlineEditor({ rootId }: OutlineEditorProps) {
         const el = refs.current.get(target);
         if (el) {
           el.focus();
-          placeCaretAtStart(el);
+          if (x != null) placeCaretAtColumn(el, direction, x);
+          else placeCaretAtStart(el);
         }
       }
     },
@@ -608,4 +609,61 @@ function placeCaretAtStart(el: HTMLElement) {
   const sel = window.getSelection();
   sel?.removeAllRanges();
   sel?.addRange(range);
+}
+
+// Cross-node caret nav preserves the column: drop the caret at the same
+// viewport x the user left at, on the line nearest the side they're entering
+// from (top line coming down, bottom line coming up). The browser already laid
+// the text out, so we ask it which character sits under that point via
+// caretPositionFromPoint -- no text-measurement library needed. See ADR 0008.
+function placeCaretAtColumn(
+  el: HTMLElement,
+  direction: "up" | "down",
+  x: number,
+) {
+  const rect = el.getBoundingClientRect();
+  const cs = getComputedStyle(el);
+  const lineH = parseFloat(cs.lineHeight) || parseFloat(cs.fontSize) * 1.4;
+  // Aim at the vertical middle of the first (down) or last (up) visual line.
+  const y =
+    direction === "down" ? rect.top + lineH / 2 : rect.bottom - lineH / 2;
+  // Keep the probe inside the element so it can't hit a neighbor.
+  const clampedX = Math.max(rect.left + 1, Math.min(x, rect.right - 1));
+
+  const hit = caretFromPoint(clampedX, y);
+  if (hit && el.contains(hit.node)) {
+    const range = document.createRange();
+    range.setStart(hit.node, hit.offset);
+    range.collapse(true);
+    const sel = window.getSelection();
+    sel?.removeAllRanges();
+    sel?.addRange(range);
+    return;
+  }
+  // Probe missed the text (empty bullet, x past the line end): fall back to the
+  // edge we entered from.
+  if (direction === "down") placeCaretAtStart(el);
+  else placeCaretAtEnd(el);
+}
+
+// Standard API with a WebKit (caretRangeFromPoint) fallback. Coordinates are
+// viewport-relative, matching getBoundingClientRect.
+function caretFromPoint(
+  x: number,
+  y: number,
+): { node: Range["startContainer"]; offset: number } | null {
+  if (document.caretPositionFromPoint) {
+    const pos = document.caretPositionFromPoint(x, y);
+    return pos ? { node: pos.offsetNode, offset: pos.offset } : null;
+  }
+  const legacy = (
+    document as Document & {
+      caretRangeFromPoint?: (x: number, y: number) => Range | null;
+    }
+  ).caretRangeFromPoint;
+  if (legacy) {
+    const range = legacy.call(document, x, y);
+    return range ? { node: range.startContainer, offset: range.startOffset } : null;
+  }
+  return null;
 }

--- a/src/components/OutlineNode.tsx
+++ b/src/components/OutlineNode.tsx
@@ -38,7 +38,10 @@ export interface NodeCommands {
   // Set whether a bullet is a task (checkbox shown/hidden).
   onSetTask: (id: string, isTask: boolean) => void;
   onToggleCollapsed: (id: string, collapsed: boolean) => void;
-  onMoveFocus: (id: string, direction: "up" | "down") => void;
+  // `x` is the caret's viewport x at the moment of the keypress, so the
+  // landing node can drop the caret at the same column. Omitted when there's
+  // no caret to preserve (e.g. the zoom title), which lands at the start.
+  onMoveFocus: (id: string, direction: "up" | "down", x?: number) => void;
   // Zoom the outline so this node becomes the temporary root.
   onZoom: (id: string) => void;
 }
@@ -146,28 +149,52 @@ export const OutlineNode = memo(function OutlineNode({
         callback: () => commands.onDeleteNode(node.id),
       },
       {
-        // ArrowUp at the start of the line: move focus to the previous node.
+        // ArrowUp on the first visual line: move to the previous node,
+        // preserving the caret's column (its x). Within a wrapped bullet the
+        // browser default handles line-1 <- line-2 itself.
         hotkey: "ArrowUp",
         callback: (e) => {
           const el = textRef.current;
           if (!el || !atLineStart(el)) return;
           e.preventDefault();
           e.stopPropagation();
-          commands.onMoveFocus(node.id, "up");
+          commands.onMoveFocus(node.id, "up", caretLineRect()?.left);
         },
         options: { preventDefault: false, stopPropagation: false },
       },
       {
-        // ArrowDown at the end of the line: move focus to the next node.
+        // ArrowDown on the last visual line: move to the next node, preserving
+        // the caret's column (its x).
         hotkey: "ArrowDown",
         callback: (e) => {
           const el = textRef.current;
           if (!el || !atLineEnd(el)) return;
           e.preventDefault();
           e.stopPropagation();
-          commands.onMoveFocus(node.id, "down");
+          commands.onMoveFocus(node.id, "down", caretLineRect()?.left);
         },
         options: { preventDefault: false, stopPropagation: false },
+      },
+      {
+        // Cmd/Ctrl+Down: open (reveal the children of) a closed bullet that
+        // has children. Direction encodes intent -- Down only ever opens.
+        // Default options preventDefault, so the caret never jumps to the end
+        // of the line; the toggle itself is conditional, making this a silent
+        // no-op on an already-open or childless bullet. See ADR 0007.
+        hotkey: "Mod+ArrowDown",
+        callback: () => {
+          if (hasChildren && node.collapsed)
+            commands.onToggleCollapsed(node.id, false);
+        },
+      },
+      {
+        // Cmd/Ctrl+Up: close (collapse) an open bullet that has children.
+        // Mirror of Mod+ArrowDown -- Up only ever closes; otherwise a no-op.
+        hotkey: "Mod+ArrowUp",
+        callback: () => {
+          if (hasChildren && !node.collapsed)
+            commands.onToggleCollapsed(node.id, true);
+        },
       },
     ],
     { target: textRef, enabled: !slash.isOpen },
@@ -273,12 +300,35 @@ function isCaretAtStart(el: HTMLElement): boolean {
   return sel.getRangeAt(0).endOffset === 0;
 }
 
+// Caret-to-neighbor navigation is about VISUAL lines, not text offset: on a
+// single-line bullet the caret is on both the first and last line at once, so
+// Up/Down should always cross to the neighbor regardless of where in the text
+// it sits. Only a wrapped (multi-line) bullet should move the caret within
+// itself first. We detect this from the caret's rect vs the element's rect.
+function caretLineRect(): DOMRect | null {
+  const sel = window.getSelection();
+  if (!sel || sel.rangeCount === 0) return null;
+  const range = sel.getRangeAt(0);
+  let rect = range.getBoundingClientRect();
+  // A collapsed caret at a text-node boundary can report an empty rect in some
+  // browsers; fall back to its first client rect.
+  if (rect.height === 0) {
+    const first = range.getClientRects()[0];
+    if (first) rect = first;
+  }
+  return rect.height === 0 ? null : rect;
+}
+
 function atLineStart(el: HTMLElement): boolean {
-  return isCaretAtStart(el);
+  const rect = caretLineRect();
+  // No measurable caret (e.g. empty bullet) -> treat as the first line so Up
+  // crosses to the neighbor.
+  if (!rect) return true;
+  return rect.top - el.getBoundingClientRect().top < rect.height / 2;
 }
 
 function atLineEnd(el: HTMLElement): boolean {
-  const sel = window.getSelection();
-  if (!sel || sel.rangeCount === 0) return false;
-  return sel.getRangeAt(0).endOffset === (el.textContent?.length ?? 0);
+  const rect = caretLineRect();
+  if (!rect) return true;
+  return el.getBoundingClientRect().bottom - rect.bottom < rect.height / 2;
 }


### PR DESCRIPTION
## What

Two keyboard behaviors for the outline, designed via `/grill-with-docs`:

### Cmd+↓ / Cmd+↑ expand/collapse (ADR 0007)
Directional, not a toggle — the key direction encodes intent.

| State | Cmd+↓ | Cmd+↑ |
|---|---|---|
| Closed, has children | **open** | no-op |
| Open, has children | no-op | **close** |
| No children | no-op | no-op |

Both always `preventDefault` so the caret never jumps. One level only; focus stays on the parent.

### Column-preserving Arrow Up/Down (ADR 0008)
Fixes a bug: Down from offset 0 of a single-line bullet slid the caret to end-of-line instead of crossing to the next bullet.

- The cross test now compares the caret's **rect** to the element's rect (visual line), not text offset — so a single-line bullet crosses at any offset, while a wrapped bullet still moves line-by-line internally.
- The landing caret **preserves the column** via `caretPositionFromPoint` (WebKit `caretRangeFromPoint` fallback). No text-measurement library: the `contentEditable` DOM already has the layout. ADR 0008 records why `@chenglou/pretext` was rejected.

## Files
- `src/components/OutlineNode.tsx` — `Mod+Arrow` hotkeys, visual-line detection, capture caret x
- `src/components/OutlineEditor.tsx` — `onMoveFocus` column landing (`placeCaretAtColumn` + `caretFromPoint`)
- `docs/adr/0007`, `docs/adr/0008`, `AGENTS.md` pointer

## Test
- `bun run typecheck` passes (only static gate).
- Manual: single-line Down crosses at any column; wrapped bullet line-1→line-2 stays internal; column holds across several bullets; crossing into a shorter bullet lands at that line's end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)