### PR TITLE
fix(react): clear all React Doctor findings for React Compiler compliance

### DIFF
--- a/src/components/OutlineEditor.tsx
+++ b/src/components/OutlineEditor.tsx
@@ -1,11 +1,11 @@
 import {
-  useCallback,
   useEffect,
-  useMemo,
+  useLayoutEffect,
   useRef,
   useState,
   type KeyboardEvent as ReactKeyboardEvent,
   type MouseEvent as ReactMouseEvent,
+  type MutableRefObject,
   type ReactNode,
   type RefObject,
 } from "react";
@@ -100,6 +100,13 @@ function onContentMouseDown(e: ReactMouseEvent) {
   if (blocksCaret(e.target as HTMLElement)) e.preventDefault();
 }
 
+/** Keep a ref aligned with the latest render value without touching .current during render. */
+function useSyncRef<T>(ref: MutableRefObject<T>, value: T) {
+  useLayoutEffect(() => {
+    ref.current = value;
+  });
+}
+
 /**
  * Top-level outline editor. Owns:
  *  - reading the live tree
@@ -116,8 +123,8 @@ export function OutlineEditor({ rootId }: OutlineEditorProps) {
   // Live handle to the current tree for the stable command/drag closures (the
   // ref pattern every live value uses, so `commands` keeps its identity across
   // renders -- a prop on every memoized OutlineNode. See ADR 0014).
-  const focusIndex = useRef<TreeIndex>(index);
-  focusIndex.current = index;
+  const focusIndex = useRef(index);
+  useSyncRef(focusIndex, index);
 
   // First-run import-or-seed bootstrap; safe to run on mount. See seed.ts.
   useBootstrapOutline();
@@ -126,30 +133,25 @@ export function OutlineEditor({ rootId }: OutlineEditorProps) {
 
   // Seam G (ADR 0018): the composed per-node visibility predicate. The core no
   // longer hardcodes `completed` -- it hides whatever the plugin view transforms
-  // hide (hide-completed today). Memoized so it stays referentially stable
-  // across keystrokes, which keeps useVisibleChildIds' cache warm and every
-  // memoized OutlineNode from re-rendering on a sibling's keystroke (ADR 0014).
-  // Depends on the whole view context for forward-correctness, though today's
-  // only hide rule reads showCompleted.
-  const viewCtx = useMemo<ViewContext>(
-    () => ({ showCompleted, search: routeSearch, rootId }),
-    [showCompleted, routeSearch, rootId],
-  );
-  const isHidden = useMemo(() => composeHidden(viewCtx), [viewCtx]);
-  // Live handle for the stable command closures + drag (mirrors the ref pattern
-  // the other live values use, so `commands` keeps its identity -- ADR 0014).
+  // hide (hide-completed today). React Compiler keeps this stable across
+  // keystrokes so useVisibleChildIds' cache stays warm (ADR 0014).
+  const viewCtx: ViewContext = { showCompleted, search: routeSearch, rootId };
+  const isHidden = composeHidden(viewCtx);
   const isHiddenRef = useRef(isHidden);
-  isHiddenRef.current = isHidden;
+  useSyncRef(isHiddenRef, isHidden);
 
-  const rootIdRef = useRef<string | null>(rootId);
-  rootIdRef.current = rootId;
+  const rootIdRef = useRef(rootId);
+  useSyncRef(rootIdRef, rootId);
 
   // Focus plumbing: the id->contentEditable registry, the post-render focus/
   // flash pass, and undo/redo (which restore focus where the action left it).
-  // The refs are returned so the command closures + drag can write them. See
-  // useOutlineFocus.
-  const { refs, registerRef, pendingFocus, pendingFocusAtStart, pendingFlash } =
-    useOutlineFocus(focusIndex);
+  const {
+    refs,
+    registerRef,
+    requestFocus,
+    requestFocusAtStart,
+    requestFlash,
+  } = useOutlineFocus(focusIndex);
 
   // The top-level <ul>, so the drag indicator knows how wide to draw.
   const listRef = useRef<HTMLUListElement | null>(null);
@@ -220,9 +222,9 @@ export function OutlineEditor({ rootId }: OutlineEditorProps) {
         afterSiblingId,
       );
       if (moved) {
-        pendingFocus.current = id;
+        requestFocus(id);
         // Tint the row it landed on so the eye can find what just moved.
-        pendingFlash.current = id;
+        requestFlash(id);
       } else drop();
     },
   });
@@ -240,9 +242,9 @@ export function OutlineEditor({ rootId }: OutlineEditorProps) {
     rootIdRef,
     isHiddenRef,
     refs,
-    pendingFocus,
-    pendingFocusAtStart,
-    pendingFlash,
+    requestFocus,
+    requestFocusAtStart,
+    requestFlash,
     navigateZoom,
     startDrag,
     consumeClick,
@@ -250,28 +252,22 @@ export function OutlineEditor({ rootId }: OutlineEditorProps) {
 
   // PluginContext factory (ADR 0018 D8): the promoted command set + tree reads +
   // a small nav surface, handed to plugin interaction handlers (Seam B). Reads
-  // live values (focusIndex/activeTagsRef) at call time; stable identity.
-  const pluginCtx = useCallback(
-    (): PluginContext => ({
-      tree: focusIndex.current,
-      mutations: commands,
-      nav: {
-        zoom: (id) => navigateZoom(id, id),
-      },
-      openOverlay: (node) => setOverlayNode(node),
-    }),
-    [commands, navigateZoom],
-  );
+  // live values at call time; React Compiler keeps this stable.
+  const pluginCtx = (): PluginContext => ({
+    tree: focusIndex.current,
+    mutations: commands,
+    nav: {
+      zoom: (id) => navigateZoom(id, id),
+    },
+    openOverlay: (node) => setOverlayNode(node),
+  });
 
   // The pruned visible-set for the active filter (matches + ancestor context),
   // or null when no filter. Now a plugin-contributed Seam-G transform (the tags
   // plugin's tag-filter), composed in registry.buildViewFilter -- the core no
   // longer imports buildTagFilter directly. Render-time only, never mutates a
   // node (ADR 0015). The composed isHidden is passed so it prunes hidden nodes.
-  const filter = useMemo(
-    () => buildViewFilter(index, viewCtx, isHidden),
-    [index, viewCtx, isHidden],
-  );
+  const filter = buildViewFilter(index, viewCtx, isHidden);
   const noMatches = filter !== null && filter.matchIds.size === 0;
 
   // Top-level roots start the fade cascade fresh: a completed ancestor above
@@ -332,7 +328,7 @@ export function OutlineEditor({ rootId }: OutlineEditorProps) {
                 focusIndex.current,
                 zoomedNode.id,
               );
-              pendingFocus.current = newId;
+              requestFocus(newId);
             }}
             onArrowDown={() => commands.onMoveFocus(zoomedNode.id, "down")}
           />
@@ -374,7 +370,7 @@ export function OutlineEditor({ rootId }: OutlineEditorProps) {
                     rootId,
                     afterId,
                   );
-                  pendingFocus.current = newId;
+                  requestFocus(newId);
                 }}
               >
                 <PlusIcon />
@@ -417,14 +413,13 @@ interface OutlineFocus {
    *  so focus logic treats titles and list items uniformly. */
   refs: RefObject<Map<string, HTMLSpanElement | null>>;
   registerRef: (id: string, el: HTMLSpanElement | null) => void;
