### PR TITLE
refactor(daily): route claimMapping errors inside the Effect pipeline

### DIFF
--- a/src/data/kv-client-effect.ts
+++ b/src/data/kv-client-effect.ts
@@ -2,11 +2,11 @@ import { Data, Duration, Effect, Schedule } from 'effect'
 
 /**
  * Effect v4 pilot — a typed-error, retrying, time-bounded variant of the kv
- * REST client. Lives alongside the throwing kv-api.ts; nothing imports it yet.
- * See `claimMapping` (daily-index.ts) for the intended call site: it's the one
- * boundary that already degrades to an errore-style value on failure, so it's
- * the natural place to prove Effect's typed-error + retry ergonomics against
- * real I/O without touching the throw-based TanStack DB mutation path.
+ * REST client. Lives alongside the throwing kv-api.ts. See `claimMapping`
+ * (daily-index.ts) for the intended call site: it's the one boundary that
+ * already degrades to an errore-style value on failure, so it's the natural
+ * place to prove Effect's typed-error + retry ergonomics against real I/O
+ * without touching the throw-based TanStack DB mutation path.
  *
  * Design notes (Effect v4, beta.90):
  *  - Domain errors are tagged classes via `Data.Error`. `Effect.catchTag`
@@ -18,6 +18,9 @@ import { Data, Duration, Effect, Schedule } from 'effect'
  *    backoff at a bounded attempt count.
  *  - Timeout: `Effect.timeoutOrElse({ duration, orElse })` turns a timeout into
  *    a `KvTimeoutError`, keeping the error channel typed.
+ *  - Recovery: `Effect.match({ onFailure, onSuccess })` is the v4 way to
+ *    convert all errors to a degraded value inside the pipeline, so
+ *    `runPromise` never rejects and the caller sees only plain success.
  */
 
 const ENDPOINT = '/api/kv'

--- a/src/plugins/daily/daily-index.ts
+++ b/src/plugins/daily/daily-index.ts
@@ -188,17 +188,24 @@ export async function claimMapping(
   key: string,
   candidate: string,
 ): Promise<{ winner: string; won: boolean }> {
+  /**
+   * Route every typed kv error to a single degraded outcome *inside* the Effect
+   * pipeline, then runPromise never rejects — caller sees only plain success.
+   * This is the whole point of the Effect boundary: error shape is known at the
+   * type level, and the recovery is expressed as a program transform, not a
+   * catch-block after the fact.
+   */
   const row = await Effect.runPromise(
-    kvGetOrCreateE<DailyRow>(KV, key, { key, nodeId: candidate }),
-  ).then(
-    (r) => r,
-    (e: KvTransportError | KvResponseError | KvTimeoutError | unknown) =>
-      e instanceof Error ? e : new Error(String(e)),
+    kvGetOrCreateE<DailyRow>(KV, key, { key, nodeId: candidate }).pipe(
+      Effect.match({
+        onFailure: (e) => {
+          console.warn(`daily: claim "${key}" failed, creating locally:`, e.message)
+          return { key, nodeId: candidate } satisfies DailyRow
+        },
+        onSuccess: (r) => r,
+      }),
+    ),
   )
-  if (row instanceof Error) {
-    console.warn(`daily: claim "${key}" failed, creating locally:`, row.message)
-    return { winner: candidate, won: true }
-  }
   return { winner: row.nodeId, won: row.nodeId === candidate }
 }
 


### PR DESCRIPTION
## What

Fixes `claimMapping` (the sole Effect call site) to actually use Effect's typed-error channel — previously it used `Effect.match`-less `.then(ok, err => ...)` which discarded the typed error structure back into throw-style handling.

### Changes
- `claimMapping` now uses `Effect.match({ onFailure, onSuccess })` — recovery is a program transform *inside* the Effect pipeline, so `runPromise` never rejects and the caller sees only plain success
- Fixes stale "nothing imports it yet" comment in `kv-client-effect.ts`
- Documents the v4 recovery pattern alongside retry + timeout

### Why This Matters
The project's own design doc says:
> _"claimMapping has no TanStack caller — it can speak Effect's typed-error channel directly and route with catchTag"_

This commit makes that line true.

### Verification
- `bun run typecheck` passes
- The intentional split is preserved: TanStack DB mutations still throw (for optimistic rollback), Effect stays clean

### Scope
Single function, one boundary — no behavioral change in success path. Error path still degrades identically (logs + falls back to the local node id as the winner).