### PR TITLE
Drag bullets to reorder and reparent (pointer + touch)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,12 +78,13 @@ These two files have a few coupled patterns worth knowing before touching them:
 - **Keyboard expand/collapse is directional, not a toggle.** `Cmd+↓` only opens a closed bullet; `Cmd+↑` only closes an open one; every other cell is a silent no-op. Both always `preventDefault` (so the caret never jumps), one level only, focus stays on the parent. Why: [ADR 0007](./docs/adr/0007-keyboard-expand-collapse.md).
 - **Arrow Up/Down crosses bullets from the edge *visual line* and preserves the caret column.** The cross test (`atLineStart`/`atLineEnd` in `OutlineNode.tsx`) compares the caret's rect to the element's rect, not text offset — so a single-line bullet crosses at any offset while a wrapped bullet still moves line-by-line internally. Landing uses `caretPositionFromPoint` to hit the same x; don't reach for a text-measurement library (the DOM already has the layout). Why: [ADR 0008](./docs/adr/0008-column-preserving-caret-nav.md).
 - **Cmd+Shift+↑/↓ moves a bullet among siblings; at the edge it outdents one level.** Swap with the nearest *visible* sibling (hidden completed ones are skipped, never a dead press); at the first/last visible child it pops out — up-edge to before its parent, down-edge to after it (the existing `outdent`). Never dives into a sibling subtree, never adopts siblings, no-op past the zoom root. `moveUp`/`moveDown` in `mutations.ts`. Why: [ADR 0009](./docs/adr/0009-move-node-among-siblings.md).
