### PR TITLE
fix(sync): post-merge follow-ups from PR #28 review

### DIFF
--- a/e2e/atomic-structural-writes.spec.ts
+++ b/e2e/atomic-structural-writes.spec.ts
@@ -175,12 +175,16 @@ test.describe("atomic structural writes", () => {
     // batch response, a second batch must not be in flight until the first lands.
     let inFlight = 0;
     let maxInFlight = 0;
+    let batchCount = 0;
     const isBatch = (req: { url(): string; method(): string; postDataJSON(): unknown }) =>
       req.url().includes("/api/nodes") &&
       req.method() === "POST" &&
       Boolean((req.postDataJSON() as { ops?: unknown } | null)?.ops);
     page.on("request", (req) => {
-      if (isBatch(req)) maxInFlight = Math.max(maxInFlight, ++inFlight);
+      if (isBatch(req)) {
+        batchCount += 1;
+        maxInFlight = Math.max(maxInFlight, ++inFlight);
+      }
     });
     page.on("requestfinished", (req) => {
       if (isBatch(req)) inFlight -= 1;
@@ -197,6 +201,9 @@ test.describe("atomic structural writes", () => {
 
     // Both batches settle; at no point were two batch POSTs in flight at once.
     await expect.poll(() => inFlight).toBe(0);
+    // Assert TWO batches were actually observed — `maxInFlight === 1` alone
+    // false-passes if the second edit silently dropped its batch.
+    expect(batchCount).toBe(2);
     expect(maxInFlight).toBe(1);
   });
 });

--- a/src/components/move-dialog.tsx
+++ b/src/components/move-dialog.tsx
@@ -15,7 +15,7 @@ import { moveNode } from "../data/mutations";
 import { runStructural } from "../data/structural";
 import { searchAliases, searchAnnotation } from "../plugins/registry";
 import { requestFlashAfterNav } from "./flash-node";
-import { capture } from "../data/history";
+import { capture, drop } from "../data/history";
 import { cn } from "@/lib/utils";
 import { setMoveDialogOpener } from "./move-dialog-opener";
 import {
@@ -180,7 +180,12 @@ function MoveDialogInner({
       const after = siblings.length ? siblings[siblings.length - 1]!.id : null;
       return moveNode(index, movedId, targetId, after);
     });
-    if (!moved) return;
+    // A no-op move (already at the exact destination) still captured an undo
+    // point; discard it so Cmd+Z doesn't look dead and redo history survives.
+    if (!moved) {
+      drop();
+      return;
+    }
     // Stay put -- moving shouldn't navigate you away. Confirm with a toast, and
     // offer a "Go" action to jump to the destination's zoom view on demand
     // (plain nav, no morph -- ADR 0003 -- since no pivot dot is involved).

--- a/src/data/collection.ts
+++ b/src/data/collection.ts
@@ -65,8 +65,8 @@ type SeqWaiter = { seq: number; resolve: () => void }
 const seqWaiters = new Set<SeqWaiter>()
 
 /** Advance the applied cursor and release any waiters it satisfies. Monotonic:
- *  a lower/equal seq (a redundant frame) is ignored. Called wherever a frame is
- *  applied (live change, resume, snapshot). */
+ *  a lower/equal seq (a redundant frame) is ignored. Called wherever a LIVE
+ *  frame is applied (live change, resume). Snapshots use `resetAppliedSeq`. */
 function advanceAppliedSeq(seq: number): void {
   if (seq <= appliedSeq) return
   appliedSeq = seq
@@ -76,6 +76,24 @@ function advanceAppliedSeq(seq: number): void {
       seqWaiters.delete(w)
       w.resolve()
     }
+  }
+}
+
+/** Reset the cursor to a snapshot's seq and release EVERY pending waiter.
+ *  A snapshot is full server truth, so it supersedes the stream regardless of
+ *  direction — and seqs are scoped per Durable Object/user, so a same-page
+ *  account switch (sign-out/sign-in is SPA-internal, no reload) can hand us a
+ *  LOWER seq than the previous user's. `advanceAppliedSeq` would ignore that
+ *  (it's monotonic) and leave the cursor stuck high, so `waitForSeq` would
+ *  resolve instantly and silently drop the P2 echo-hold for the new outline.
+ *  Setting (not advancing) and resolving all waiters makes any in-flight
+ *  structural tx trust the snapshot — the same fallback `waitForSeq`'s timeout
+ *  already takes. */
+function resetAppliedSeq(seq: number): void {
+  appliedSeq = seq
+  for (const w of seqWaiters) {
+    seqWaiters.delete(w)
+    w.resolve()
   }
 }
 
@@ -250,8 +268,9 @@ export const nodesCollection = createCollection({
             commit()
             // A fresh snapshot supersedes every earlier seq (and may be the
             // resolution a runStructural transaction is waiting on after a
-            // reconnect), so advance the cursor to it.
-            advanceAppliedSeq(msg.seq)
+            // reconnect or a same-page account switch), so reset the cursor to
+            // it — even if it's LOWER than what a prior outline left behind.
+            resetAppliedSeq(msg.seq)
             initialError = null
             ensureReady()
             // Self-heal any persisted sibling-chain corruption now that the full

--- a/src/plugins/daily/index.tsx
+++ b/src/plugins/daily/index.tsx
@@ -22,7 +22,7 @@ import { toast } from 'sonner'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { definePlugin, type PluginContext } from '../types'
-import { capture } from '../../data/history'
+import { capture, drop } from '../../data/history'
 import {
   appendChild,
   insertChildAtStart,
@@ -243,11 +243,15 @@ export default definePlugin({
           capture(ctx.tree, nodeId)
           return moveNode(ctx.tree, nodeId, todayId, after)
         })
-        if (moved) {
-          toast.success('Moved to Today', {
-            action: { label: 'Go', onClick: () => ctx.nav.zoom(todayId) },
-          })
+        // No-op move (already last child of today) still captured an undo
+        // point; drop it so Cmd+Z isn't a dead step and redo history survives.
+        if (!moved) {
+          drop()
+          return
         }
+        toast.success('Moved to Today', {
+          action: { label: 'Go', onClick: () => ctx.nav.zoom(todayId) },
+        })
       },
     },
   ],


### PR DESCRIPTION
Follow-up fixes for the 6 CodeRabbit comments on #28 (atomic structural writes). Triaged after merge: 3 real bugs + 1 test gap fixed here; the other 2 were a heavy/incomplete suggestion and a docs nit (see Skipped).

## Fixed

### 1. `appliedSeq` cursor isn't reset when a snapshot supersedes the stream (Major, `collection.ts`)
The seq cursor is module-global, but seqs are **per-DO/user** and sign-out/sign-in is **SPA-internal (no page reload)**. So on a same-page account switch:
- User A edits → `appliedSeq` climbs to ~50.
- User B signs in (no reload) → DO_B snapshot arrives at seq 10 → `advanceAppliedSeq(10)` is a no-op (monotonic).
- User B's next structural edit gets seq 11 → `waitForSeq(11)` resolves **instantly** → P2 echo-hold silently bypassed until B's seq climbs past 50.

That re-opens the sibling-chain corruption window this PR class exists to close (healed on next snapshot, but the flash/unmovable-node symptom recurs). Fix: a snapshot now **sets** the cursor (either direction) and releases all waiters — a snapshot is full truth, the same fallback `waitForSeq`'s timeout already takes.

### 2. No-op move leaves a dead undo step (Minor, `move-dialog.tsx` + daily "Send to Today")
`capture()` runs before `moveNode()`, which returns `false` for an already-exact destination. Without `drop()`, a no-op move adds an undo entry **and wipes redo history**. Now mirrors the editor's own no-op paths (`OutlineEditor.tsx` indent/outdent/move/delete all `drop()` on no-op).

### 3. Test could false-pass (Minor, `atomic-structural-writes.spec.ts`)
The wire-ordering test asserted `maxInFlight === 1`, which also passes if only one batch ever fired. Added `batchCount === 2` so a dropped second batch can't green the serialization guarantee.

## Skipped (with reason)
- **`api.ts` ambiguous-batch-failure (#4):** the suggested fix (block `batchTail` until sync confirms) is heavy **and incomplete** — the optimistic mutation is computed at `body()` time, before `persistBatch` runs, so blocking the queue only delays the network send, not the stale local read. Already backstopped by the WS echo re-applying the committed frame + `healSiblingChains` on snapshot. Documented as a known limitation rather than shipping a queue-wedging change without a repro.
- **`AGENTS.md:160` docs nit (#1):** cosmetic guidance wording; not a bug.

## Verification
- `bun run typecheck` / `typecheck:worker` / `lint` — green
- `bun run test:e2e atomic-structural-writes sibling-chain-repair` — 4 passed (incl. the hardened batch-count + the P2 echo-gap test that exercises the changed seq path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)