### PR TITLE
feat(logging): evlog structured logging (Worker + SPA client)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,7 @@
         "cnfast": "^0.0.8",
         "date-fns": "^4.4.0",
         "errore": "^0.14.1",
+        "evlog": "^2.19.2",
         "fuse.js": "^7.4.2",
         "grab-bcv": "^0.1.5",
         "lucide-react": "^1.21.0",
@@ -715,6 +716,8 @@
     "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
 
     "eventsource-parser": ["eventsource-parser@3.1.0", "", {}, "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg=="],
+
+    "evlog": ["evlog@2.19.2", "", { "peerDependencies": { "@nestjs/common": ">=11.1.19", "@nuxt/kit": "^4.4.2", "@orpc/server": ">=1.14.0", "@tanstack/start-client-core": "^1.167.20", "ai": ">=6.0.168", "elysia": ">=1.4.28", "express": ">=5.2.1", "fastify": ">=5.8.5", "h3": "^1.15.11", "hono": ">=4.11.0", "next": ">=16.2.4", "nitro": "^3.0.260311-beta", "nitropack": "^2.13.3", "ofetch": "^1.5.1", "react": ">=19.2.5", "react-router": ">=7.14.2", "vite": "^7.0.0 || ^8.0.0" }, "optionalPeers": ["@nestjs/common", "@nuxt/kit", "@orpc/server", "@tanstack/start-client-core", "ai", "elysia", "express", "fastify", "h3", "hono", "next", "nitro", "nitropack", "ofetch", "react", "react-router", "vite"] }, "sha512-6a8ynL4tKhYK8p+mQv0in1tv3EUDSPvVPAWAuDRlpXTTIoLsR1Nol9dRIqhowakTP9XGNk6atSpvupTTGQDOTA=="],
 
     "execa": ["execa@9.6.1", "", { "dependencies": { "@sindresorhus/merge-streams": "^4.0.0", "cross-spawn": "^7.0.6", "figures": "^6.1.0", "get-stream": "^9.0.0", "human-signals": "^8.0.1", "is-plain-obj": "^4.1.0", "is-stream": "^4.0.1", "npm-run-path": "^6.0.0", "pretty-ms": "^9.2.0", "signal-exit": "^4.1.0", "strip-final-newline": "^4.0.0", "yoctocolors": "^2.1.1" } }, "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA=="],
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -252,3 +252,37 @@ new users start empty. Removable once that data is wherever it belongs.
 **Don't:** key the DO off the email (permanent-name orphaning — use `user.id`); make `createAuth` a
 module singleton (the D1 binding is request-scoped); gate the static shell (the login screen must
 load); or relax the `/api/*` session check to trust a client-supplied id.
+
+---
+
+## Structured logging (evlog)
+
+Observability is **evlog**, wired through its runtime-specific entries — `evlog/workers` in
+`worker/index.ts`, `evlog/client` in `src/lib/log.ts` — **not** the documented `evlog/nitro`
+TanStack Start integration. Console drain only: the Worker emits one structured wide event per
+`/api` request (visible in `wrangler tail`), and the SPA logs to the browser console with uncaught
+errors + unhandled rejections auto-captured and the session `user.id` stamped via `setIdentity`.
+evlog is the **logging** layer only — control flow stays errore (errors as values; see the Error
+Handling rule in `AGENTS.md`); we never adopt evlog's throw-based `createError()`.
+
+**Why it's not in the code:** evlog's headline TanStack Start setup is a Nitro v3 module +
+`nitro.config.ts` + a root-route `evlogErrorHandler` + `useRequest().context.log`, all of which
+assume a **Nitro server in the request path**. This app has none — it's **SPA mode** (no SSR, see
+the constraint under *Sync via a per-user Durable Object*) served as static assets, and every
+`/api/*` request is handled by the **Cloudflare Worker**, not Nitro. Wired the documented way, the
+Nitro module and the root-route middleware **never execute** — dead code that reads like working
+observability (evlog's own docs say the integration is "not for SPA mode"). So the logger lives
+where the server actually is: the Worker (`evlog/workers` auto-extracts method/path/cf-ray and
+flushes async drains via `ctx.waitUntil`) and the browser (`evlog/client`, internally gated by
+`isBrowser()`, so it no-ops during the build-time prerender of `/`).
+
+**Console-only is the v1 floor, not the ceiling.** Client logs are ephemeral (devtools only); to
+land them somewhere an agent can read *after the fact*, add a `transport` to `initLog` pointing at
+an `/api/logs` route on the Worker that re-logs them into `wrangler tail` (`evlog/http` →
+`createHttpLogDrain`). One route, deliberately deferred.
+
+**Don't:** add `nitro.config.ts` / the `evlog/nitro` module / a root-route `evlogErrorHandler`
+(all inert under SPA + Workers); replace errore returns with evlog's `createError()`/throw (it
+fights the whole codebase — evlog logs, errore controls flow); or create a logger for static-asset
+requests (the Worker short-circuits non-`/api` to `env.ASSETS` *before* building one — keep that
+order, asset serving is high-volume and uninteresting).

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "cnfast": "^0.0.8",
     "date-fns": "^4.4.0",
     "errore": "^0.14.1",
