### PR TITLE
Inline `code` chips: blurred render + live decoration

### DIFF
--- a/src/components/OutlineNode.tsx
+++ b/src/components/OutlineNode.tsx
@@ -60,16 +60,20 @@ export const OutlineNode = memo(function OutlineNode({
   showCompleted,
 }: OutlineNodeProps) {
   const textRef = useRef<HTMLSpanElement | null>(null);
-  // Whether this bullet currently holds the caret. We EDIT raw plain text
-  // (single text node, backticks visible) and DISPLAY formatted HTML (inline
-  // `code` chips) only while blurred. Tracked in a ref, not state, so the
-  // focus/blur swap below runs synchronously inside the same focus event the
-  // editor triggers programmatically -- the caret it then places lands on the
-  // raw text node, so all the caret/keyboard logic keeps working unchanged.
-  const focusedRef = useRef(false);
-  // Last (text, focused) pair written to the DOM, so the sync effect skips
-  // redundant work -- including pointless innerHTML churn while blurred.
-  const syncedRef = useRef<{ text: string; focused: boolean } | null>(null);
+  // Inline `code` is decorated LIVE -- the contentEditable always holds
+  // formatted HTML (mono chips), even while the caret is in the bullet. Each
+  // keystroke re-tokenizes the line and rebuilds its DOM, so we save the caret
+  // as an absolute character offset before the rebuild and restore it after
+  // (see decorate()). Backticks stay visible inside the chip, which keeps the
+  // source offset and the displayed offset identical -- no position mapping.
+  //
+  // Last text written to the DOM, so the sync effect skips redundant rebuilds
+  // (and the caret-jitter they'd cause) on unrelated re-renders.
+  const syncedRef = useRef<string | null>(null);
+  // True between compositionstart/end (IME: accents, CJK). Rebuilding the DOM
+  // mid-composition aborts the IME session, so we suspend decoration until it
+  // ends, then decorate once with the committed text.
+  const composingRef = useRef(false);
   // Hide completed subtrees when the toggle is off. Filtering here (where
   // children are listed) means a hidden completed node takes its whole subtree
   // with it for free.
@@ -90,24 +94,20 @@ export const OutlineNode = memo(function OutlineNode({
     onTextChange: (text) => commands.onTextChange(node.id, text),
   });
 
-  // Keep the contentEditable in sync with stored text WITHOUT clobbering the
-  // user's caret. While focused we write RAW text (and only when it differs,
-  // which is essentially never during typing -- the keystroke updates the
-  // store which echoes back equal). While blurred we render formatted HTML so
-  // inline `code` shows as a mono chip. The (text, focused) guard avoids
-  // re-writing identical content on unrelated re-renders.
+  // Push stored text into the contentEditable as formatted HTML when it
+  // changes from something OTHER than this bullet's own typing -- initial
+  // mount, undo, a programmatic setText. The guard (syncedRef === node.text)
+  // makes the common echo-after-keystroke a no-op: onInput already decorated
+  // and recorded the text, so the store round-trip rebuilds nothing and the
+  // caret never moves. We skip mid-composition; compositionend re-syncs.
   useEffect(() => {
     const el = textRef.current;
-    if (!el) return;
-    const focused = focusedRef.current;
-    const last = syncedRef.current;
-    if (last && last.text === node.text && last.focused === focused) return;
-    if (focused) {
-      if (el.textContent !== node.text) el.textContent = node.text;
-    } else {
-      el.innerHTML = inlineMarkupHtml(node.text);
-    }
-    syncedRef.current = { text: node.text, focused };
+    if (!el || composingRef.current) return;
+    if (syncedRef.current === node.text) return;
+    // Preserve the caret only when this bullet is focused (e.g. undo while
+    // editing); otherwise there's nothing to preserve.
+    decorate(el, node.text, document.activeElement === el);
+    syncedRef.current = node.text;
   });
 
   // Outline keyboard shortcuts, scoped to THIS bullet's contentEditable via
@@ -293,26 +293,30 @@ export const OutlineNode = memo(function OutlineNode({
           suppressContentEditableWarning
           role="textbox"
           data-completed={node.completed}
-          onFocus={(e) => {
-            // Swap formatted HTML -> raw text synchronously, BEFORE the editor
-            // places the caret after a programmatic .focus(). No-op for the
-            // common case (no inline markup) where raw == rendered text.
-            focusedRef.current = true;
-            const el = e.currentTarget;
-            if (el.textContent !== node.text) el.textContent = node.text;
-            syncedRef.current = { text: node.text, focused: true };
-          }}
           onInput={(e) => {
-            commands.onTextChange(node.id, e.currentTarget.textContent ?? "");
+            const el = e.currentTarget;
+            const text = el.textContent ?? "";
+            commands.onTextChange(node.id, text);
             slash.handleInput();
+            // Re-decorate live, preserving the caret. Suspended during IME
+            // composition; compositionend handles that case.
+            if (!composingRef.current) {
+              decorate(el, text, true);
+              syncedRef.current = text;
+            }
           }}
-          onBlur={(e) => {
-            slash.close();
-            // Re-render the formatted view now that the caret has left.
-            focusedRef.current = false;
-            e.currentTarget.innerHTML = inlineMarkupHtml(node.text);
-            syncedRef.current = { text: node.text, focused: false };
+          onCompositionStart={() => {
+            composingRef.current = true;
           }}
+          onCompositionEnd={(e) => {
+            composingRef.current = false;
+            const el = e.currentTarget;
+            const text = el.textContent ?? "";
+            commands.onTextChange(node.id, text);
+            decorate(el, text, true);
+            syncedRef.current = text;
+          }}
+          onBlur={slash.close}
           // The "/" menu owns its own Arrow/Enter/Tab/Esc navigation while
           // open; the outline shortcuts above defer to it via `enabled`.
           onKeyDown={slash.handleKeyDown}
@@ -347,19 +351,24 @@ export const OutlineNode = memo(function OutlineNode({
 });
 
 // Inline `code` runs: `like this`. Single-line, non-empty, no nested backtick.
-// We render these as mono chips only while a bullet is BLURRED; the focused
-// bullet always edits the raw source (backticks visible). Keep this in lockstep
-// with how the text is *stored* -- the store still holds the raw markdown.
-const INLINE_CODE = /`([^`\n]+)`/g;
+// Backticks are kept VISIBLE inside the chip so the source string and the
+// rendered text have identical length -- caret offsets need no source<->display
+// mapping. The stored text is always the raw markdown.
+const INLINE_CODE = /`[^`\n]+`/g;
 
-// Build the display HTML for a bullet's stored text. Escapes first (the text is
-// user input going into innerHTML), then wraps inline-code runs. Backticks
-// aren't escaped, so they survive escaping and the regex still matches; the
-// captured group is already-escaped text, safe to drop straight into <code>.
+const CODE_CLASS =
+  "rounded-[4px] border border-border/60 bg-muted px-1.5 py-0.5 font-mono text-[0.85em] text-foreground";
+
+// Build the display HTML for a bullet's text. Escapes first (the text is user
+// input going into innerHTML), then wraps inline-code runs. We wrap the WHOLE
+// match -- backticks included -- so the chip's text length equals the source's;
+// that's what lets the caret-offset save/restore work without mapping source
+// positions to display positions. Backticks aren't escaped, so they survive
+// escaping and the regex still matches the already-escaped text.
 function inlineMarkupHtml(text: string): string {
   return escapeHtml(text).replace(
     INLINE_CODE,
-    '<code class="rounded-[4px] border border-border/60 bg-muted px-1.5 py-0.5 font-mono text-[0.85em] text-foreground">$1</code>',
+    (match) => `<code class="${CODE_CLASS}">${match}</code>`,
   );
 }
 
@@ -370,17 +379,72 @@ function escapeHtml(s: string): string {
     .replace(/>/g, "&gt;");
 }
 
+// Re-render `el` as formatted HTML, optionally keeping the caret put. The DOM
+// rebuild invalidates any (node, offset) selection, so we capture the caret as
+// an absolute character offset first and re-derive it against the new tree
+// after. Writing innerHTML only when it actually changes avoids needless
+// rebuilds (and the caret flicker they cause) when text is already current.
+function decorate(el: HTMLElement, text: string, preserveCaret: boolean): void {
+  const html = inlineMarkupHtml(text);
+  if (el.innerHTML === html) return;
+  const offset = preserveCaret ? getCaretOffset(el) : -1;
+  el.innerHTML = html;
+  if (offset >= 0) setCaretOffset(el, offset);
+}
+
+// Absolute count of characters before the collapsed caret within `el`, across
+// all text nodes (so a `<code>` chip in the middle is counted transparently).
+function getCaretOffset(el: HTMLElement): number {
+  const sel = window.getSelection();
+  if (!sel || sel.rangeCount === 0) return 0;
+  const range = sel.getRangeAt(0);
+  if (!el.contains(range.endContainer)) return 0;
+  const pre = range.cloneRange();
+  pre.selectNodeContents(el);
+  pre.setEnd(range.endContainer, range.endOffset);
+  return pre.toString().length;
+}
+
+// Drop the caret at absolute character `offset`, walking text nodes until the
+// offset falls inside one. Past-the-end lands at the very end.
+function setCaretOffset(el: HTMLElement, offset: number): void {
+  const sel = window.getSelection();
+  if (!sel) return;
+  const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
+  let remaining = offset;
+  let node = walker.nextNode();
+  while (node) {
+    const len = node.textContent?.length ?? 0;
+    if (remaining <= len) {
+      const range = document.createRange();
+      range.setStart(node, remaining);
+      range.collapse(true);
+      sel.removeAllRanges();
+      sel.addRange(range);
+      return;
+    }
+    remaining -= len;
+    node = walker.nextNode();
+  }
+  const range = document.createRange();
+  range.selectNodeContents(el);
+  range.collapse(false);
+  sel.removeAllRanges();
+  sel.addRange(range);
+}
+
+// Caret at the very end / start of the bullet, measured by absolute offset so
+// the test holds whether the line is one text node or split around chips.
 function isCaretAtEnd(el: HTMLElement): boolean {
   const sel = window.getSelection();
   if (!sel || sel.rangeCount === 0) return true;
-  const range = sel.getRangeAt(0);
-  return range.endOffset === el.textContent?.length;
+  return getCaretOffset(el) === (el.textContent?.length ?? 0);
 }
 
 function isCaretAtStart(el: HTMLElement): boolean {
   const sel = window.getSelection();
   if (!sel || sel.rangeCount === 0) return true;
-  return sel.getRangeAt(0).endOffset === 0;
+  return getCaretOffset(el) === 0;
 }
 
 // Caret-to-neighbor navigation is about VISUAL lines, not text offset: on a

--- a/src/components/OutlineNode.tsx
+++ b/src/components/OutlineNode.tsx
@@ -60,6 +60,16 @@ export const OutlineNode = memo(function OutlineNode({
   showCompleted,
 }: OutlineNodeProps) {
   const textRef = useRef<HTMLSpanElement | null>(null);
+  // Whether this bullet currently holds the caret. We EDIT raw plain text
+  // (single text node, backticks visible) and DISPLAY formatted HTML (inline
+  // `code` chips) only while blurred. Tracked in a ref, not state, so the
+  // focus/blur swap below runs synchronously inside the same focus event the
+  // editor triggers programmatically -- the caret it then places lands on the
+  // raw text node, so all the caret/keyboard logic keeps working unchanged.
+  const focusedRef = useRef(false);
+  // Last (text, focused) pair written to the DOM, so the sync effect skips
+  // redundant work -- including pointless innerHTML churn while blurred.
+  const syncedRef = useRef<{ text: string; focused: boolean } | null>(null);
   // Hide completed subtrees when the toggle is off. Filtering here (where
   // children are listed) means a hidden completed node takes its whole subtree
   // with it for free.
@@ -80,15 +90,24 @@ export const OutlineNode = memo(function OutlineNode({
     onTextChange: (text) => commands.onTextChange(node.id, text),
   });
 
-  // Keep the contentEditable in sync with stored text WITHOUT clobbering
-  // the user's caret. We only write to the DOM when the stored text
-  // differs from what's rendered, which is essentially never during
-  // typing (the keystroke updates the store which echoes back equal).
+  // Keep the contentEditable in sync with stored text WITHOUT clobbering the
+  // user's caret. While focused we write RAW text (and only when it differs,
+  // which is essentially never during typing -- the keystroke updates the
+  // store which echoes back equal). While blurred we render formatted HTML so
+  // inline `code` shows as a mono chip. The (text, focused) guard avoids
+  // re-writing identical content on unrelated re-renders.
   useEffect(() => {
     const el = textRef.current;
-    if (el && el.textContent !== node.text) {
-      el.textContent = node.text;
+    if (!el) return;
+    const focused = focusedRef.current;
+    const last = syncedRef.current;
+    if (last && last.text === node.text && last.focused === focused) return;
+    if (focused) {
+      if (el.textContent !== node.text) el.textContent = node.text;
+    } else {
+      el.innerHTML = inlineMarkupHtml(node.text);
     }
+    syncedRef.current = { text: node.text, focused };
   });
 
   // Outline keyboard shortcuts, scoped to THIS bullet's contentEditable via
@@ -274,11 +293,26 @@ export const OutlineNode = memo(function OutlineNode({
           suppressContentEditableWarning
           role="textbox"
           data-completed={node.completed}
+          onFocus={(e) => {
+            // Swap formatted HTML -> raw text synchronously, BEFORE the editor
+            // places the caret after a programmatic .focus(). No-op for the
+            // common case (no inline markup) where raw == rendered text.
+            focusedRef.current = true;
+            const el = e.currentTarget;
+            if (el.textContent !== node.text) el.textContent = node.text;
+            syncedRef.current = { text: node.text, focused: true };
+          }}
           onInput={(e) => {
             commands.onTextChange(node.id, e.currentTarget.textContent ?? "");
             slash.handleInput();
           }}
-          onBlur={slash.close}
+          onBlur={(e) => {
+            slash.close();
+            // Re-render the formatted view now that the caret has left.
+            focusedRef.current = false;
+            e.currentTarget.innerHTML = inlineMarkupHtml(node.text);
+            syncedRef.current = { text: node.text, focused: false };
+          }}
           // The "/" menu owns its own Arrow/Enter/Tab/Esc navigation while
           // open; the outline shortcuts above defer to it via `enabled`.
           onKeyDown={slash.handleKeyDown}
@@ -311,6 +345,30 @@ export const OutlineNode = memo(function OutlineNode({
     </li>
   );
 });
+
+// Inline `code` runs: `like this`. Single-line, non-empty, no nested backtick.
+// We render these as mono chips only while a bullet is BLURRED; the focused
+// bullet always edits the raw source (backticks visible). Keep this in lockstep
+// with how the text is *stored* -- the store still holds the raw markdown.
+const INLINE_CODE = /`([^`\n]+)`/g;
+
+// Build the display HTML for a bullet's stored text. Escapes first (the text is
+// user input going into innerHTML), then wraps inline-code runs. Backticks
+// aren't escaped, so they survive escaping and the regex still matches; the
+// captured group is already-escaped text, safe to drop straight into <code>.
+function inlineMarkupHtml(text: string): string {
+  return escapeHtml(text).replace(
+    INLINE_CODE,
+    '<code class="rounded-[4px] border border-border/60 bg-muted px-1.5 py-0.5 font-mono text-[0.85em] text-foreground">$1</code>',
+  );
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
 
 function isCaretAtEnd(el: HTMLElement): boolean {
   const sel = window.getSelection();


### PR DESCRIPTION
Renders inline `code` runs (`` `like this` ``) as font-mono chips in the outline. Two commits tell the story:

1. **Blurred render** — bullets show formatted chips when not focused, swap to raw text on focus. Imperative focus/blur swap so it runs synchronously inside `el.focus()`, keeping all caret/keyboard logic on a single text node.
2. **Live decoration** — chips now render *as you type*. The contentEditable always holds formatted HTML; each keystroke re-tokenizes the line and rebuilds its DOM, saving the caret as an absolute character offset and restoring it after. `isCaretAtEnd/Start` moved to offset-based so Enter/Backspace/arrow-crossing keep working across the multi-node DOM. IME composition guarded.

## Design notes
- Backticks stay **visible inside the chip**, so source length == display length — no source↔display position mapping. Deliberate simplicity tradeoff vs. hiding the delimiters (Obsidian/Workflowy style), which is a possible follow-up.
- **Storage unchanged**: the store holds raw markdown; this is a pure render layer with HTML escaping.
- All in `OutlineNode.tsx`. Typecheck passes (the only static gate).

## Not yet verified live
Implemented and typechecked, but not driven in a browser by the agent (agent-browser not installed here). Worth a manual pass on: typing past a chip, backspacing a delimiter, clicking mid-chip-line, trailing spaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Inline code formatting is now applied and displayed live as you edit, providing instant visual feedback.

* **Bug Fixes**
  * Cursor position is reliably preserved during editing, even when content is reorganized.
  * Enhanced support for IME input methods during text composition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->