### PR TITLE
feat: add light/dark SVG favicons synced to theme

### DIFF
--- a/public/favicon-dark.svg
+++ b/public/favicon-dark.svg
@@ -1,0 +1,4 @@
+<svg width="340" height="340" viewBox="0 0 340 340" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="170" cy="170" r="170" fill="#2C2C2C"/>
+  <circle cx="170" cy="170" r="66" fill="#E5E5E5"/>
+</svg>

--- a/public/favicon-light.svg
+++ b/public/favicon-light.svg
@@ -1,0 +1,4 @@
+<svg width="340" height="340" viewBox="0 0 340 340" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="170" cy="170" r="170" fill="#E2E2E2"/>
+  <circle cx="170" cy="170" r="66" fill="#171717"/>
+</svg>

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -6,6 +6,7 @@ import {
   useMemo,
   useSyncExternalStore,
 } from "react";
+import { setFavicon } from "../lib/favicon";
 import {
   LEGACY_THEME_KEY,
   readStorageMigrated,
@@ -65,6 +66,7 @@ function applyTheme(theme: Theme) {
         : "light"
       : theme;
   root.classList.toggle("dark", resolved === "dark");
+  setFavicon(resolved);
 }
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {

--- a/src/lib/favicon.ts
+++ b/src/lib/favicon.ts
@@ -1,0 +1,15 @@
+export const FAVICON_LIGHT = "/favicon-light.svg";
+export const FAVICON_DARK = "/favicon-dark.svg";
+
+export function faviconHref(resolved: "light" | "dark") {
+  return resolved === "dark" ? FAVICON_DARK : FAVICON_LIGHT;
+}
+
+export function setFavicon(resolved: "light" | "dark") {
+  const link =
+    document.getElementById("dotflowy-favicon") ??
+    document.querySelector('link[rel="icon"]');
+  if (link instanceof HTMLLinkElement) {
+    link.href = faviconHref(resolved);
+  }
+}

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -14,6 +14,7 @@ import { PluginStyles } from '../components/plugin-styles'
 import { Toaster } from '../components/ui/sonner'
 import { AuthScreen } from '../components/auth-screen'
 import { useSession } from '../lib/auth-client'
+import { FAVICON_DARK, FAVICON_LIGHT } from '../lib/favicon'
 import { LEGACY_THEME_KEY, THEME_KEY } from '../lib/storage-keys'
 import '../styles.css'
 
@@ -36,6 +37,8 @@ const noFlashThemeScript = `
     var dark = t === 'dark' || (t === 'system' &&
       window.matchMedia('(prefers-color-scheme: dark)').matches);
     if (dark) document.documentElement.classList.add('dark');
+    var favicon = document.getElementById('dotflowy-favicon');
+    if (favicon) favicon.href = dark ? '${FAVICON_DARK}' : '${FAVICON_LIGHT}';
   } catch (e) {}
 })();
 `
@@ -88,6 +91,12 @@ function RootDocument({ children }: Readonly<{ children: ReactNode }>) {
   return (
     <html lang="en" className="[scrollbar-gutter:stable]">
       <head>
+        <link
+          rel="icon"
+          type="image/svg+xml"
+          href={FAVICON_LIGHT}
+          id="dotflowy-favicon"
+        />
         <script dangerouslySetInnerHTML={{ __html: noFlashThemeScript }} />
         <HeadContent />
       </head>


### PR DESCRIPTION
## Summary
- Adds `public/favicon-light.svg` and `public/favicon-dark.svg` (gray ring + contrasting center dot).
- Wires the favicon in `__root.tsx` and updates it from the no-flash theme script so the correct icon shows before first paint.
- Keeps the favicon in sync when toggling light/dark/system via `ThemeProvider`.

## Test plan
- [ ] Run `bun run dev` and confirm the tab icon appears.
- [ ] In light mode, verify the light favicon (gray outer, dark center).
- [ ] In dark mode, verify the dark favicon (dark outer, light center).
- [ ] Toggle theme with the header control and confirm the tab icon updates.
- [ ] Reload with each theme preference saved and confirm no flash of the wrong icon.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The app favicon now updates automatically to match the active light or dark theme.
  * Theme changes are kept in sync across the page appearance and browser tab icon, including system theme changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->