+    "evlog": "^2.19.2",
     "fuse.js": "^7.4.2",
     "grab-bcv": "^0.1.5",
     "lucide-react": "^1.21.0",

--- a/src/lib/log.ts
+++ b/src/lib/log.ts
@@ -1,0 +1,53 @@
+/// <reference types="vite/client" />
+import { initLog, log, setIdentity, clearIdentity } from 'evlog/client'
+
+/**
+ * SPA client logging (evlog/client).
+ *
+ * Console-only for now: structured events land in the browser devtools console
+ * (pretty-printed in dev, JSON in prod). evlog's `initLog` touches no browser
+ * globals, so importing this module is safe during the build-time prerender
+ * of `/`; the only window access (error capture) is guarded below.
+ *
+ * Upgrade path — to ship these to the Worker (so they show up in `wrangler tail`
+ * next to the server's wide events, where an agent can read them after the
+ * fact), pass a `transport` here pointing at an `/api/logs` ingest route and add
+ * that route to the Worker. See `evlog/http` (`createHttpLogDrain`).
+ */
+let started = false
+
+export function initClientLog() {
+  if (started) return
+  started = true
+  initLog({
+    console: true,
+    pretty: import.meta.env.DEV,
+    service: 'dotflowy-client',
+    minLevel: import.meta.env.DEV ? 'debug' : 'info',
+  })
+  installErrorCapture()
+}
+
+/**
+ * Surface otherwise-invisible client crashes — uncaught errors and unhandled
+ * promise rejections — as structured `error` logs. These are exactly the
+ * failures that vanish from a user's console before anyone can read them.
+ * Browser-only; a no-op during prerender.
+ */
+function installErrorCapture() {
+  if (typeof window === 'undefined') return
+  window.addEventListener('error', (e) => {
+    log.error({
+      event: 'window.error',
+      message: e.message,
+      source: e.filename,
+      line: e.lineno,
+      col: e.colno,
+    })
+  })
+  window.addEventListener('unhandledrejection', (e) => {
+    log.error({ event: 'unhandledrejection', reason: String(e.reason) })
+  })
+}
+
+export { log, setIdentity, clearIdentity }

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react'
+import { useEffect, type ReactNode } from 'react'
 import {
   Outlet,
   createRootRoute,
@@ -14,6 +14,7 @@ import { PluginStyles } from '../components/plugin-styles'
 import { Toaster } from '../components/ui/sonner'
 import { AuthScreen } from '../components/auth-screen'
 import { useSession } from '../lib/auth-client'
+import { clearIdentity, initClientLog, setIdentity } from '../lib/log'
 import { LEGACY_THEME_KEY, THEME_KEY } from '../lib/storage-keys'
 import '../styles.css'
 
@@ -52,6 +53,11 @@ export const Route = createRootRoute({
 })
 
 function RootComponent() {
+  // Start the SPA logger once, in the browser (effects don't run at prerender).
+  useEffect(() => {
+    initClientLog()
+  }, [])
+
   return (
     <RootDocument>
       <ThemeProvider>
@@ -79,6 +85,15 @@ function RootComponent() {
  */
 function AuthGate({ children }: Readonly<{ children: ReactNode }>) {
   const { data: session, isPending } = useSession()
+
+  // Stamp the signed-in user onto every client log so per-user bugs are
+  // traceable; clear it on sign-out.
+  const userId = session?.user.id ?? null
+  useEffect(() => {
+    if (userId) setIdentity({ userId })
+    else clearIdentity()
+  }, [userId])
+
   if (isPending) return null
   if (!session) return <AuthScreen />
   return <>{children}</>

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -17,6 +17,8 @@
  * non-destructive import into the owner's DO (`ensureSeeded`).
  */
 
+import { createWorkersLogger, initWorkersLogger } from 'evlog/workers'
+import type { AuditableLogger } from 'evlog'
 import { UserOutlineDO } from './outline-do'
 import type { Node } from './outline-do'
 import { createAuth } from './auth'
@@ -25,6 +27,11 @@ import type { AuthEnv } from './auth'
 // Re-export the DO class so the Workers runtime can instantiate it (the
 // wrangler `durable_objects` binding resolves `UserOutlineDO` from the entry).
 export { UserOutlineDO }
+
+// One structured logger per isolate; no drain configured, so it writes to the
+// console -> visible in `wrangler tail` and the CF dashboard. Swap in an HTTP
+// drain (Axiom/PostHog/etc.) here later without touching the request path.
+initWorkersLogger({ env: { service: 'dotflowy-worker' } })
 
 interface Env extends AuthEnv {
   DB: D1Database
@@ -205,62 +212,102 @@ async function handleKv(
   }
 }
 
+/** The custom fields this Worker accumulates onto each request's wide event
+ *  (method/path/cf-ray/status are handled by evlog). */
+type ApiLogFields = {
+  user: { id: string }
+  outlineDO: string
+  error: { message: string }
+}
+
+/**
+ * Route an authenticated `/api/*` request to the caller's Durable Object.
+ * Everything here is gated by a valid Better Auth session (the public static
+ * shell is served before we reach this). `log` is the request's wide event —
+ * we accumulate user / DO / error context on it; `fetch` emits it once with the
+ * final status.
+ */
+async function routeApi(
+  request: Request,
+  env: Env,
+  url: URL,
+  log: AuditableLogger<ApiLogFields>,
+): Promise<Response> {
+  const auth = createAuth(env)
+
+  // Better Auth owns everything under /api/auth/* (sign-up/in/out, session).
+  if (url.pathname.startsWith('/api/auth/')) return auth.handler(request)
+
+  // Identity = the validated session's stable user id. No session -> 401.
+  const session = await auth.api.getSession({ headers: request.headers })
+  if (!session) return json({ error: 'unauthorized' }, 401)
+  log.set({ user: { id: session.user.id } })
+
+  const userId = resolveUserId(session.user.id, env)
+  log.set({ outlineDO: userId })
+  const stub = env.USER_OUTLINE.get(env.USER_OUTLINE.idFromName(userId))
+
+  try {
+    // Only the owner's DO ('default') has legacy D1 rows to import; new users
+    // start empty, so skip the import (and its D1 query) for them.
+    const maybeSeed =
+      request.method === 'GET' && userId === OWNER_DO_ID
+        ? ensureSeeded(stub, env)
+        : Promise.resolve()
+
+    // Real-time sync: a WebSocket upgrade, forwarded to the caller's DO, which
+    // hibernation-accepts it and streams outline changes. The session is
+    // already validated above, so the socket only ever opens for an authed
+    // user. Seed first (owner only) so the DO's initial snapshot includes any
+    // imported legacy rows — the live client no longer GETs /api/nodes.
+    if (url.pathname === '/api/sync') {
+      if (request.headers.get('Upgrade') !== 'websocket') {
+        return json({ error: 'expected a websocket upgrade' }, 426)
+      }
+      await maybeSeed
+      return await stub.fetch(request)
+    }
+
+    if (url.pathname === '/api/nodes') {
+      await maybeSeed
+      return await handleNodes(request, stub)
+    }
+    if (url.pathname === '/api/kv') {
+      const collection = url.searchParams.get('collection')
+      if (!collection || !KV_COLLECTIONS.has(collection)) {
+        return json({ error: 'unknown collection' }, 400)
+      }
+      await maybeSeed
+      return await handleKv(request, stub, collection)
+    }
+  } catch (err) {
+    log.set({ error: { message: String(err) } })
+    return json({ error: String(err) }, 500)
+  }
+  return json({ error: 'not found' }, 404)
+}
+
 export default {
-  async fetch(request: Request, env: Env): Promise<Response> {
+  async fetch(
+    request: Request,
+    env: Env,
+    ctx: ExecutionContext,
+  ): Promise<Response> {
     const url = new URL(request.url)
 
     // The static shell + assets are PUBLIC so the login screen can load. Serve
-    // them without instantiating auth — only the data API is gated, below.
+    // them without instantiating auth (or a logger) — only the data API is
+    // gated and logged, below.
     if (!url.pathname.startsWith('/api/')) return env.ASSETS.fetch(request)
 
-    const auth = createAuth(env)
-
-    // Better Auth owns everything under /api/auth/* (sign-up/in/out, session).
-    if (url.pathname.startsWith('/api/auth/')) return auth.handler(request)
-
-    // Identity = the validated session's stable user id. No session -> 401.
-    const session = await auth.api.getSession({ headers: request.headers })
-    if (!session) return json({ error: 'unauthorized' }, 401)
-
-    const userId = resolveUserId(session.user.id, env)
-    const stub = env.USER_OUTLINE.get(env.USER_OUTLINE.idFromName(userId))
-
-    try {
-      // Only the owner's DO ('default') has legacy D1 rows to import; new users
-      // start empty, so skip the import (and its D1 query) for them.
-      const maybeSeed =
-        request.method === 'GET' && userId === OWNER_DO_ID
-          ? ensureSeeded(stub, env)
-          : Promise.resolve()
-
-      // Real-time sync: a WebSocket upgrade, forwarded to the caller's DO, which
-      // hibernation-accepts it and streams outline changes. The session is
-      // already validated above, so the socket only ever opens for an authed
-      // user. Seed first (owner only) so the DO's initial snapshot includes any
-      // imported legacy rows — the live client no longer GETs /api/nodes.
-      if (url.pathname === '/api/sync') {
-        if (request.headers.get('Upgrade') !== 'websocket') {
-          return json({ error: 'expected a websocket upgrade' }, 426)
-        }
-        await maybeSeed
-        return await stub.fetch(request)
-      }
-
-      if (url.pathname === '/api/nodes') {
-        await maybeSeed
-        return await handleNodes(request, stub)
-      }
-      if (url.pathname === '/api/kv') {
-        const collection = url.searchParams.get('collection')
-        if (!collection || !KV_COLLECTIONS.has(collection)) {
-          return json({ error: 'unknown collection' }, 400)
-        }
-        await maybeSeed
-        return await handleKv(request, stub, collection)
-      }
-    } catch (err) {
-      return json({ error: String(err) }, 500)
-    }
-    return json({ error: 'not found' }, 404)
+    // One wide event per API request: method / path / cf-ray are auto-extracted;
+    // routeApi adds user / DO / error context; we emit the final status here.
+    // `executionCtx` lets a future async drain finish via waitUntil.
+    const log = createWorkersLogger<ApiLogFields>(request, {
+      executionCtx: ctx,
+    })
+    const response = await routeApi(request, env, url, log)
+    log.emit({ status: response.status })
+    return response
   },
 } satisfies ExportedHandler<Env>


### PR DESCRIPTION
## What

Wire **evlog** for structured logging across the two surfaces that actually run server/client code, so server and (eventually) client failures produce readable, contextual events instead of scattered `console.log`.

- **Worker** (`evlog/workers`, `worker/index.ts`) — `initWorkersLogger` console drain; one structured **wide event per `/api` request** carrying `user.id`, the DO routing key (`outlineDO`), any caught error, and the final status. Method/path/cf-ray/duration are auto-extracted. Routing was extracted into `routeApi()`; static-asset requests short-circuit to `env.ASSETS` **before** a logger is built.
- **SPA client** (`evlog/client`, new `src/lib/log.ts`) — console-only `initLog`; auto-captures uncaught errors + unhandled promise rejections (the SPA bugs that vanish from a user's console). The Better Auth session `user.id` is stamped onto every log via `setIdentity` in `__root.tsx`.
- evlog is the **logging layer only** — control flow stays **errore** (errors as values). No `createError()`/throw.

## Why not the documented Nitro integration

evlog's headline TanStack Start setup (`nitro.config.ts` + `evlog/nitro` module + root-route `evlogErrorHandler` + `useRequest().context.log`) assumes a Nitro server in the request path. This app is **SPA mode (no SSR)** served as static assets, with every `/api/*` request handled by the **Cloudflare Worker** — so that wiring would be **inert dead code**. evlog's own docs say the integration is "not for SPA mode." Full rationale + the console-only upgrade path (ship client logs to `/api/logs` → `wrangler tail`) is in `docs/DECISIONS.md` → *Structured logging (evlog)*.

## Verification

- `bun run typecheck` ✓
- `bun run typecheck:worker` ✓
- `bun run lint` ✓
- `bun run build` (incl. prerender of `/`) ✓
- Runtime smoke test of both loggers — Worker emits a structured wide event; client emits in a browser-like env with identity stamped (it's `isBrowser()`-gated, so it no-ops at prerender).

🤖 Generated with [Claude Code](https://claude.com/claude-code)