### PR TITLE
Make header sticky and disable document overscroll bounce

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -13,7 +13,7 @@ import { ShowCompletedToggle } from "./show-completed-toggle";
  */
 export function Header({ children }: { children?: ReactNode }) {
   return (
-    <header className="border-b">
+    <header className="sticky top-0 z-10 border-b bg-background">
       {/* Border spans the full viewport; inner row is centered to match the
           720px outline content below. */}
       <div className="mx-auto flex max-w-[720px] items-center justify-between gap-3 px-6 py-3">

--- a/src/styles.css
+++ b/src/styles.css
@@ -127,6 +127,7 @@
   }
   html {
     @apply font-sans;
+    overscroll-behavior: none;
   }
 }
 


### PR DESCRIPTION
## What
- App header is now `sticky top-0` with `bg-background` + `z-10` so it pins to the top on scroll.
- `overscroll-behavior: none` on `html` removes the rubber-band bounce at scroll edges.

## Why
Header should stay visible while scrolling the outline; the bouncy overscroll felt off.

## Notes
- `bg-background` added so outline bullets don't bleed through the previously-transparent header row.
- Typecheck passes (`bun run typecheck`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)