+- **Dragging the bullet dot reorders *and* reparents in one drop** (mouse + touch). Pointer y picks the gap, pointer x picks depth (clamped to `[depth(below), depth(above)+1]`); it commits through the single `moveNode` mutation. The whole gesture lives in `use-drag-reorder.ts` and runs imperatively (DOM, not React state) on the hot path. The dot still zooms on a plain click — a movement threshold tells drag from click, and `consumeClick()` suppresses the zoom after a real drag. Why: [ADR 0010](./docs/adr/0010-drag-to-reorder-and-reparent.md).
 
 ## Zoom + view transitions
 
 Clicking a bullet zooms it to a temporary root (the README's "not built" note is stale). Two rules an agent must not break:
 
-- **The bullet dot zooms; collapse/expand is the hover chevron** in the left gutter (`OutlineNode`). Don't move zoom onto the collapse control.
+- **The bullet dot zooms (click) and drags (press + move); collapse/expand is the hover chevron** in the left gutter (`OutlineNode`). Don't move zoom onto the collapse control. The dot's click/drag split is owned by `use-drag-reorder.ts` (see ADR 0010).
 - **`rootId` is route-owned** (`routes/index.tsx` → `null`, `routes/$nodeId.tsx` → `nodeId`); don't add editor-local zoom state.
 
 How it's URL-driven and how the pivot morph animates: [ADR 0003](./docs/adr/0003-zoom-via-view-transitions.md). That ADR also covers why screenshots can't verify the transition.

--- a/docs/adr/0010-drag-to-reorder-and-reparent.md
+++ b/docs/adr/0010-drag-to-reorder-and-reparent.md
@@ -1,0 +1,187 @@
+# ADR 0010: Drag to reorder and reparent (pointer + touch)
+
+Status: accepted (2026-06-22), implemented
+
+## Glossary
+
+- **Drag-move** — relocating a bullet (and its whole subtree) by pointing: pressing on
+  its bullet dot and dragging to a new spot. Distinct from *keyboard move* (ADR 0009),
+  which only ever changes vertical order or pops out one level at an edge.
+- **Fused move** — the single operation a drop performs: it sets both the node's new
+  parent *and* its new position among siblings at once. The keyboard deliberately refuses
+  to expose this (it keeps order and depth on separate keys); drag exposes it on purpose.
+  See *Why a drag may fuse what keys may not*.
+- **moveNode** — the one new mutation: `moveNode(index, nodeId, newParentId, afterSiblingId)`.
+  Relinks the `prevSiblingId` chain to detach the node from its old slot and splice it into
+  the new one. Everything in this ADR reduces to one call to it.
+- **Grabbed node** — the bullet being dragged. Its subtree is carried with it and
+  *collapses to a single row* for the duration of the drag, restoring on drop.
+- **Floating pill** — the visual of the grabbed node while dragging: a highlighted row
+  that follows the pointer (the Workflowy treatment).
+- **Drop gap** — the position between two rendered rows (or above the first / below the
+  last) where the node will land. The pointer's *vertical* position picks the gap.
+- **Target depth** — the indent level the node will land at within a gap. The pointer's
+  *horizontal* position picks it, snapped to the legal range.
+- **Legal depth range** — for a gap between the row above (`A`) and the row below (`B`),
+  the set of allowed target depths is `[depth(B), depth(A) + 1]`, then clamped so the
+  node stays inside the current zoom (no shallower than a direct child of `rootId`).
+- **Drop indicator** — a thin horizontal line drawn at the drop gap; its **left edge is
+  indented to the target depth**, so the indent itself is the depth feedback.
+- **Boundary parent** — the zoom root (`rootId`), same meaning as ADR 0009. Drag operates
+  only within the rendered (zoomed) tree; a node cannot be dropped out of it.
+
+## Decision
+
+A bullet can be relocated by dragging its **bullet dot** with mouse or touch. A drag
+performs one **fused move**: `moveNode(node, newParentId, afterSiblingId)` sets the new
+parent and the new sibling position together.
+
+### Why a drag may fuse what keys may not
+
+ADR 0009 built a wall: **arrows = vertical order, Tab = depth**, and explicitly rejected
+any key that changes both at once. Drag breaks that wall on purpose, and that is correct
+because **the modality changes the contract**. A keypress carries one bit of intent, so
+fusing depth and order onto one key would be ambiguous. A drop carries an exact pixel:
+the pointer names a gap *and* an indent, so resolving both from one gesture is honest.
+The keyboard model is left completely undisturbed.
+
+### The unit, and what happens mid-drag
+
+You drag a **node plus its entire subtree**. While dragging, the subtree **collapses to a
+single row** (the floating pill), so you are moving one compact thing rather than a tall
+block, and it **restores its prior expand/collapse state on drop**.
+
+### How a drop resolves to parent + position
+
+1. The pointer's **vertical** position picks the **drop gap** (between two rendered rows).
+2. The pointer's **horizontal** position picks the **target depth**, snapped to the
+   **legal depth range** `[depth(below), depth(above) + 1]`. The snap is **biased toward
+   the shallower level** (`NEST_RESISTANCE`): you must travel most of an indent rightward
+   to nest one level deeper, so a near-vertical drag holds sibling depth instead of
+   slipping under the row above. Shedding depth (moving left) stays unbiased.
+3. Depth is then **clamped to the boundary**: never shallower than a direct child of the
+   current zoom root. (When zoomed all the way out, `rootId === null`, the floor is
+   top-level — no clamp bites.)
+4. Target depth + gap together determine `newParentId` and `afterSiblingId`, which is the
+   single `moveNode` call.
+
+Reparenting to **any node on screen** is allowed: drag into a sibling's subtree, out to a
+shallower level, anywhere the legal range reaches.
+
+### Invariants (the truth table)
+
+| Situation                                                  | Behavior |
+| ---------------------------------------------------------- | -------- |
+| Drop target is the grabbed node or inside its own subtree  | **Illegal** — indicator turns off; no move on release |
+| Target depth shallower than a direct child of `rootId`     | **Clamped** to direct-child depth (can't leave the zoom) |
+| Drop onto / just under a **collapsed** parent              | Allowed; the parent **expands on drop** so the result is visible |
+| A sibling at the gap is a **hidden completed** node        | **Ignored** — drag lands exactly at the pointer; the visible-filter does not apply |
+| Drop in the **whitespace below the list**                  | Lands as the **last child of `rootId`** (top-level when not zoomed) |
+| Release without crossing the drag threshold                | **No move**; treated as a click on the dot → **zoom** |
+
+### Trigger and touch
+
+- **The dot is the handle.** Click the dot = zoom (unchanged, ADR 0003). Press-and-drag
+  the dot past a small movement **threshold** = move. A release that never crossed the
+  threshold must fire the **zoom**, not a no-op move, so the dot keeps both jobs.
+- **Touch starts the drag immediately** from the dot — no long-press. A touch that begins
+  on the dot lifts the node; a touch anywhere else scrolls the page as normal. The dot is
+  a small, intentional target, so it disambiguates scroll-vs-move without a press delay.
+
+### Feedback
+
+- **Drop indicator:** a thin horizontal line at the drop gap; its left edge is **indented
+  to the target depth**. The indent *is* how horizontal position reads back to the user.
+- **Floating pill:** the grabbed (collapsed) row follows the pointer.
+- **Auto-scroll:** when the pointer nears the top or bottom viewport edge mid-drag, the
+  view scrolls so off-screen targets in a long outline are reachable. Required for the
+  feature to be usable on a real outline; it is the one piece safe to land in a fast
+  follow if the first cut ships without it.
+
+### Undo
+
+One drag = **one undo step**: `capture` the pre-drag state, run `moveNode`, done. Same
+`capture` / `pendingFocus` / discard-on-no-op pattern as `onMoveUp`. Nothing fancier (no
+separate undo entry for the mid-drag collapse).
+
+## Why
+
+- **Direct manipulation earns the fused move.** The pointer supplies the exact gap and
+  indent a key can't, so a drop legitimately sets parent and order together without
+  reopening the keyboard's order-vs-depth split.
+- **`[depth(below), depth(above)+1]` is the only range that's never surprising.** You can
+  land as deep as "first child of the row above" or as shallow as "sibling of the row
+  below," and nothing in between is illegal. Anything outside would drop the node at a
+  depth that has no visual anchor at that gap.
+- **Drag ignores the visible-filter; keyboard respects it.** ADR 0009 skips hidden
+  completed siblings because a *keypress needs a visible effect*. A drag has a real cursor
+  at a real pixel, so it must land exactly where pointed — applying the filter would make
+  it land somewhere other than where the user aimed.
+- **Expand-collapsed-on-drop preserves trust.** Dropping into a black box and watching the
+  node vanish is the kind of thing that makes people stop trusting the gesture. Expanding
+  shows the result.
+- **One handle (the dot) beats a second affordance.** Touch has no hover, so a hover-only
+  grip would have to be permanently visible on touch devices — gutter clutter for every
+  row. Reusing the dot keeps mouse and touch identical with zero new chrome.
+
+## Rejected alternatives
+
+- **Order-only drag (reorder within current parent, never reparent).** Would preserve the
+  ADR 0009 wall perfectly. Rejected: reparenting by drag is the single most expected thing
+  about dragging an outline node; withholding it to protect a keyboard-only invariant
+  helps no one.
+- **A separate drag grip in the gutter.** Clean click/drag separation. Rejected: invisible
+  on touch without being always-shown, and always-shown means permanent clutter. The dot
+  already affords "grab me."
+- **Long-press to lift on touch.** The iOS-reorder pattern. Rejected: adds latency to
+  every single move, and the dot is a precise enough target that scroll-vs-move
+  disambiguates on contact.
+- **Breadcrumb crumbs as drop targets (drag a node out of the zoom).** Rejected: adds a
+  whole second drop surface for a rare move. Escaping a zoom is what zoom-out plus the
+  existing keyboard outdent are for.
+- **Depth chosen by which row you hover rather than horizontal x.** Rejected: at a gap
+  between a deep row and a shallow row, hover alone can't express the intermediate depths
+  the legal range allows; horizontal position can.
+- **Pull in a drag library (e.g. dnd-kit).** Rejected: its sortable preset doesn't do
+  tree reparenting, so we'd still hand-write depth-from-x; it imports React, which trips
+  the documented stale-Vite-dep crash (see AGENTS.md); and the move mechanics are already
+  `prevSiblingId` relinks that fit this editor's hand-rolled style.
+
+## Known rough edges
+
+- **Threshold tuning.** The dot does double duty (click = zoom, drag = move). The movement
+  threshold and a "did we actually move" guard must keep a sloppy click from triggering a
+  no-op move, and keep a real drag from also firing a zoom on release. This is the one
+  fiddly interaction knob.
+- **No test runner.** `typecheck` is the only static gate (AGENTS.md). Drag-drop is exactly
+  where edge cases hide, so the edge list below must be walked by hand: drop on self, drop
+  into a collapsed parent, drop at the very top/bottom, drop in empty whitespace, drag near
+  a hidden completed sibling, drag while zoomed (boundary clamp), drag on touch.
+
+## What changed
+
+- **`moveNode(index, nodeId, newParentId, afterSiblingId)`** in `src/data/mutations.ts`.
+  Detach: repoint the node's old next sibling to its old `prevSiblingId` (same relink
+  `removeNode` does). Reattach: set `parentId` + `prevSiblingId`, then repoint whatever
+  followed the new slot. Rejects (returns false) when `afterSiblingId`/`newParentId` is the
+  node itself, when the target is inside the node's own subtree (cycle guard walks
+  `parentId` up from the target), and on a true no-op (same parent, same predecessor).
+- **`src/components/use-drag-reorder.ts`** — a `useDragReorder` hook driving the gesture
+  imperatively (no React state on the hot path). `pointerdown` arms a 5px threshold;
+  crossing it dims the source row, hides its subtree (a CSS class, no data change), and
+  spawns a floating pill + drop indicator on `document.body`. Each `pointermove` rebuilds
+  the visible rows from the index, resolves the drop gap (pointer y) and target depth
+  (pointer x, clamped to `[depth(below), depth(above)+1]`), and positions the indicator.
+  An rAF loop auto-scrolls near the viewport edges. `pointerup` commits via `onMove` and
+  flags the click as consumed.
+- **`OutlineNode.tsx`** — the bullet dot now wires `onPointerDown → onBulletPointerDown`
+  and `onClick → onBulletClick` (added to `NodeCommands`). The boundary clamp falls out of
+  the relative-depth model for free: depth 0 is a direct child of `rootId`, so a drop can
+  never land shallower than the current view.
+- **`OutlineEditor.tsx`** — instantiates the hook with getters over the live refs;
+  `onMove` runs `capture` → `moveNode` → `pendingFocus` (discard the undo point on a
+  no-op), and `onBulletClick` zooms only when `consumeClick()` reports no drag happened. A
+  `listRef` on the top `<ul>` gives the indicator its right edge.
+- **`styles.css`** — `.bullet { touch-action: none }` so a touch on the dot is a drag, not
+  a scroll; plus `.drag-source`, `.drag-collapsed`, `.drag-pill`, `.drag-indicator`, and
+  `body.dragging-active`.