-  /** The node to focus after the next render (most-recently inserted/moved). */
-  pendingFocus: RefObject<string | null>;
+  /** Queue focus on a node after the next render. */
+  requestFocus: (id: string) => void;
   /** When an Enter-split moved text into the new bullet, land the caret at its
-   *  START, not its end (every other pending-focus wants the end). */
-  pendingFocusAtStart: RefObject<boolean>;
-  /** Like pendingFocus, but pulses the row's background to mark a just-moved
-   *  node (set after a drag/keyboard move). */
-  pendingFlash: RefObject<string | null>;
+   *  START, not its end (every other requestFocus wants the end). */
+  requestFocusAtStart: () => void;
+  /** Pulse the row's background to mark a just-moved node. */
+  requestFlash: (id: string) => void;
 }
 
 /**
@@ -434,19 +429,28 @@ interface OutlineFocus {
  * are returned so the command closures and drag can write them. See ADR 0014.
  */
 function useOutlineFocus(focusIndex: RefObject<TreeIndex>): OutlineFocus {
-  // The refs registry. Lazy-init the Map once: useRef has no lazy-initializer
-  // form, so passing `new Map()` directly would rebuild and discard it on every
-  // render. (react-doctor/rerender-lazy-ref-init.)
-  const refs = useRef<Map<string, HTMLSpanElement | null>>(null!);
-  if (!refs.current) refs.current = new Map();
-  const registerRef = useCallback((id: string, el: HTMLSpanElement | null) => {
+  // Stable Map instance via useState lazy init — avoids touching ref.current
+  // during render (react-hooks-js/refs) while keeping one map for the editor.
+  const [refsMap] = useState(() => new Map<string, HTMLSpanElement | null>());
+  const refs = useRef(refsMap);
+  const registerRef = (id: string, el: HTMLSpanElement | null) => {
     if (el) refs.current.set(id, el);
     else refs.current.delete(id);
-  }, []);
+  };
 
   const pendingFocus = useRef<string | null>(null);
   const pendingFocusAtStart = useRef(false);
   const pendingFlash = useRef<string | null>(null);
+
+  const requestFocus = (id: string) => {
+    pendingFocus.current = id;
+  };
+  const requestFocusAtStart = () => {
+    pendingFocusAtStart.current = true;
+  };
+  const requestFlash = (id: string) => {
+    pendingFlash.current = id;
+  };
 
   // After every render, if a focus is pending and the target exists, focus it;
   // likewise flash a just-moved row. Both run post-render because the target row
@@ -471,13 +475,13 @@ function useOutlineFocus(focusIndex: RefObject<TreeIndex>): OutlineFocus {
 
   // The currently-focused bullet id, by reverse-looking-up the registry (covers
   // list items and the zoomed title). Null when focus is outside the outline.
-  const findFocusedId = useCallback((): string | null => {
+  const findFocusedId = (): string | null => {
     const active = document.activeElement;
     for (const [id, el] of refs.current) {
       if (el === active) return id;
     }
     return null;
-  }, []);
+  };
 
   // Cmd/Ctrl+Z / Cmd/Ctrl+Shift+Z: undo/redo, owning history over the browser's
   // native contentEditable undo (preventDefault). The focused id is handed in so
@@ -500,7 +504,13 @@ function useOutlineFocus(focusIndex: RefObject<TreeIndex>): OutlineFocus {
     { preventDefault: true },
   );
 
-  return { refs, registerRef, pendingFocus, pendingFocusAtStart, pendingFlash };
+  return {
+    refs,
+    registerRef,
+    requestFocus,
+    requestFocusAtStart,
+    requestFlash,
+  };
 }
 
 interface ZoomNavigationArgs {
@@ -535,11 +545,11 @@ function useZoomNavigation({
   const location = useLocation();
   const pivotId = location.state.pivotId ?? null;
   const pivotIdRef = useRef<string | null>(pivotId);
-  pivotIdRef.current = pivotId;
+  useSyncRef(pivotIdRef, pivotId);
   const rootIdRef = useRef<string | null>(rootId);
-  rootIdRef.current = rootId;
+  useSyncRef(rootIdRef, rootId);
   const navigateRef = useRef(navigate);
-  navigateRef.current = navigate;
+  useSyncRef(navigateRef, navigate);
 
   /**
    * Navigate to a new zoom root with a shared-element morph. `pivot` is the
@@ -547,8 +557,7 @@ function useZoomNavigation({
    * the current root when zooming out (title -> list item). We name the pivot in
    * the OUTGOING view here; the incoming view names it declaratively.
    */
-  const navigateZoom = useCallback(
-    (toRootId: string | null, pivot: string) => {
+  const navigateZoom = (toRootId: string | null, pivot: string) => {
       const navigate = navigateRef.current;
       // Zooming out reveals the trail: expand any collapsed ancestor between the
       // node we're leaving and the destination root, so the pivot is actually
@@ -579,9 +588,7 @@ function useZoomNavigation({
       };
       if (toRootId === null) navigate({ to: "/", ...opts });
       else navigate({ to: "/$nodeId", params: { nodeId: toRootId }, ...opts });
-    },
-    [focusIndex, refs],
-  );
+  };
 
   // Cmd/Ctrl+,: zoom out one level -- navigate to the current root's parent,
   // with the current root as the morph pivot (title -> list item). No-op at the
@@ -647,9 +654,9 @@ interface NodeCommandsArgs {
   rootIdRef: RefObject<string | null>;
   isHiddenRef: RefObject<(node: Node) => boolean>;
   refs: RefObject<Map<string, HTMLSpanElement | null>>;
-  pendingFocus: RefObject<string | null>;
-  pendingFocusAtStart: RefObject<boolean>;
-  pendingFlash: RefObject<string | null>;
+  requestFocus: (id: string) => void;
+  requestFocusAtStart: () => void;
+  requestFlash: (id: string) => void;
   navigateZoom: (toRootId: string | null, pivot: string) => void;
   startDrag: ReturnType<typeof useDragReorder>["startDrag"];
   consumeClick: ReturnType<typeof useDragReorder>["consumeClick"];
@@ -665,15 +672,14 @@ function useNodeCommands({
   rootIdRef,
   isHiddenRef,
   refs,
-  pendingFocus,
-  pendingFocusAtStart,
-  pendingFlash,
+  requestFocus,
+  requestFocusAtStart,
+  requestFlash,
   navigateZoom,
   startDrag,
   consumeClick,
 }: NodeCommandsArgs): NodeCommands {
-  return useMemo<NodeCommands>(
-    () => ({
+  return {
       onTextChange: (id, text) => {
         // Coalesce a run of keystrokes on one bullet into a single undo step,
         // capturing the pre-typing state on the first keystroke of the run.
@@ -696,10 +702,8 @@ function useNodeCommands({
         const isOpen =
           !node.collapsed && childrenOf(focusIndex.current, id).length > 0;
         if (caretAtEnd && isOpen) {
-          pendingFocus.current = insertChildAtStart(
-            focusIndex.current,
-            id,
-            node.isTask,
+          requestFocus(
+            insertChildAtStart(focusIndex.current, id, node.isTask),
           );
           return;
         }
@@ -715,9 +719,9 @@ function useNodeCommands({
         if (!caretAtEnd) {
           setText(id, before);
           // Caret sits before the moved text, where the split happened.
-          pendingFocusAtStart.current = true;
+          requestFocusAtStart();
         }
-        pendingFocus.current = newId;
+        requestFocus(newId);
       },
 
       onIndent: (id) => {
@@ -725,8 +729,8 @@ function useNodeCommands({
         // its contentEditable and drops focus. Re-focus it after the render.
         capture(focusIndex.current, id);
         if (indent(focusIndex.current, id)) {
-          pendingFocus.current = id;
-          pendingFlash.current = id;
+          requestFocus(id);
+          requestFlash(id);
         } else drop(); // no move happened; discard the redundant undo point
       },
 
@@ -738,8 +742,8 @@ function useNodeCommands({
         // Same remount-drops-focus issue as indent; re-focus on a real move.
         capture(focusIndex.current, id);
         if (outdent(focusIndex.current, id)) {
-          pendingFocus.current = id;
-          pendingFlash.current = id;
+          requestFocus(id);
+          requestFlash(id);
         } else drop();
       },
 
@@ -751,8 +755,8 @@ function useNodeCommands({
           rootId: rootIdRef.current,
         });
         if (moved) {
-          pendingFocus.current = id;
-          pendingFlash.current = id;
+          requestFocus(id);
+          requestFlash(id);
         } else drop();
       },
 
@@ -763,8 +767,8 @@ function useNodeCommands({
           rootId: rootIdRef.current,
         });
         if (moved) {
-          pendingFocus.current = id;
-          pendingFlash.current = id;
+          requestFocus(id);
+          requestFlash(id);
         } else drop();
       },
 
@@ -774,7 +778,7 @@ function useNodeCommands({
         if (isProtected(id)) return;
         capture(focusIndex.current, id);
         const focusId = removeNode(focusIndex.current, id);
-        if (focusId) pendingFocus.current = focusId;
+        if (focusId) requestFocus(focusId);
         else drop(); // node didn't exist; nothing was deleted
       },
 
@@ -825,15 +829,7 @@ function useNodeCommands({
         if (consumeClick()) return;
         navigateZoom(id, id);
       },
-    }),
-    // commands MUST keep stable identity (a prop on every memoized OutlineNode,
-    // ADR 0014). Every live value it touches is read through a ref at call time
-    // (focusIndex/refs/pendingFocus/...), so the only real deps are the three
-    // stable callbacks; the flagged ref.current captures can't be listed and
-    // would defeat the pattern.
-    // eslint-disable-next-line react-doctor/exhaustive-deps
-    [navigateZoom, startDrag, consumeClick],
-  );
+  };
 }
 
 /**

--- a/src/components/OutlineNode.tsx
+++ b/src/components/OutlineNode.tsx
@@ -1,4 +1,4 @@
-import { Fragment, memo, useEffect, useRef, type PointerEvent } from "react";
+import { Fragment, useEffect, useRef, type PointerEvent } from "react";
 import { ChevronRight } from "lucide-react";
 import type { Node } from "../data/schema";
 import type { TagFilter } from "../data/tags";
@@ -87,20 +87,17 @@ export interface NodeCommands {
 
 /**
  * Thin reactive wrapper: reads this node from the shared store and renders the
- * body only when it exists. Memoized so a parent re-render skips it when its
- * (stable) props are unchanged; its own `useNode` subscription still re-renders
- * it when THIS node's data changes. The early return lives here -- before any
- * other hooks -- so the rules of hooks hold while still letting a deleted node
- * (id present in a parent's stale snapshot) render nothing. See ADR 0014.
+ * body only when it exists. React Compiler memoizes the output; its own
+ * `useNode` subscription still re-renders it when THIS node's data changes.
+ * The early return lives here -- before any other hooks -- so the rules of
+ * hooks hold while still letting a deleted node (id present in a parent's
+ * stale snapshot) render nothing. See ADR 0014.
  */
-export const OutlineNode = memo(function OutlineNode({
-  nodeId,
-  ...rest
-}: OutlineNodeProps) {
+export function OutlineNode({ nodeId, ...rest }: OutlineNodeProps) {
   const node = useNode(nodeId);
   if (!node) return null;
   return <OutlineNodeBody node={node} {...rest} />;
-});
+}
 
 function OutlineNodeBody({
   node,

--- a/src/components/Subheader.tsx
+++ b/src/components/Subheader.tsx
@@ -1,5 +1,5 @@
-import { Fragment, useCallback, useLayoutEffect, useRef, useState } from "react";
-import { motion, useReducedMotion } from "motion/react";
+import { Fragment, useLayoutEffect, useRef, useState } from "react";
+import { LazyMotion, domAnimation, m, useReducedMotion } from "motion/react";
 import { subheaderSlots } from "../plugins/registry";
 import type { PluginContext } from "../plugins/types";
 import { cn } from "@/lib/utils";
@@ -19,25 +19,25 @@ export function Subheader({
   getCtx?: () => PluginContext;
 }) {
   const reduceMotion = useReducedMotion();
-  const contentRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLElement>(null);
   const shellRef = useRef<HTMLDivElement>(null);
   const [open, setOpen] = useState(false);
   const [height, setHeight] = useState(0);
 
-  const measure = useCallback(() => {
+  useLayoutEffect(() => {
     const content = contentRef.current;
     const shell = shellRef.current;
     if (!content || !shell) return;
-    const has = content.childElementCount > 0;
-    setOpen(has);
-    // offsetHeight on the bordered shell — scrollHeight on the inner row
-    // clipped the bottom border under overflow-hidden.
-    setHeight(has ? shell.offsetHeight : 0);
-  }, []);
 
-  useLayoutEffect(() => {
-    const content = contentRef.current;
-    if (!content) return;
+    const measure = () => {
+      const c = contentRef.current;
+      const s = shellRef.current;
+      if (!c || !s) return;
+      const has = c.childElementCount > 0;
+      setOpen(has);
+      setHeight(has ? s.offsetHeight : 0);
+    };
+
     measure();
     const ro = new ResizeObserver(measure);
     ro.observe(content);
@@ -47,44 +47,49 @@ export function Subheader({
       ro.disconnect();
       mo.disconnect();
     };
-  }, [measure]);
+  }, []);
 
   useLayoutEffect(() => {
-    measure();
-  }, [open, measure]);
+    const content = contentRef.current;
+    const shell = shellRef.current;
+    if (!content || !shell) return;
+    const has = content.childElementCount > 0;
+    setHeight(has ? shell.offsetHeight : 0);
+  }, [open]);
 
   if (!getCtx) return null;
 
   return (
-    <motion.div
-      initial={false}
-      animate={
-        reduceMotion
-          ? { height: open ? "auto" : 0 }
-          : { height: open ? height : 0, opacity: open ? 1 : 0 }
-      }
-      transition={{ duration: 0.2, ease: "easeOut" }}
-      className="overflow-hidden"
-      aria-hidden={!open}
-    >
-      <div
-        ref={shellRef}
-        className={cn("bg-muted/30", open && "border-b border-border")}
+    <LazyMotion features={domAnimation}>
+      <m.div
+        initial={false}
+        animate={
+          reduceMotion
+            ? { height: open ? "auto" : 0 }
+            : { height: open ? height : 0, opacity: open ? 1 : 0 }
+        }
+        transition={{ duration: 0.2, ease: "easeOut" }}
+        className="overflow-hidden"
+        aria-hidden={!open}
       >
         <div
-          ref={contentRef}
-          role="region"
-          aria-label="Active filters"
-          className={cn(
-            "mx-auto flex max-w-[720px] flex-wrap items-center gap-2",
-            open && "px-6 py-2",
-          )}
+          ref={shellRef}
+          className={cn("bg-muted/30", open && "border-b border-border")}
         >
-          {subheaderSlots.map((s) => (
-            <Fragment key={s.id}>{s.render(getCtx)}</Fragment>
-          ))}
+          <section
+            ref={contentRef}
+            aria-label="Active filters"
+            className={cn(
+              "mx-auto flex max-w-[720px] flex-wrap items-center gap-2",
+              open && "px-6 py-2",
+            )}
+          >
+            {subheaderSlots.map((s) => (
+              <Fragment key={s.id}>{s.render(getCtx)}</Fragment>
+            ))}
+          </section>
         </div>
-      </div>
-    </motion.div>
+      </m.div>
+    </LazyMotion>
   );
 }

--- a/src/components/auth-gate.tsx
+++ b/src/components/auth-gate.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from "react";
+import { useSession } from "../lib/auth-client";
+import { AuthScreen } from "./auth-screen";
+
+/**
+ * Gate the whole app behind a Better Auth session. The shell is public so this
+ * renders the login screen for signed-out visitors; only the editor (and the
+ * data API it hits) require a session. While the session is still loading we
+ * render nothing to avoid flashing the login screen at an authed user.
+ */
+export function AuthGate({ children }: Readonly<{ children: ReactNode }>) {
+  const { data: session, isPending } = useSession();
+  if (isPending) return null;
+  if (!session) return <AuthScreen />;
+  return <>{children}</>;
+}

--- a/src/components/auth-screen.tsx
+++ b/src/components/auth-screen.tsx
@@ -1,7 +1,55 @@
-import { useState, type FormEvent } from "react";
+import { useReducer, type FormEvent } from "react";
 import { signIn, signUp } from "../lib/auth-client";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
+
+type AuthMode = "signin" | "signup";
+
+type AuthState = {
+  mode: AuthMode;
+  name: string;
+  email: string;
+  password: string;
+  error: string | null;
+  busy: boolean;
+};
+
+type AuthAction =
+  | { type: "set-mode"; mode: AuthMode }
+  | { type: "set-name"; name: string }
+  | { type: "set-email"; email: string }
+  | { type: "set-password"; password: string }
+  | { type: "submit-start" }
+  | { type: "submit-error"; error: string }
+  | { type: "submit-end" };
+
+const initialAuthState: AuthState = {
+  mode: "signin",
+  name: "",
+  email: "",
+  password: "",
+  error: null,
+  busy: false,
+};
+
+function authReducer(state: AuthState, action: AuthAction): AuthState {
+  switch (action.type) {
+    case "set-mode":
+      return { ...state, mode: action.mode, error: null };
+    case "set-name":
+      return { ...state, name: action.name };
+    case "set-email":
+      return { ...state, email: action.email };
+    case "set-password":
+      return { ...state, password: action.password };
+    case "submit-start":
+      return { ...state, error: null, busy: true };
+    case "submit-error":
+      return { ...state, error: action.error, busy: false };
+    case "submit-end":
+      return { ...state, busy: false };
+  }
+}
 
 /**
  * The unauthenticated view. Email + password, with a sign in / sign up toggle.
@@ -10,19 +58,13 @@ import { Input } from "./ui/input";
  * app shell is public (worker/index.ts), so this loads without a session.
  */
 export function AuthScreen() {
-  const [mode, setMode] = useState<"signin" | "signup">("signin");
-  const [name, setName] = useState("");
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const [error, setError] = useState<string | null>(null);
-  const [busy, setBusy] = useState(false);
-
+  const [state, dispatch] = useReducer(authReducer, initialAuthState);
+  const { mode, name, email, password, error, busy } = state;
   const isSignup = mode === "signup";
 
   async function onSubmit(e: FormEvent) {
     e.preventDefault();
-    setError(null);
-    setBusy(true);
+    dispatch({ type: "submit-start" });
     try {
       const res = isSignup
         ? await signUp.email({
@@ -32,13 +74,19 @@ export function AuthScreen() {
           })
         : await signIn.email({ email, password });
       if (res.error) {
-        setError(res.error.message ?? "Something went wrong. Try again.");
+        dispatch({
+          type: "submit-error",
+          error: res.error.message ?? "Something went wrong. Try again.",
+        });
+        return;
       }
       // On success the session store updates and the gate swaps in the editor.
+      dispatch({ type: "submit-end" });
     } catch {
-      setError("Network error. Check your connection and try again.");
-    } finally {
-      setBusy(false);
+      dispatch({
+        type: "submit-error",
+        error: "Network error. Check your connection and try again.",
+      });
     }
   }
 
@@ -59,7 +107,9 @@ export function AuthScreen() {
               placeholder="Name"
               autoComplete="name"
               value={name}
-              onChange={(e) => setName(e.target.value)}
+              onChange={(e) =>
+                dispatch({ type: "set-name", name: e.target.value })
+              }
             />
           )}
           <Input
@@ -68,7 +118,9 @@ export function AuthScreen() {
             autoComplete="email"
             required
             value={email}
-            onChange={(e) => setEmail(e.target.value)}
+            onChange={(e) =>
+              dispatch({ type: "set-email", email: e.target.value })
+            }
           />
           <Input
             type="password"
@@ -77,7 +129,9 @@ export function AuthScreen() {
             required
             minLength={8}
             value={password}
-            onChange={(e) => setPassword(e.target.value)}
+            onChange={(e) =>
+              dispatch({ type: "set-password", password: e.target.value })
+            }
           />
 
           {error && <p className="text-sm text-destructive">{error}</p>}
@@ -92,10 +146,12 @@ export function AuthScreen() {
           <button
             type="button"
             className="font-medium text-foreground underline-offset-4 hover:underline"
-            onClick={() => {
-              setMode(isSignup ? "signin" : "signup");
-              setError(null);
-            }}
+            onClick={() =>
+              dispatch({
+                type: "set-mode",
+                mode: isSignup ? "signin" : "signup",
+              })
+            }
           >
             {isSignup ? "Sign in" : "Create an account"}
           </button>

--- a/src/components/menu-engine.tsx
+++ b/src/components/menu-engine.tsx
@@ -1,6 +1,4 @@
 import {
-  useCallback,
-  useMemo,
   useState,
   type KeyboardEvent as ReactKeyboardEvent,
 } from "react";
@@ -74,23 +72,18 @@ export function useMenus({
 
   // The entries for the open menu, recomputed as the query changes. Reads the
   // live tree/commands through ctx(); keyed on the open state + this node.
-  const entries = useMemo<MenuEntry[]>(() => {
-    if (!open || !spec) return [];
-    return spec.entries(open.trigger, node, ctx());
-    // ctx is a referentially-stable factory read at call time; recompute only
-    // when the open menu / node changes, not on ctx identity.
-    // eslint-disable-next-line react-doctor/exhaustive-deps
-  }, [open, spec, node]);
+  const entries: MenuEntry[] =
+    open && spec ? spec.entries(open.trigger, node, ctx()) : [];
 
   // "Open" only counts when there's something to show (or the spec opts into an
   // empty state), so a brand-new `#tag`'s Enter is never swallowed.
   const isOpen = open !== null && (entries.length > 0 || !!spec?.openWhenEmpty);
 
-  const close = useCallback(() => setOpen(null), []);
+  const close = () => setOpen(null);
 
   // Re-evaluate the triggers after every input. The first spec whose trigger is
   // live AND has something to open wins; otherwise the menu closes.
-  const handleInput = useCallback(() => {
+  const handleInput = () => {
     const el = getEl();
     if (!el) return setOpen(null);
     const caret = caretOffset(el);
@@ -116,10 +109,9 @@ export function useMenus({
       return;
     }
     setOpen(null);
-  }, [getEl, node, ctx]);
+  };
 
-  const pick = useCallback(
-    (index: number) => {
+  const pick = (index: number) => {
       const el = getEl();
       if (!el || !open) return;
       const entry = entries[index];
@@ -139,14 +131,11 @@ export function useMenus({
       setCaretOffset(el, caret);
       setOpen(null);
       entry.after?.();
-    },
-    [getEl, open, entries, onTextChange],
-  );
+  };
 
   // Intercept navigation keys while open. Returns true if it consumed the event,
   // so the caller skips its own Enter/Tab/Arrow handling.
-  const handleKeyDown = useCallback(
-    (e: ReactKeyboardEvent<HTMLElement>): boolean => {
+  const handleKeyDown = (e: ReactKeyboardEvent<HTMLElement>): boolean => {
       if (!isOpen || !open) return false;
       switch (e.key) {
         case "ArrowDown":
@@ -177,9 +166,7 @@ export function useMenus({
         default:
           return false;
       }
-    },
-    [isOpen, open, entries.length, pick],
-  );
+  };
 
   const menu =
     isOpen && open

--- a/src/components/move-dialog.tsx
+++ b/src/components/move-dialog.tsx
@@ -1,6 +1,5 @@
 import {
   useEffect,
-  useMemo,
   useState,
   useSyncExternalStore,
   type ReactNode,
@@ -130,40 +129,32 @@ function MoveDialogInner({
   // Candidate destinations: every node except the one being moved and its own
   // subtree (you can't move a branch into itself -- `moveNode` guards this too,
   // but listing those rows would be a dead press). Built only while open.
-  const candidates = useMemo(() => {
-    if (!nodeId) return [];
-    const excluded = subtreeIds(index, nodeId);
-    return Array.from(index.byId.values()).filter(
-      (n) => !excluded.has(n.id) && n.text.trim() !== "",
-    );
-  }, [index, nodeId]);
+  const candidates = !nodeId
+    ? []
+    : Array.from(index.byId.values()).filter(
+        (n) =>
+          !subtreeIds(index, nodeId).has(n.id) && n.text.trim() !== "",
+      );
 
-  const fuse = useMemo(
-    () => (open ? new Fuse(candidates, FUSE_OPTIONS) : null),
-    [open, candidates],
-  );
+  const fuse = open ? new Fuse(candidates, FUSE_OPTIONS) : null;
 
   const q = query.trim();
 
   // null => empty-query mode (show bookmarks, mirroring the quick-switcher).
   // Otherwise the Fuse hits over every candidate.
-  const results = useMemo<Hit[] | null>(() => {
-    if (!q || !fuse) return null;
-    return fuse
-      .search(q, { limit: RESULT_LIMIT })
-      .map((r) => ({ node: r.item, matches: r.matches }));
-  }, [q, fuse]);
+  const results: Hit[] | null =
+    q && fuse
+      ? fuse
+          .search(q, { limit: RESULT_LIMIT })
+          .map((r) => ({ node: r.item, matches: r.matches }))
+      : null;
 
   // Bookmarked destinations for the empty-query state, newest first. Drawn from
   // `candidates` (not all nodes), so the moved node and its own subtree are
   // already excluded -- you can't bookmark-jump a branch into itself.
-  const bookmarks = useMemo(
-    () =>
-      candidates
-        .filter((n) => n.bookmarkedAt != null)
-        .sort((a, b) => (b.bookmarkedAt ?? 0) - (a.bookmarkedAt ?? 0)),
-    [candidates],
-  );
+  const bookmarks = candidates
+    .filter((n) => n.bookmarkedAt != null)
+    .sort((a, b) => (b.bookmarkedAt ?? 0) - (a.bookmarkedAt ?? 0));
 
   // "Home" shows on an empty query or when the text looks like the word.
   const showHome = q === "" || "home".includes(q.toLowerCase());

--- a/src/components/node-switcher.tsx
+++ b/src/components/node-switcher.tsx
@@ -1,6 +1,5 @@
 import {
   useEffect,
-  useMemo,
   useState,
   useSyncExternalStore,
   type ReactNode,
@@ -145,36 +144,34 @@ function SwitcherDialog({
   const { index } = useTree();
   const navigate = useNavigate();
 
-  const nodes = useMemo(() => Array.from(index.byId.values()), [index]);
+  const nodes = Array.from(index.byId.values());
 
   // Build the Fuse index only while open. When closed we skip the work; when
   // open the outline isn't being edited, so `nodes` is stable.
-  const fuse = useMemo(() => {
+  const fuse = (() => {
     if (!open) return null;
     const searchable: Searchable[] = [];
     for (const n of nodes) {
       if (n.text.trim() !== "") {
-        searchable.push({ node: n, text: stripLinks(n.text), aliases: searchAliases(n) });
+        searchable.push({
+          node: n,
+          text: stripLinks(n.text),
+          aliases: searchAliases(n),
+        });
       }
     }
     return new Fuse(searchable, FUSE_OPTIONS);
-  }, [open, nodes]);
+  })();
 
   const q = query.trim();
 
   // null => empty-query mode (show bookmarks). Otherwise the Fuse hits.
-  const results = useMemo(() => {
-    if (!q || !fuse) return null;
-    return fuse.search(q, { limit: RESULT_LIMIT });
-  }, [q, fuse]);
+  const results =
+    q && fuse ? fuse.search(q, { limit: RESULT_LIMIT }) : null;
 
-  const bookmarks = useMemo(
-    () =>
-      nodes
-        .filter((n) => n.bookmarkedAt != null)
-        .sort((a, b) => (b.bookmarkedAt ?? 0) - (a.bookmarkedAt ?? 0)),
-    [nodes],
-  );
+  const bookmarks = nodes
+    .filter((n) => n.bookmarkedAt != null)
+    .sort((a, b) => (b.bookmarkedAt ?? 0) - (a.bookmarkedAt ?? 0));
 
   function go(nodeId: string) {
     onPicked();
@@ -185,16 +182,15 @@ function SwitcherDialog({
   // Plugin-contributed VIRTUAL rows (Seam J), built from the live query -- the
   // daily plugin's "Go to Today" when today's note doesn't exist yet. Each runs
   // its own action (create + navigate) on pick. Empty for an empty query.
-  const actions = useMemo<SearchAction[]>(() => {
-    if (!q) return [];
-    return searchActions(q, {
-      index,
-      goTo: (id) => {
-        onPicked();
-        navigate({ to: "/$nodeId", params: { nodeId: id } });
-      },
-    });
-  }, [q, index, navigate, onPicked]);
+  const actions: SearchAction[] = !q
+    ? []
+    : searchActions(q, {
+        index,
+        goTo: (id) => {
+          onPicked();
+          navigate({ to: "/$nodeId", params: { nodeId: id } });
+        },
+      });
 
   return (
     <CommandDialog

--- a/src/components/root-document.tsx
+++ b/src/components/root-document.tsx
@@ -1,0 +1,41 @@
+import type { ReactNode } from "react";
+import { HeadContent, Scripts } from "@tanstack/react-router";
+import { LEGACY_THEME_KEY, THEME_KEY } from "../lib/storage-keys";
+
+// Runs before first paint so the page never flashes the wrong theme. Mirrors
+// the resolution logic in theme-provider.tsx (same storage key).
+const noFlashThemeScript = `
+(function () {
+  try {
+    var key = '${THEME_KEY}';
+    var legacy = '${LEGACY_THEME_KEY}';
+    var t = localStorage.getItem(key);
+    if (!t) {
+      t = localStorage.getItem(legacy);
+      if (t) {
+        localStorage.setItem(key, t);
+        localStorage.removeItem(legacy);
+      }
+    }
+    t = t || 'system';
+    var dark = t === 'dark' || (t === 'system' &&
+      window.matchMedia('(prefers-color-scheme: dark)').matches);
+    if (dark) document.documentElement.classList.add('dark');
+  } catch (e) {}
+})();
+`;
+
+export function RootDocument({ children }: Readonly<{ children: ReactNode }>) {
+  return (
+    <html lang="en" className="[scrollbar-gutter:stable]">
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: noFlashThemeScript }} />
+        <HeadContent />
+      </head>
+      <body>
+        {children}
+        <Scripts />
+      </body>
+    </html>
+  );
+}

--- a/src/components/show-completed-provider.tsx
+++ b/src/components/show-completed-provider.tsx
@@ -1,10 +1,4 @@
-import {
-  createContext,
-  use,
-  useCallback,
-  useMemo,
-  useSyncExternalStore,
-} from "react";
+import { createContext, use, useSyncExternalStore } from "react";
 import {
   LEGACY_SHOW_COMPLETED_KEY,
   readStorageMigrated,
@@ -50,6 +44,11 @@ function notifyShowCompletedListeners() {
   for (const l of showCompletedListeners) l();
 }
 
+function setShowCompleted(next: boolean) {
+  localStorage.setItem(SHOW_COMPLETED_KEY, String(next));
+  notifyShowCompletedListeners();
+}
+
 /**
  * Global "Show completed" preference (Workflowy's header toggle). When false,
  * completed bullets and their entire subtrees are hidden from the outline. This
@@ -71,15 +70,7 @@ export function ShowCompletedProvider({
     getShowCompletedServerSnapshot,
   );
 
-  const setShowCompleted = useCallback((next: boolean) => {
-    localStorage.setItem(SHOW_COMPLETED_KEY, String(next));
-    notifyShowCompletedListeners();
-  }, []);
-
-  const value = useMemo(
-    () => ({ showCompleted, setShowCompleted }),
-    [showCompleted, setShowCompleted],
-  );
+  const value = { showCompleted, setShowCompleted };
 
   return (
     <ShowCompletedContext.Provider value={value}>

--- a/src/components/slash-menu.tsx
+++ b/src/components/slash-menu.tsx
@@ -1,9 +1,4 @@
-import {
-  useCallback,
-  useMemo,
-  useState,
-  type KeyboardEvent as ReactKeyboardEvent,
-} from "react";
+import { useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
 import { createPortal } from "react-dom";
 import { CornerUpRightIcon } from "lucide-react";
 import type { Node } from "../data/schema";
@@ -82,15 +77,12 @@ export function useSlashMenu({
 }) {
   const [state, setState] = useState<SlashState | null>(null);
 
-  const items = useMemo(
-    () => (state ? filterCommands(node, state.query) : []),
-    [state, node],
-  );
+  const items = state ? filterCommands(node, state.query) : [];
 
-  const close = useCallback(() => setState(null), []);
+  const close = () => setState(null);
 
   // Re-evaluate the trigger after every input. Opens, updates, or closes.
-  const handleInput = useCallback(() => {
+  const handleInput = () => {
     const el = getEl();
     if (!el) return;
     const hit = detectSlash(el);
@@ -107,10 +99,9 @@ export function useSlashMenu({
       x: pos.x,
       y: pos.y,
     }));
-  }, [getEl]);
+  };
 
-  const select = useCallback(
-    (index: number) => {
+  const select = (index: number) => {
       const el = getEl();
       if (!el || !state) return;
       const list = filterCommands(node, state.query);
@@ -130,14 +121,11 @@ export function useSlashMenu({
       setCaretOffset(el, state.slashIndex);
       setState(null);
       item.run(node.id, ctx());
-    },
-    [getEl, state, node, ctx, onTextChange],
-  );
+  };
 
   // Intercept navigation keys while open. Returns true if it consumed the
   // event, so the caller skips its own Enter/Tab/Arrow handling.
-  const handleKeyDown = useCallback(
-    (e: ReactKeyboardEvent<HTMLElement>): boolean => {
+  const handleKeyDown = (e: ReactKeyboardEvent<HTMLElement>): boolean => {
       if (!state) return false;
       switch (e.key) {
         case "ArrowDown":
@@ -168,9 +156,7 @@ export function useSlashMenu({
         default:
           return false;
       }
-    },
-    [state, items.length, select],
-  );
+  };
 
   const menu = state
     ? createPortal(

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,11 +1,4 @@
-import {
-  createContext,
-  use,
-  useCallback,
-  useEffect,
-  useMemo,
-  useSyncExternalStore,
-} from "react";
+import { createContext, use, useEffect, useSyncExternalStore } from "react";
 import {
   LEGACY_THEME_KEY,
   readStorageMigrated,
@@ -51,6 +44,11 @@ function notifyThemeListeners() {
   for (const l of themeListeners) l();
 }
 
+function setTheme(next: Theme) {
+  localStorage.setItem(THEME_KEY, next);
+  notifyThemeListeners();
+}
+
 /**
  * Applies the resolved theme to <html>. "system" follows the OS preference.
  * Kept in sync with the inline no-flash script in __root.tsx (same storage key
@@ -87,12 +85,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
     return () => mq.removeEventListener("change", onChange);
   }, [theme]);
 
-  const setTheme = useCallback((next: Theme) => {
-    localStorage.setItem(THEME_KEY, next);
-    notifyThemeListeners();
-  }, []);
-
-  const value = useMemo(() => ({ theme, setTheme }), [theme, setTheme]);
+  const value = { theme, setTheme };
 
   return (
     <ThemeProviderContext.Provider value={value}>

--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -5,6 +5,6 @@ import { createAuthClient } from "better-auth/react";
  * origin and the default basePath (/api/auth) matches the Worker's route. The
  * app is a pure SPA, so this is only ever used in the browser.
  */
-export const authClient = createAuthClient();
+const authClient = createAuthClient();
 
 export const { signIn, signUp, signOut, useSession } = authClient;

--- a/src/plugins/daily/index.tsx
+++ b/src/plugins/daily/index.tsx
@@ -74,10 +74,17 @@ async function ensureNodeExists(
   awaitRemote: boolean,
 ): Promise<boolean> {
   if (hasNode(nodeId)) return true
-  if (awaitRemote) {
-    resyncNodes()
-    await waitForNode(nodeId, 1500).catch(() => {})
-    if (hasNode(nodeId)) return true
+  if (!awaitRemote) {
+    materialize()
+    return hasNode(nodeId)
+  }
+  resyncNodes()
+  if (hasNode(nodeId)) return true
+  try {
+    await waitForNode(nodeId, 1500)
+    return true
+  } catch {
+    // Timed out waiting for the winner's replica — materialize locally.
   }
   materialize()
   return hasNode(nodeId)

--- a/src/plugins/daily/navigation-progress.tsx
+++ b/src/plugins/daily/navigation-progress.tsx
@@ -1,4 +1,4 @@
-import { motion } from 'motion/react'
+import { LazyMotion, domAnimation, m } from 'motion/react'
 import { useDailyNavigationPending } from './pending'
 
 /** Full-width indeterminate bar on the sticky header stack while daily get-or-create runs. */
@@ -7,21 +7,22 @@ export function DailyNavigationProgress() {
   if (!pending) return null
 
   return (
-    <div
-      className="pointer-events-none absolute inset-x-0 bottom-0 z-20 h-0.5 overflow-hidden"
-      role="status"
-      aria-live="polite"
-    >
-      <span className="sr-only">Opening today&apos;s note…</span>
-      <motion.div
-        className="h-full w-1/4 bg-primary"
-        animate={{ x: ['-100%', '400%'] }}
-        transition={{
-          repeat: Infinity,
-          duration: 1.2,
-          ease: 'easeInOut',
-        }}
-      />
-    </div>
+    <LazyMotion features={domAnimation}>
+      <output
+        className="pointer-events-none absolute inset-x-0 bottom-0 z-20 block h-0.5 overflow-hidden"
+        aria-live="polite"
+      >
+        <span className="sr-only">Opening today&apos;s note…</span>
+        <m.div
+          className="h-full w-1/4 bg-primary"
+          animate={{ x: ['-100%', '400%'] }}
+          transition={{
+            repeat: Infinity,
+            duration: 1.2,
+            ease: 'easeInOut',
+          }}
+        />
+      </output>
+    </LazyMotion>
   )
 }

--- a/src/plugins/daily/pending.ts
+++ b/src/plugins/daily/pending.ts
@@ -18,12 +18,12 @@ function getSnapshot(): boolean {
   return pendingDepth > 0
 }
 
-export function beginDailyNavigation(): void {
+function beginDailyNavigation(): void {
   pendingDepth += 1
   notify()
 }
 
-export function endDailyNavigation(): void {
+function endDailyNavigation(): void {
   pendingDepth = Math.max(0, pendingDepth - 1)
   notify()
 }

--- a/src/plugins/tags/tag-color-menu.tsx
+++ b/src/plugins/tags/tag-color-menu.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 import { Ban } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -20,7 +20,7 @@ import {
  */
 export function TagColorStyles() {
   const rows = useTagColorRows();
-  const overrides = useMemo(() => tagColorsCss(rows), [rows]);
+  const overrides = tagColorsCss(rows);
   return (
     <>
       <style data-tag-palette>{tagColorPaletteCss}</style>

--- a/src/plugins/tags/use-tag-filter.ts
+++ b/src/plugins/tags/use-tag-filter.ts
@@ -8,7 +8,7 @@ let navigateRef: NavigateFn | null = null;
 let rootIdRef: string | null = null;
 
 /** Binds live route writers for chip-click handlers outside React hooks. */
-export function bindTagFilterNav(navigate: NavigateFn, rootId: string | null) {
+function bindTagFilterNav(navigate: NavigateFn, rootId: string | null) {
   navigateRef = navigate;
   rootIdRef = rootId;
 }

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,10 +1,4 @@
-import type { ReactNode } from 'react'
-import {
-  Outlet,
-  createRootRoute,
-  HeadContent,
-  Scripts,
-} from '@tanstack/react-router'
+import { Outlet, createRootRoute } from '@tanstack/react-router'
 import { ThemeProvider } from '../components/theme-provider'
 import { ShowCompletedProvider } from '../components/show-completed-provider'
 import { NodeSwitcher } from '../components/node-switcher'
@@ -12,33 +6,9 @@ import { MoveDialog } from '../components/move-dialog'
 import { TagColorStyles } from '../plugins/tags/tag-color-menu'
 import { PluginStyles } from '../components/plugin-styles'
 import { Toaster } from '../components/ui/sonner'
-import { AuthScreen } from '../components/auth-screen'
-import { useSession } from '../lib/auth-client'
-import { LEGACY_THEME_KEY, THEME_KEY } from '../lib/storage-keys'
+import { AuthGate } from '../components/auth-gate'
+import { RootDocument } from '../components/root-document'
 import '../styles.css'
-
-// Runs before first paint so the page never flashes the wrong theme. Mirrors
-// the resolution logic in theme-provider.tsx (same storage key).
-const noFlashThemeScript = `
-(function () {
-  try {
-    var key = '${THEME_KEY}';
-    var legacy = '${LEGACY_THEME_KEY}';
-    var t = localStorage.getItem(key);
-    if (!t) {
-      t = localStorage.getItem(legacy);
-      if (t) {
-        localStorage.setItem(key, t);
-        localStorage.removeItem(legacy);
-      }
-    }
-    t = t || 'system';
-    var dark = t === 'dark' || (t === 'system' &&
-      window.matchMedia('(prefers-color-scheme: dark)').matches);
-    if (dark) document.documentElement.classList.add('dark');
-  } catch (e) {}
-})();
-`
 
 export const Route = createRootRoute({
   head: () => ({
@@ -68,33 +38,5 @@ function RootComponent() {
         <Toaster />
       </ThemeProvider>
     </RootDocument>
-  )
-}
-
-/**
- * Gate the whole app behind a Better Auth session. The shell is public so this
- * renders the login screen for signed-out visitors; only the editor (and the
- * data API it hits) require a session. While the session is still loading we
- * render nothing to avoid flashing the login screen at an authed user.
- */
-function AuthGate({ children }: Readonly<{ children: ReactNode }>) {
-  const { data: session, isPending } = useSession()
-  if (isPending) return null
-  if (!session) return <AuthScreen />
-  return <>{children}</>
-}
-
-function RootDocument({ children }: Readonly<{ children: ReactNode }>) {
-  return (
-    <html lang="en" className="[scrollbar-gutter:stable]">
-      <head>
-        <script dangerouslySetInnerHTML={{ __html: noFlashThemeScript }} />
-        <HeadContent />
-      </head>
-      <body>
-        {children}
-        <Scripts />
-      </body>
-    </html>
   )
 }


### PR DESCRIPTION
## Summary
- Fix React Compiler blockers in `OutlineEditor` (refs during render, immutability on focus refs) and remove redundant `useMemo`/`useCallback`/`memo` now that the compiler is enabled
- Fix remaining React Doctor findings: auth screen `try/finally` + `useReducer`, LazyMotion bundle trim, semantic HTML, unused exports, daily sync guard, and split `__root` helpers into dedicated files

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `npx react-doctor@latest . --verbose` → **100/100, no issues**
- [ ] Smoke test login/signup flow
- [ ] Smoke test outline editing, tag filter subheader animation, and Today navigation progress bar


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a sign-in gate for protected areas of the app, showing an authentication screen when needed.
  * Improved first-load theme handling to prevent the wrong theme from flashing before the app appears.
  * Updated progress and subheader UI elements to use smoother, more accessible rendering patterns.

* **Bug Fixes**
  * Made focus and navigation behavior more reliable in the outline editor.
  * Improved destination and search dialogs so results stay in sync as you type or open them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->