--- a/src/components/OutlineEditor.tsx
+++ b/src/components/OutlineEditor.tsx
@@ -9,6 +9,7 @@ import {
   insertChildAtStart,
   insertSibling,
   moveDown,
+  moveNode,
   moveUp,
   outdent,
   removeNode,
@@ -20,6 +21,7 @@ import {
 import { seedIfEmpty } from "../data/seed";
 import { capture, drop, undo } from "../data/history";
 import { OutlineNode, type NodeCommands } from "./OutlineNode";
+import { useDragReorder } from "./use-drag-reorder";
 import { Header } from "./Header";
 import { useShowCompleted } from "./show-completed-provider";
 import { Button } from "./ui/button";
@@ -63,6 +65,9 @@ export function OutlineEditor({ rootId }: OutlineEditorProps) {
     if (el) refs.current.set(id, el);
     else refs.current.delete(id);
   }, []);
+
+  // The top-level <ul>, so the drag indicator knows how wide to draw.
+  const listRef = useRef<HTMLUListElement | null>(null);
 
   // First-run seed. Runs when the collection has loaded and is empty.
   useEffect(() => {
@@ -227,6 +232,30 @@ export function OutlineEditor({ rootId }: OutlineEditorProps) {
     { preventDefault: true },
   );
 
+  // Pointer/touch drag to reorder + reparent, hung off each bullet dot. Reads
+  // live values through getters (the same ref pattern the commands use), and
+  // commits through the one fused `moveNode` mutation. See docs/adr/0010.
+  const drag = useDragReorder({
+    getIndex: () => focusIndex.current,
+    getRootId: () => rootIdRef.current,
+    getShowCompleted: () => showCompleted,
+    getRowEl: (id) =>
+      (refs.current.get(id)?.closest(".outline-row") as HTMLElement | null) ??
+      null,
+    getListEl: () => listRef.current,
+    onMove: (id, newParentId, afterSiblingId) => {
+      capture(focusIndex.current, id);
+      const moved = moveNode(
+        focusIndex.current,
+        id,
+        newParentId,
+        afterSiblingId,
+      );
+      if (moved) pendingFocus.current = id;
+      else drop();
+    },
+  });
+
   const commands: NodeCommands = {
     onTextChange: (id, text) => {
       // Coalesce a run of keystrokes on one bullet into a single undo step,
@@ -324,6 +353,15 @@ export function OutlineEditor({ rootId }: OutlineEditorProps) {
 
     // Zooming in: the clicked node is the pivot (list item -> title).
     onZoom: (id) => navigateZoom(id, id),
+
+    onBulletPointerDown: (id, e) => drag.startDrag(id, e),
+
+    // The dot's click fires right after pointerup. Suppress the zoom when that
+    // press was actually a drag; otherwise zoom as before.
+    onBulletClick: (id) => {
+      if (drag.consumeClick()) return;
+      navigateZoom(id, id);
+    },
   };
 
   // Top-level roots start the fade cascade fresh: a completed ancestor above
@@ -373,7 +411,7 @@ export function OutlineEditor({ rootId }: OutlineEditorProps) {
           />
         )}
 
-        <ul className="outline-list">
+        <ul className="outline-list" ref={listRef}>
           {topLevel.map((node) => (
             <OutlineNode
               key={node.id}

--- a/src/components/OutlineEditor.tsx
+++ b/src/components/OutlineEditor.tsx
@@ -181,6 +181,10 @@ export function OutlineEditor({ rootId }: OutlineEditorProps) {
    * in the OUTGOING view here; the incoming view names it declaratively.
    */
   const navigateZoom = (toRootId: string | null, pivot: string) => {
+    // Zooming out reveals the trail: expand any collapsed ancestor between the
+    // node we're leaving and the destination root, so the pivot is actually
+    // visible when we land (otherwise a collapsed parent hides where you were).
+    revealAncestorsToRoot(focusIndex.current, pivot, toRootId);
     if (prefersReducedMotion()) {
       // No morph, but still carry the pivot so the new view restores focus.
       const state = { pivotId: pivot };
@@ -595,6 +599,37 @@ function CollapsedCrumbs({
       </div>
     </span>
   );
+}
+
+/**
+ * On zoom-out, expand every collapsed ancestor on the path from `pivot` (the
+ * node we're leaving) up to — but not including — `toRootId` (the destination
+ * root, or null for Home). This makes the trail that led to `pivot` visible in
+ * the view we're navigating to.
+ *
+ * No-op unless `pivot` is actually a descendant of `toRootId` — so zooming IN
+ * (pivot === toRootId) and any non-ancestral jump leave collapse state alone.
+ */
+function revealAncestorsToRoot(
+  index: TreeIndex,
+  pivot: string,
+  toRootId: string | null,
+) {
+  if (pivot === toRootId) return;
+  const collapsedOnPath: string[] = [];
+  let current = index.byId.get(pivot)?.parentId ?? null;
+  // Guard against corrupted parent chains, mirroring buildTrail.
+  let guard = index.byId.size + 1;
+  while (current && current !== toRootId && guard-- > 0) {
+    const node = index.byId.get(current);
+    if (!node) break;
+    if (node.collapsed) collapsedOnPath.push(current);
+    current = node.parentId ?? null;
+  }
+  // Only expand if we walked all the way up to the destination root; otherwise
+  // pivot wasn't below it and we'd be mangling an unrelated branch.
+  if (current !== toRootId) return;
+  for (const id of collapsedOnPath) toggleCollapsed(id, false);
 }
 
 /**

--- a/src/components/OutlineNode.tsx
+++ b/src/components/OutlineNode.tsx
@@ -357,7 +357,7 @@ export const OutlineNode = memo(function OutlineNode({
 const INLINE_CODE = /`[^`\n]+`/g;
 
 const CODE_CLASS =
-  "rounded-[4px] border border-border/60 bg-muted px-1.5 py-0.5 font-mono text-[0.85em] text-foreground";
+  "rounded-[4px] border border-border/60 bg-muted px-0.5 py-0.5 font-mono text-[0.85em] text-foreground";
 
 // Build the display HTML for a bullet's text. Escapes first (the text is user
 // input going into innerHTML), then wraps inline-code runs. We wrap the WHOLE

--- a/src/components/OutlineNode.tsx
+++ b/src/components/OutlineNode.tsx
@@ -247,7 +247,7 @@ export const OutlineNode = memo(function OutlineNode({
       <div className="outline-row" data-faded={faded}>
         <button
           type="button"
-          className="collapse-toggle"
+          className="collapse-toggle touch-hitbox"
           aria-label={node.collapsed ? "Expand" : "Collapse"}
           data-has-children={hasChildren}
           data-collapsed={node.collapsed}
@@ -373,10 +373,7 @@ function inlineMarkupHtml(text: string): string {
 }
 
 function escapeHtml(s: string): string {
-  return s
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
 // Re-render `el` as formatted HTML, optionally keeping the caret put. The DOM

--- a/src/components/OutlineNode.tsx
+++ b/src/components/OutlineNode.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useRef } from "react";
+import { memo, useEffect, useRef, type PointerEvent } from "react";
 import { useHotkeys } from "@tanstack/react-hotkeys";
 import { ChevronRight } from "lucide-react";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -48,6 +48,10 @@ export interface NodeCommands {
   onMoveFocus: (id: string, direction: "up" | "down", x?: number) => void;
   // Zoom the outline so this node becomes the temporary root.
   onZoom: (id: string) => void;
+  // Drag-to-reorder, hung off the bullet dot. pointerdown arms a drag; click
+  // zooms only when no drag happened. See docs/adr/0010.
+  onBulletPointerDown: (id: string, e: PointerEvent) => void;
+  onBulletClick: (id: string) => void;
 }
 
 export const OutlineNode = memo(function OutlineNode({
@@ -263,7 +267,8 @@ export const OutlineNode = memo(function OutlineNode({
           type="button"
           className="bullet touch-hitbox"
           aria-label="Zoom in"
-          onClick={() => commands.onZoom(node.id)}
+          onPointerDown={(e) => commands.onBulletPointerDown(node.id, e)}
+          onClick={() => commands.onBulletClick(node.id)}
           title="Zoom in"
         >
           <span

--- a/src/components/use-drag-reorder.ts
+++ b/src/components/use-drag-reorder.ts
@@ -1,0 +1,355 @@
+import { useCallback, useRef, type PointerEvent as ReactPointerEvent } from "react";
+import { childrenOf, type TreeIndex } from "../data/tree";
+
+/**
+ * Pointer-driven drag to reorder and reparent a bullet, for mouse and touch.
+ * Drives the gesture imperatively (no React state on the hot path): on each
+ * pointermove it measures the rendered rows, resolves the drop to a parent +
+ * predecessor, and positions a floating pill and a drop indicator directly in
+ * the DOM. The single `moveNode` call happens on release. See docs/adr/0010.
+ *
+ * The whole feature hangs off the bullet dot, which already zooms on click:
+ * `startDrag` arms a movement threshold on pointerdown, and `consumeClick`
+ * lets the dot's click handler tell a real drag apart from a plain click (only
+ * the latter should zoom).
+ */
+
+// Movement (px) before a press becomes a drag. Below this, it's a click → zoom.
+const THRESHOLD = 5;
+// Indent per depth level. Matches `.outline-children { padding-left }` in
+// styles.css; measured from the live rows when possible, this is the fallback.
+const INDENT_FALLBACK = 24;
+// How much of an indent the pointer must travel rightward before a drop nests
+// one level deeper. 0 = snap to the nearest level (flips at the halfway point);
+// higher = stickier toward the shallower level, so a near-vertical drag stays
+// at sibling depth instead of slipping under the row above. 0.4 means you cross
+// ~90% of an indent to nest. Tunable feel knob. See docs/adr/0010.
+const NEST_RESISTANCE = 0.4;
+// Distance from a viewport edge (px) that triggers auto-scroll while dragging.
+const EDGE = 72;
+// Max auto-scroll speed (px per frame) at the very edge.
+const SCROLL_MAX = 18;
+
+interface Row {
+  id: string;
+  parentId: string | null;
+  depth: number; // relative to the zoom root: its direct children are depth 0
+  el: HTMLElement | null;
+}
+
+interface DragDeps {
+  getIndex: () => TreeIndex;
+  getRootId: () => string | null;
+  getShowCompleted: () => boolean;
+  /** The `.outline-row` element for a node id (via the editor's refs registry). */
+  getRowEl: (id: string) => HTMLElement | null;
+  /** The `ul.outline-list` element, for the indicator's right edge. */
+  getListEl: () => HTMLElement | null;
+  onMove: (
+    id: string,
+    newParentId: string | null,
+    afterSiblingId: string | null,
+  ) => void;
+}
+
+interface DragState {
+  id: string;
+  startX: number;
+  startY: number;
+  dragging: boolean;
+  rows: Row[]; // visible rows excluding the grabbed node + its subtree
+  indent: number;
+  lastX: number;
+  lastY: number;
+  pending: { parentId: string | null; afterSiblingId: string | null } | null;
+  indicator: HTMLElement | null;
+  pill: HTMLElement | null;
+  raf: number | null;
+  // The exact listener instances registered for this drag, so cleanup removes
+  // the same references even if the component re-rendered mid-drag.
+  moveHandler: (e: PointerEvent) => void;
+  upHandler: () => void;
+}
+
+export function useDragReorder(deps: DragDeps) {
+  const depsRef = useRef(deps);
+  depsRef.current = deps;
+
+  const state = useRef<DragState | null>(null);
+  // Set on a real drag so the dot's click (which follows pointerup) skips zoom.
+  const consumed = useRef(false);
+
+  const cleanup = useCallback(() => {
+    const s = state.current;
+    if (!s) return;
+    if (s.raf != null) cancelAnimationFrame(s.raf);
+    s.indicator?.remove();
+    s.pill?.remove();
+    const sourceRow = depsRef.current.getRowEl(s.id);
+    sourceRow?.classList.remove("drag-source");
+    sourceRow?.closest(".outline-node")?.classList.remove("drag-collapsed");
+    document.body.classList.remove("dragging-active");
+    document.removeEventListener("pointermove", s.moveHandler);
+    document.removeEventListener("pointerup", s.upHandler);
+    document.removeEventListener("pointercancel", s.upHandler);
+    state.current = null;
+  }, []);
+
+  // Build the visible, ordered rows (matching what's rendered), with depth,
+  // excluding the grabbed node and everything under it (can't drop into self).
+  const buildRows = useCallback((grabbedId: string): Row[] => {
+    const { getIndex, getRootId, getShowCompleted, getRowEl } = depsRef.current;
+    const index = getIndex();
+    const rootId = getRootId();
+    const showCompleted = getShowCompleted();
+
+    const skip = new Set<string>([grabbedId]);
+    const stack = [grabbedId];
+    while (stack.length) {
+      const id = stack.pop()!;
+      for (const c of childrenOf(index, id)) {
+        skip.add(c.id);
+        stack.push(c.id);
+      }
+    }
+
+    const rows: Row[] = [];
+    const walk = (parentId: string | null, depth: number) => {
+      for (const child of childrenOf(index, parentId)) {
+        if (!showCompleted && child.completed) continue;
+        if (!skip.has(child.id)) {
+          rows.push({
+            id: child.id,
+            parentId: child.parentId,
+            depth,
+            el: getRowEl(child.id),
+          });
+        }
+        // Descend regardless of skip: a non-skipped node can't live under a
+        // skipped (grabbed) one, so this only walks real visible structure.
+        if (!child.collapsed && !skip.has(child.id)) walk(child.id, depth + 1);
+      }
+    };
+    walk(rootId, 0);
+    return rows;
+  }, []);
+
+  const beginDrag = useCallback(() => {
+    const s = state.current;
+    if (!s) return;
+    s.dragging = true;
+    s.rows = buildRows(s.id);
+
+    // Derive the per-level indent from two rows at different depths; fall back
+    // to the CSS constant when the list is too shallow to measure.
+    s.indent = INDENT_FALLBACK;
+    const a = s.rows.find((r) => r.el);
+    const b = s.rows.find((r) => r.el && r.depth !== a?.depth);
+    if (a?.el && b?.el && a.depth !== b.depth) {
+      const la = a.el.getBoundingClientRect().left;
+      const lb = b.el.getBoundingClientRect().left;
+      s.indent = Math.abs((la - lb) / (a.depth - b.depth)) || INDENT_FALLBACK;
+    }
+
+    const sourceRow = depsRef.current.getRowEl(s.id);
+    sourceRow?.classList.add("drag-source");
+    // Visually collapse the grabbed subtree so we carry one compact row.
+    sourceRow?.closest(".outline-node")?.classList.add("drag-collapsed");
+
+    const index = depsRef.current.getIndex();
+    const text = index.byId.get(s.id)?.text?.trim() || "Untitled";
+
+    const pill = document.createElement("div");
+    pill.className = "drag-pill";
+    pill.textContent = text;
+    document.body.appendChild(pill);
+    s.pill = pill;
+
+    const indicator = document.createElement("div");
+    indicator.className = "drag-indicator";
+    document.body.appendChild(indicator);
+    s.indicator = indicator;
+
+    document.body.classList.add("dragging-active");
+  }, [buildRows]);
+
+  // Resolve the pointer position to a drop gap + target depth, position the
+  // indicator and pill, and stash the pending (parent, predecessor).
+  const project = useCallback((px: number, py: number) => {
+    const s = state.current;
+    if (!s) return;
+    const rows = s.rows.filter((r) => r.el);
+    const rects = rows.map((r) => r.el!.getBoundingClientRect());
+
+    // Gap: index of the first row whose vertical midpoint is below the pointer.
+    let gap = rows.length;
+    for (let i = 0; i < rows.length; i++) {
+      if (py < rects[i]!.top + rects[i]!.height / 2) {
+        gap = i;
+        break;
+      }
+    }
+    const above = gap > 0 ? rows[gap - 1]! : null;
+    const aboveRect = gap > 0 ? rects[gap - 1]! : null;
+    const below = gap < rows.length ? rows[gap]! : null;
+    const belowRect = gap < rows.length ? rects[gap]! : null;
+
+    // Legal depth range at this gap: as deep as a child of the row above, as
+    // shallow as the row below (or top-level). 0 = direct child of the zoom
+    // root, so the lower bound also keeps the node inside the current view.
+    const maxDepth = above ? above.depth + 1 : 0;
+    const minDepth = below ? below.depth : 0;
+
+    // Base x of depth 0, backed out from a known row, then depth from pointer x.
+    const ref = above ?? below;
+    const refRect = aboveRect ?? belowRect;
+    const baseLeft = ref && refRect ? refRect.left - ref.depth * s.indent : 0;
+    // Subtract NEST_RESISTANCE so gaining depth needs deliberate rightward
+    // travel; shedding depth (moving left) stays easy.
+    const desired = Math.round((px - baseLeft) / s.indent - NEST_RESISTANCE);
+    const depth = Math.max(minDepth, Math.min(maxDepth, desired));
+
+    // Parent + predecessor for `depth` at this gap.
+    let parentId: string | null;
+    if (depth === 0 || !above) {
+      parentId = depsRef.current.getRootId();
+    } else if (depth === above.depth + 1) {
+      parentId = above.id; // become the row above's (last/only) child
+    } else if (depth === above.depth) {
+      parentId = above.parentId; // sibling of the row above
+    } else {
+      // Shallower than the row above: adopt the nearest ancestor at this depth.
+      let found: string | null = depsRef.current.getRootId();
+      for (let i = gap - 1; i >= 0; i--) {
+        if (rows[i]!.depth === depth) {
+          found = rows[i]!.parentId;
+          break;
+        }
+        if (rows[i]!.depth < depth) break;
+      }
+      parentId = found;
+    }
+
+    // Predecessor: nearest row above the gap at exactly `depth` under `parentId`.
+    // Stop if we drop below `depth` first — then we're the first child (null).
+    let afterSiblingId: string | null = null;
+    for (let i = gap - 1; i >= 0; i--) {
+      if (rows[i]!.depth < depth) break;
+      if (rows[i]!.depth === depth && rows[i]!.parentId === parentId) {
+        afterSiblingId = rows[i]!.id;
+        break;
+      }
+    }
+
+    s.pending = { parentId, afterSiblingId };
+
+    // Indicator: a line at the gap, indented to the target depth.
+    const listEl = depsRef.current.getListEl();
+    const listRect = listEl?.getBoundingClientRect();
+    const y = aboveRect
+      ? aboveRect.bottom
+      : belowRect
+        ? belowRect.top
+        : (listRect?.top ?? py);
+    const left = baseLeft + depth * s.indent;
+    const right = listRect?.right ?? left + 240;
+    if (s.indicator) {
+      s.indicator.style.top = `${y}px`;
+      s.indicator.style.left = `${left}px`;
+      s.indicator.style.width = `${Math.max(40, right - left)}px`;
+    }
+    if (s.pill) {
+      s.pill.style.left = `${px + 12}px`;
+      s.pill.style.top = `${py + 12}px`;
+    }
+  }, []);
+
+  // Auto-scroll loop: while the pointer sits in a top/bottom edge band, scroll
+  // the window and re-project so off-screen drop targets become reachable.
+  const tickScroll = useCallback(() => {
+    const s = state.current;
+    if (!s || !s.dragging) return;
+    const y = s.lastY;
+    const h = window.innerHeight;
+    let dy = 0;
+    if (y < EDGE) dy = -SCROLL_MAX * (1 - y / EDGE);
+    else if (y > h - EDGE) dy = SCROLL_MAX * (1 - (h - y) / EDGE);
+    if (dy !== 0) {
+      window.scrollBy(0, dy);
+      project(s.lastX, s.lastY);
+    }
+    s.raf = requestAnimationFrame(tickScroll);
+  }, [project]);
+
+  function onMove(e: PointerEvent) {
+    const s = state.current;
+    if (!s) return;
+    s.lastX = e.clientX;
+    s.lastY = e.clientY;
+    if (!s.dragging) {
+      const moved = Math.hypot(e.clientX - s.startX, e.clientY - s.startY);
+      if (moved < THRESHOLD) return;
+      beginDrag();
+      s.raf = requestAnimationFrame(tickScroll);
+    }
+    e.preventDefault();
+    project(e.clientX, e.clientY);
+  }
+
+  function onUp() {
+    const s = state.current;
+    if (!s) return;
+    if (s.dragging) {
+      consumed.current = true;
+      const pending = s.pending;
+      const id = s.id;
+      cleanup();
+      if (pending) {
+        depsRef.current.onMove(id, pending.parentId, pending.afterSiblingId);
+      }
+      return;
+    }
+    cleanup();
+  }
+
+  const startDrag = useCallback(
+    (id: string, e: ReactPointerEvent) => {
+      // A fresh press: clear any stale click-suppression.
+      consumed.current = false;
+      // Ignore secondary buttons.
+      if (e.button !== 0 && e.pointerType === "mouse") return;
+      state.current = {
+        id,
+        startX: e.clientX,
+        startY: e.clientY,
+        dragging: false,
+        rows: [],
+        indent: INDENT_FALLBACK,
+        lastX: e.clientX,
+        lastY: e.clientY,
+        pending: null,
+        indicator: null,
+        pill: null,
+        raf: null,
+        moveHandler: onMove,
+        upHandler: onUp,
+      };
+      document.addEventListener("pointermove", onMove, { passive: false });
+      document.addEventListener("pointerup", onUp);
+      document.addEventListener("pointercancel", onUp);
+    },
+    [],
+  );
+
+  // True when the click that follows pointerup came from a real drag and should
+  // be swallowed (no zoom). Resets itself so the next genuine click zooms.
+  const consumeClick = useCallback(() => {
+    if (consumed.current) {
+      consumed.current = false;
+      return true;
+    }
+    return false;
+  }, []);
+
+  return { startDrag, consumeClick };
+}

--- a/src/data/mutations.ts
+++ b/src/data/mutations.ts
@@ -332,6 +332,81 @@ export function moveDown(
 }
 
 /**
+ * Move `nodeId` to be a child of `newParentId`, positioned immediately after
+ * `afterSiblingId` (or as the first child when `afterSiblingId` is null). This
+ * is the fused move that drag-and-drop performs: it changes parent AND sibling
+ * order in one shot, unlike the keyboard moves which only ever do one. See
+ * docs/adr/0010.
+ *
+ * Returns true if a real move happened. No-ops (and returns false) when the
+ * target is the node's current position, or when the move would create a cycle
+ * (dropping a node into its own subtree).
+ *
+ * Like every mutation here it reads sibling order from the pre-mutation `index`
+ * and relinks the `prevSiblingId` chain: detach the node (its old next sibling
+ * inherits its old prev), then splice it in (the node that followed the new
+ * slot now follows the node).
+ */
+export function moveNode(
+  index: TreeIndex,
+  nodeId: string,
+  newParentId: string | null,
+  afterSiblingId: string | null,
+): boolean {
+  const node = index.byId.get(nodeId)
+  if (!node) return false
+  // Can't land after yourself, and can't become your own parent.
+  if (afterSiblingId === nodeId || newParentId === nodeId) return false
+
+  // Cycle guard: walk up from the target parent; bail if we reach the node.
+  // Dropping a branch inside itself would orphan it. See docs/adr/0010.
+  if (newParentId !== null) {
+    let cursor: Node | undefined = index.byId.get(newParentId)
+    let guard = index.byId.size + 1
+    while (cursor && guard-- > 0) {
+      if (cursor.id === nodeId) return false
+      cursor = cursor.parentId
+        ? index.byId.get(cursor.parentId)
+        : undefined
+    }
+  }
+
+  // Already exactly here? Nothing to do (same parent, same predecessor).
+  if (
+    newParentId === node.parentId &&
+    (afterSiblingId ?? null) === (node.prevSiblingId ?? null)
+  ) {
+    return false
+  }
+
+  // The node currently following us under the OLD parent inherits our old prev.
+  const oldSiblings = childrenOf(index, node.parentId)
+  const oi = oldSiblings.findIndex((n) => n.id === nodeId)
+  const oldNext =
+    oi !== -1 && oi + 1 < oldSiblings.length ? oldSiblings[oi + 1]! : null
+
+  // The node that will follow us under the NEW parent: the one after
+  // `afterSiblingId`, or the current head when we're becoming the first child.
+  const newSiblings = childrenOf(index, newParentId)
+  let newNext: Node | null = null
+  if (afterSiblingId === null) {
+    newNext = newSiblings[0] ?? null
+  } else {
+    const ni = newSiblings.findIndex((n) => n.id === afterSiblingId)
+    newNext = ni !== -1 && ni + 1 < newSiblings.length ? newSiblings[ni + 1]! : null
+  }
+
+  // Detach, then re-splice. Reads above are all from the pre-mutation index, so
+  // ordering of the writes below doesn't matter.
+  if (oldNext) update(oldNext.id, { prevSiblingId: node.prevSiblingId })
+  update(nodeId, { parentId: newParentId, prevSiblingId: afterSiblingId })
+  if (newNext && newNext.id !== nodeId) {
+    update(newNext.id, { prevSiblingId: nodeId })
+  }
+  return true
+}
+
+/**
  * Delete a node. Children are deleted recursively (Workflowy behavior:
  * deleting a parent deletes its subtree). Returns the id to focus
  * afterwards: the next sibling if any, else the previous sibling, else

--- a/src/styles.css
+++ b/src/styles.css
@@ -278,6 +278,9 @@
   align-items: center;
   justify-content: center;
   border-radius: 99px;
+  /* A touch starting on the dot is a drag (or a tap-to-zoom), never a scroll,
+     so the gesture stays ours. See docs/adr/0010. */
+  touch-action: none;
 }
 
 .bullet:active {
@@ -329,6 +332,57 @@
 .node-text:empty::before {
   content: "";
   display: inline-block;
+}
+
+/* --- Drag to reorder (docs/adr/0010) --- */
+
+/* While a drag is live: a grab cursor everywhere, and no accidental text
+   selection as the pointer sweeps across rows. */
+body.dragging-active {
+  cursor: grabbing;
+  user-select: none;
+}
+
+body.dragging-active * {
+  cursor: grabbing !important;
+}
+
+/* The grabbed row sits in place, dimmed; its subtree hides so we carry one
+   compact row. Both are visual-only and removed on drop (no data change). */
+.outline-row.drag-source {
+  @apply bg-card;
+}
+
+.outline-node.drag-collapsed > .outline-children-wrap {
+  display: none;
+}
+
+/* The floating label that follows the pointer. */
+.drag-pill {
+  position: fixed;
+  z-index: 50;
+  pointer-events: none;
+  max-width: 320px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  padding: 4px 10px;
+  border-radius: 6px;
+  font-size: 13px;
+  background: var(--popover);
+  color: var(--popover-foreground);
+  border: 1px solid var(--border);
+  box-shadow: 0 6px 20px rgb(0 0 0 / 18%);
+}
+
+/* The drop line. Its left edge is indented to the target depth, so the indent
+   itself is the depth feedback. A dot at the left marks the insertion point. */
+.drag-indicator {
+  @apply fixed h-1.5 rounded-full w-full;
+  z-index: 50;
+  pointer-events: none;
+  margin-top: -2px;
+  background: var(--primary);
 }
 
 .outline-empty {


### PR DESCRIPTION
Grab a bullet's dot and drag to move it (and its whole subtree) anywhere in the outline, on mouse or touch.

## What
- **`moveNode`** in `mutations.ts` — one fused mutation: relinks the `prevSiblingId` chain to set new parent + sibling position at once. Guards cycles (drop-into-own-subtree) and no-ops.
- **`use-drag-reorder.ts`** — pointer/touch controller, imperative on the hot path. Pointer y picks the drop gap, pointer x picks depth (clamped to `[depth(below), depth(above)+1]`, biased toward the shallower level so a near-vertical drag holds sibling depth). Floating pill + indented drop line, edge auto-scroll.
- **Dot keeps zooming** on a plain click — a movement threshold tells drag from click; `consumeClick()` suppresses the zoom after a real drag.
- Undo via the existing `capture`/`drop` pattern.

## Design
Decided through `/grill-with-docs`: see [ADR 0010](./docs/adr/0010-drag-to-reorder-and-reparent.md) for the operation model, depth-resolution rule, invariants, and rejected alternatives.

## Verification
- `bun run typecheck` and `bun run build` pass.
- `moveNode` relink logic checked against the real `buildTreeIndex`/`childrenOf` across 12 cases (reorder up/down, move-to-head, cross-parent, cycle guard, no-op, subtree integrity).
- Pointer/DOM interaction verified by hand (drop placement, click-vs-drag, collapsed-target expand, touch, auto-scroll, undo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added drag-to-reorder functionality for outline nodes with visual feedback elements (drop indicator and floating label)
  * Improved zoom navigation to automatically expand collapsed ancestors when zooming out
  * Added auto-scroll support near viewport edges during drag operations
  * Separated click-to-zoom from drag-to-move interactions on bullet dots for better control

<!-- end of auto-generated comment: release notes by coderabbit.ai -->