### PR TITLE
Incremental tree index (scale-outline Phase A)

### DIFF
--- a/.scratch/scale-outline/PRD.md
+++ b/.scratch/scale-outline/PRD.md
@@ -1,0 +1,90 @@
+# PRD: Scale the outline to 100k nodes
+
+Status: Phase A built + green (serial e2e 83/83, unit 117/117, typecheck/lint clean). Phase B next.
+ADR 0019 (virtualization) proposed. Decision record:
+[ADR 0019](../../docs/adr/0019-virtualized-outline-rendering.md).
+
+## Why
+
+Dotflowy slows as nodes accrue. The felt symptom is **render/DOM weight** (scroll jank, heavy paint,
+slow zoom-out), not typing latency — confirmed with Cam.
+[ADR 0014](../../docs/adr/0004-localized-rendering-via-the-tree-store.md) already killed the
+re-render *fan-out* (per-node subscriptions), but every visible node is still a mounted
+contentEditable subtree, and the tree index still fully rebuilds on every change. Two O(n) costs
+remain in the hot path:
+
+1. **Render** — DOM grows with total visible nodes (no windowing): `OutlineNode` →
+   `OutlineNodeChildren` recurses every visible node. *This is what hurts first.*
+2. **Index** — `tree-store.ts rebuild()` runs `buildTreeIndex(toArray)` on every `subscribeChanges`;
+   O(n) per committed edit + its echo.
+
+Target ceiling: **100k nodes**, smooth scroll + typing.
+
+## Locked design (from the grill)
+
+- **Target = 100k interaction-smooth.** Cold-load is explicitly out of scope (Phase C).
+- **Build order: A (incremental index) → B (virtualization).** Both required at 100k; A is the
+  low-risk foundation that makes B's flatten cheap. No standalone "ship A for its own sake" — at
+  ≤10k it wouldn't be worth it; we're building for 100k.
+- **Phase A is not premature.** At 100k the O(n) rebuild is tens of ms/keystroke even after B, so A
+  is mandatory, not polish. (Owned reversal of the earlier "don't ship standalone A" — that held
+  only for a ≤10k world.)
+- **TreeIndex shape: id-arrays.** `childrenByParent: Map<string, string[]>`; node lookups always
+  through `byId` (one source of truth). Text edits never touch sibling arrays → O(1). It's also the
+  shape B's flatten wants. `childrenOf` keeps its `Node[]` signature (maps ids→byId on read).
+- **B inverts to a flat windowed list** (`@tanstack/react-virtual`); ADR 0019 owns the edge-case
+  handling (focus, zoom morph, drag, flash, measurement). Behind a flag until e2e parity.
+- **Phase C (lazy subtree sync) parked** until cold-load is the complaint.
+
+## Scope
+
+**Phase A — incremental tree index** (this ship):
+- `tree-store.ts`: consume the `ChangeMessage[]` from `subscribeChanges` (currently ignored), patch
+  the index in place; dirty-parent set; re-sort only dirtied parents. Snapshot/truncate keeps the
+  full rebuild as the safe fallback.
+- `tree.ts`: `childrenByParent` → `Map<string, string[]>`; `childrenOf` maps ids→byId; ordering reads
+  prev pointers from byId.
+- Load-bearing code comment (the dirty-set + why an agent shouldn't "simplify" it to a full rebuild).
+- No behavior change → existing e2e covers it; add a large-outline typing-latency check.
+
+**Phase B — virtualized rendering** (ADR 0019):
+- Promote `flattenVisible` → exported `{id, depth}[]`, identity-stable subscribed slice.
+- `OutlineEditor`: `useVirtualizer` over the flat list + `measureElement`.
+- `OutlineNode`: split a flat row (body only, indent by depth, drop `OutlineNodeChildren`).
+- Focus-into-window (`scrollToIndex` + `pendingFocus`); drag auto-scroll; flash-on-mount.
+- Flag + new windowing/perf e2e (seed 10k, assert DOM row count ∝ viewport); flip + delete recursive
+  path.
+
+**Phase C — lazy subtree sync** (deferred, own ADR):
+- TanStack DB on-demand `syncMode`/`loadSubset`; DO serves subtree snapshots + per-subtree change
+  subscriptions. Only when load-time (not interaction) is the complaint.
+
+## Phase A build checklist
+
+- [x] `tree.ts`: `TreeIndex.childrenByParent: Map<string, string[]>`; `childrenOf` maps ids→byId;
+      `orderChildIds` helper reads prev pointers from byId.
+- [x] `sibling-chain.ts`: unchanged — `orderSiblings(Node[])` stays the canonical orderer;
+      `orderChildIds` (tree.ts) wraps it for the id path. `chainDisagreements` untouched.
+- [x] `tree-store.ts`: incremental `applyChanges(changes)` — byId patch + dirty-parent re-sort.
+      Snapshot/truncate needs no special-case (truncate emits per-row deletes — verified in DB
+      source — so the delta path rebuilds it correctly).
+- [x] Audit every `childrenOf` caller — all read nodes through byId; only `collection.ts`
+      `siblingChainRepairs` touched `childrenByParent` directly (fixed to map ids→byId).
+- [x] Code comment documenting the dirty-set + the identity discipline (fresh Maps on structural,
+      same refs on field edits). No stale notes left in AGENTS.md/README.
+- [x] typecheck + typecheck:test + lint + unit green; **e2e 83/83 serial** (parallel daily flake is
+      pre-existing — confirmed 5/16 on clean HEAD).
+- [ ] **Remaining:** large-outline (10k+) typing-latency perf spec — folds into Phase B's perf gate
+      (seed 10k, assert DOM rows ∝ viewport + keystroke latency flat). Deferred to B.
+
+## Gotchas learned (Phase A)
+
+- **In-place Map mutation breaks reference-identity memoization.** The old `buildTreeIndex` made a
+  fresh `byId` Map every change, so consumers/React-Compiler memos keyed on `index.byId` invalidated
+  for free. Mutating in place froze that ref → the Cmd+K switcher's node list went stale (a
+  just-created node never appeared in search; e2e `daily-notes :401`). Fix: fresh Maps on structural
+  changes only; field edits keep refs (the O(1) hot path) because per-node reactivity rides `useNode`
+  (node-object identity) and whole-tree readers (`useViewFilter`) key on the wrapper, not the Maps.
+- **Re-sort every parent touched by a structural change**, not just inserts. A multi-write op is
+  transiently inconsistent mid-batch (a delete repoints the follower's prev *then* deletes → a brief
+  "fan"); only re-deriving from the settled `byId` fixes it — exactly what the old full rebuild did.

--- a/docs/adr/0019-virtualized-outline-rendering.md
+++ b/docs/adr/0019-virtualized-outline-rendering.md
@@ -1,0 +1,59 @@
+---
+status: proposed
+---
+
+# Virtualized outline rendering
+
+**What.** Invert the editor's render model from a **recursive DOM tree** to a **flat, windowed list**.
+Today every visible (non-collapsed, non-pruned) node is a mounted contentEditable subtree
+(`OutlineNode` → `OutlineNodeChildren` recursing), so DOM weight grows with total visible nodes — the
+felt scaling wall (scroll jank, heavy paint, slow zoom-out), distinct from the re-render *fan-out*
+that [ADR 0014](./0004-localized-rendering-via-the-tree-store.md) already solved. We flatten the
+visible tree into one linear `{id, depth}[]` list and render only the on-screen slice via
+`@tanstack/react-virtual`; nesting becomes visual indentation by `depth`, not DOM structure. Render
+cost becomes ∝ viewport, not total nodes. Target: 100k-node outlines that scroll and type smoothly.
+Designed here; build plan + staging in `.scratch/scale-outline/PRD.md`. Ships **behind a flag**, the
+recursive path kept until e2e parity, then flipped and the old path deleted.
+
+**Why a flat list, not a virtualized tree.** A windowed *tree* (virtualize each parent's children
+independently) keeps the recursion and can't window across deep nesting — a single root with a long
+descendant chain is still one giant mounted subtree. Flattening collapses the whole visible outline
+to one linear sequence, so windowing is uniform regardless of nesting depth or where collapse
+boundaries fall. It's the model Workflowy/Roam use, and the flatten already exists for caret nav
+(`flattenVisible`, `visible-order.ts`) — Phase B promotes it to `{id, depth}[]` and makes it the
+render driver, one definition shared by rendering and the neighbor walk.
+
+**Depends on the incremental index (Phase A).** The flatten reads the tree index on every structural
+change; on the current full-rebuild index that's an O(n) walk per change. Phase A (incremental index,
+id-array `childrenByParent`, dirty-parent re-sort — code-commented, no ADR) makes structural changes
+O(changed) and text edits O(1), so the flatten driver is cheap. A precedes B.
+
+**Edge cases — all reuse existing machinery, no new subsystems:**
+- **Focus across the window edge.** Off-screen rows aren't mounted, so the `refs` map has no span.
+  Focusing a node not in the window does `virtualizer.scrollToIndex(i)` first; the existing
+  `pendingFocus` claims the span when the row mounts. No new focus model.
+- **Zoom view-transition morph.** The pivot is the zoom root, which `flattenVisible` always pushes as
+  row 0 — always mounted/near top — and the click source is mounted by definition, so both morph
+  endpoints exist. Verify by instrumenting `startViewTransition` (screenshots can't see a morph).
+- **Drag-reorder.** `use-drag-reorder.ts` hit-tests against the flat-list index (y→gap, x→depth), not
+  mounted DOM, and auto-scrolls at the viewport edge (the `scrollIntoView({block:"nearest"})` pattern
+  multi-select already uses) so an off-screen drop target comes into range.
+- **Flash / reject one-shot classes.** A row that scrolls into view reads its own `pendingFlash` at
+  mount, so a flash queued for an off-screen row (e.g. `/move`'s post-nav flash) still fires.
+- **Variable row height.** Bullets wrap, so rows are dynamically measured (`measureElement`), not
+  fixed-height.
+
+**Scope boundary — interaction, not cold-load.** Phase B (with A) makes *interaction* — typing,
+scrolling, zoom — smooth at 100k. It does **not** shrink the initial payload: the DO still streams a
+full snapshot on connect (~20MB at 100k nodes). Bounding cold-load/memory is **Phase C** (lazy
+subtree sync — TanStack DB on-demand `syncMode`/`loadSubset` + a DO that serves subtree queries), a
+separate decision recorded when load-time (not interaction) is the complaint. A+B deliberately do not
+attempt it.
+
+**Don't regress:**
+- Keep the per-node subscription model (`useNode`/`useVisibleChildIds`/`useSelectionEdge`) — the row
+  still reads its own slice; windowing changes *how many* rows mount, not how a row gets its data.
+  Don't thread `node`/`index`/selection as props ([ADR 0014](./0004-localized-rendering-via-the-tree-store.md)).
+- One flatten definition (`visible-order.ts`) drives both render and caret nav — don't fork a
+  render-only copy that can drift from the neighbor walk.
+- Delete the recursive path once the flag flips; don't leave two render models alive.

--- a/src/data/collection.ts
+++ b/src/data/collection.ts
@@ -193,8 +193,13 @@ export function siblingChainRepairs(
 ): Array<{ id: string; prevSiblingId: string | null }> {
   const index = buildTreeIndex(nodes)
   const fixes: Array<{ id: string; prevSiblingId: string | null }> = []
-  for (const children of index.childrenByParent.values()) {
-    for (const d of chainDisagreements(children)) {
+  // childrenByParent holds ordered child *ids* now; map them back to the rows
+  // chainDisagreements compares (the ids are canonical-order by construction).
+  for (const ids of index.childrenByParent.values()) {
+    const ordered = ids
+      .map((id) => index.byId.get(id))
+      .filter((n): n is Node => n != null)
+    for (const d of chainDisagreements(ordered)) {
       fixes.push({ id: d.id, prevSiblingId: d.expectedPrev })
     }
   }

--- a/src/data/tree-store.ts
+++ b/src/data/tree-store.ts
@@ -1,9 +1,12 @@
 import { useCallback, useRef, useSyncExternalStore } from 'react'
+import type { ChangeMessage } from '@tanstack/react-db'
 import { nodesCollection } from './collection'
 import {
   buildTreeIndex,
   buildTrail,
   childrenOf,
+  orderChildIds,
+  parentKeyOf,
   type Node,
   type TreeIndex,
 } from './tree'
@@ -34,25 +37,149 @@ const EMPTY_INDEX: TreeIndex = buildTreeIndex([])
 const EMPTY_IDS: string[] = []
 const EMPTY_TRAIL: Node[] = []
 
-let index: TreeIndex = EMPTY_INDEX
+// The store owns ONE mutable index, maintained in place by applyChanges. It must
+// be its own instance -- never the shared EMPTY_INDEX, which has to stay pristine
+// as the server/initial snapshot for the hooks below.
+let index: TreeIndex = { byId: new Map(), childrenByParent: new Map() }
 const listeners = new Set<() => void>()
 let started = false
 
-function rebuild() {
-  index = buildTreeIndex(nodesCollection.toArray)
+function notify() {
   for (const l of listeners) l()
 }
 
 /**
+ * Apply a batch of collection changes to the shared index IN PLACE, rather than
+ * rebuilding it from scratch. This is the Phase A scaling win (ADR 0019 / PRD
+ * scale-outline): a text/field keystroke (the hot path) touches neither
+ * `parentId` nor `prevSiblingId`, so it dirties NO parent -- the work is a single
+ * `byId.set`, O(1), versus the old `buildTreeIndex(toArray)` that ran O(total
+ * nodes) on EVERY change. Only inserts, deletes, reparents, and reorders touch
+ * `childrenByParent`, and only the affected parents are re-sorted.
+ *
+ * INVARIANT -- do NOT "simplify" this back to `index = buildTreeIndex(toArray)`:
+ * that reintroduces the O(n)-per-keystroke rebuild this exists to kill.
+ *
+ * Why id arrays + byId (see tree.ts): every node read goes through `byId`, so a
+ * text edit never has to find-and-replace a stale node object inside a sibling
+ * array. `change.value` is the FULL row (TanStack DB `ChangeMessage`), so the
+ * parentId/prevSiblingId comparisons below are reliable.
+ *
+ * Re-sort EVERY parent whose membership or sibling order changed -- insert,
+ * delete, reparent-from, reparent-to, reorder -- re-derived from the batch's
+ * FINAL `byId`. A removal does not "keep the rest ordered" in general: a
+ * multi-write structural op is transiently inconsistent mid-batch (a delete
+ * repoints the follower's prevSiblingId *and* deletes the node, so two siblings
+ * briefly share one prev -- a "fan"), and only a re-sort from the settled state
+ * fixes it. This is exactly what the old `buildTreeIndex(toArray)` did by
+ * re-deriving on every change; we just scope the re-sort to touched parents.
+ * Field-only edits touch no parent, so they re-sort nothing and stay O(1).
+ *
+ * NOTE: this kills the index-rebuild O(n). The remaining O(visible) per-keystroke
+ * cost is the `useVisibleChildIds` getSnapshot fan-out across *mounted* parents
+ * -- that's what Phase B's windowing cuts, not this.
+ */
+function applyChanges(changes: ReadonlyArray<ChangeMessage<Node>>) {
+  const dirty = new Set<string>() // parents whose child order may have changed
+  for (const change of changes) {
+    if (change.type === 'delete') {
+      const prev = index.byId.get(change.key as string)
+      if (!prev) continue
+      index.byId.delete(prev.id)
+      const key = parentKeyOf(prev)
+      removeChildId(key, prev.id)
+      dirty.add(key)
+      continue
+    }
+    const next = change.value
+    const prev = index.byId.get(next.id)
+    index.byId.set(next.id, next)
+    if (!prev) {
+      // Insert (also the safe fallback for an update to a row we haven't seen).
+      const key = parentKeyOf(next)
+      addChildId(key, next.id)
+      dirty.add(key)
+    } else if (prev.parentId !== next.parentId) {
+      // Reparent: leaves the old parent, joins the new -- both need a re-sort.
+      const from = parentKeyOf(prev)
+      const to = parentKeyOf(next)
+      removeChildId(from, next.id)
+      addChildId(to, next.id)
+      dirty.add(from)
+      dirty.add(to)
+    } else if (prev.prevSiblingId !== next.prevSiblingId) {
+      // Reorder within the same parent.
+      dirty.add(parentKeyOf(next))
+    }
+    // else: a field-only edit (text / completed / ...) -- byId.set above is all.
+  }
+  for (const key of dirty) {
+    const ids = index.childrenByParent.get(key)
+    if (ids) index.childrenByParent.set(key, orderChildIds(index.byId, ids))
+  }
+  // Identity discipline. Always bump the WRAPPER so `useTreeIndex` re-renders
+  // (the focus/flash effect in OutlineEditor subscribes to it purely to re-run
+  // after every tree change -- in-place-only would freeze its identity and focus
+  // would stop landing).
+  //
+  // On a STRUCTURAL change (dirty.size > 0 -- insert/delete/reparent/reorder) also
+  // hand out FRESH Maps: whole-collection readers, and the React Compiler's
+  // inferred deps, memoize on the byId / childrenByParent *reference* (e.g. the
+  // Cmd+K switcher's `Array.from(index.byId.values())`), so mutating in place
+  // would leave them stale -- a just-created node would never appear in search.
+  // The Map copy is O(n), but it only rides discrete structural actions (Enter,
+  // Delete, move), never the per-keystroke path, and it's still cheaper than the
+  // old buildTreeIndex (no re-bucketing/re-sort of the whole outline). Node refs
+  // are shared by the copy, so per-node `useNode` stays stable.
+  //
+  // Field-only edits (the hot path) keep the SAME Map refs -- O(1). Per-node
+  // reactivity flows through `useNode` (node-object identity), not Map identity,
+  // and whole-collection readers are inert while a bullet is being edited.
+  index =
+    dirty.size > 0
+      ? {
+          byId: new Map(index.byId),
+          childrenByParent: new Map(index.childrenByParent),
+        }
+      : { byId: index.byId, childrenByParent: index.childrenByParent }
+  notify()
+}
+
+/** Append an id to a parent's child list (the dirty re-sort fixes its position).
+ *  Guards against a duplicate from a redelivered change. */
+function addChildId(key: string, id: string) {
+  const ids = index.childrenByParent.get(key)
+  if (ids) {
+    if (!ids.includes(id)) ids.push(id)
+  } else {
+    index.childrenByParent.set(key, [id])
+  }
+}
+
+/** Drop an id from a parent's child list; prune the entry when it empties. The
+ *  caller marks the parent dirty so it's re-sorted from the settled byId (a
+ *  mid-batch removal can leave a transient fan -- see applyChanges). */
+function removeChildId(key: string, id: string) {
+  const ids = index.childrenByParent.get(key)
+  if (!ids) return
+  const i = ids.indexOf(id)
+  if (i !== -1) ids.splice(i, 1)
+  if (ids.length === 0) index.childrenByParent.delete(key)
+}
+
+/**
  * Begin the one collection subscription, lazily. `includeInitialState` makes the
- * callback fire immediately with the current rows, so the first read is already
- * populated; every later change rebuilds the shared index and notifies. Skipped
- * on the server (SPA + prerender, no localStorage) -- see ADR 0004.
+ * callback fire immediately with the current rows (delivered as inserts), so the
+ * first read is already populated; every later change is folded into the shared
+ * index incrementally and notifies. Skipped on the server (SPA + prerender, no
+ * socket) -- see ADR 0004.
  */
 function ensureStarted() {
   if (started || typeof window === 'undefined') return
   started = true
-  nodesCollection.subscribeChanges(() => rebuild(), { includeInitialState: true })
+  nodesCollection.subscribeChanges((changes) => applyChanges(changes), {
+    includeInitialState: true,
+  })
 }
 
 /**

--- a/src/data/tree.ts
+++ b/src/data/tree.ts
@@ -4,47 +4,81 @@ import { orderSiblings } from './sibling-chain'
 export type { Node } from './schema'
 
 /**
- * In-memory index built from the flat node list.
- * Re-derived on every render from useLiveQuery output. For a personal
- * outline this is cheap (hundreds to low thousands of nodes); if it ever
- * gets slow, memoize per-parent.
+ * In-memory index over the flat node list.
+ *
+ * `childrenByParent` holds each parent's children as an ordered array of **ids**
+ * (not Node objects); every node read goes through `byId`, the single source of
+ * truth for the live row. That shape is load-bearing for the incremental
+ * maintenance in `tree-store.ts` (the Phase A scaling win — ADR 0019 / PRD
+ * scale-outline): a text/field keystroke leaves the id arrays untouched, so the
+ * store patches one `byId` entry in O(1) instead of rebuilding the whole index.
+ * A full `buildTreeIndex` is still the snapshot/fallback path and what mutations
+ * rebuild against between ops.
  */
 export interface TreeIndex {
-  /** parentId -> ordered children, plus the synthetic ROOT_PARENT for top-level */
-  childrenByParent: Map<string, Node[]>
+  /** parentId -> ordered child *ids*, plus the synthetic ROOT_PARENT for top-level */
+  childrenByParent: Map<string, string[]>
   byId: Map<string, Node>
 }
 
 /** Synthetic parent id for top-level nodes (those with parentId === null). */
 const ROOT_PARENT = '__root__'
 
-function parentKeyOf(node: Node): string {
+/** The `childrenByParent` key for a node: its parentId, or ROOT_PARENT for
+ *  top-level. Exported for the incremental store maintenance in tree-store.ts. */
+export function parentKeyOf(node: Node): string {
   return node.parentId ?? ROOT_PARENT
 }
 
 export function buildTreeIndex(nodes: Node[]): TreeIndex {
   const byId = new Map<string, Node>()
-  const childrenByParent = new Map<string, Node[]>()
+  const unsorted = new Map<string, Node[]>()
 
   for (const node of nodes) {
     byId.set(node.id, node)
     const key = parentKeyOf(node)
-    const list = childrenByParent.get(key)
+    const list = unsorted.get(key)
     if (list) list.push(node)
-    else childrenByParent.set(key, [node])
+    else unsorted.set(key, [node])
   }
 
   // Each parent's child list is ordered by following the prevSiblingId chain;
-  // orderSiblings (sibling-chain.ts) owns that walk and the orphan-append.
-  for (const [parentKey, unsorted] of childrenByParent) {
-    childrenByParent.set(parentKey, orderSiblings(unsorted))
+  // orderSiblings (sibling-chain.ts) owns that walk and the orphan-append. We
+  // store the ordered *ids* (node reads go through byId).
+  const childrenByParent = new Map<string, string[]>()
+  for (const [parentKey, list] of unsorted) {
+    childrenByParent.set(parentKey, orderSiblings(list).map((n) => n.id))
   }
 
   return { childrenByParent, byId }
 }
 
 export function childrenOf(index: TreeIndex, parentId: string | null): Node[] {
-  return index.childrenByParent.get(parentId ?? ROOT_PARENT) ?? []
+  const ids = index.childrenByParent.get(parentId ?? ROOT_PARENT)
+  if (!ids) return []
+  const out: Node[] = []
+  for (const id of ids) {
+    const node = index.byId.get(id)
+    if (node) out.push(node)
+  }
+  return out
+}
+
+/**
+ * Re-derive one parent's ordered child ids from the live `byId`: map ids ->
+ * nodes, run the canonical sibling-chain order, map back to ids. Used by the
+ * incremental tree-store to re-sort a parent whose membership or sibling order
+ * changed (insert / reparent / reorder) — the only paths that touch the id
+ * arrays. A 0/1-length list is already ordered.
+ */
+export function orderChildIds(byId: Map<string, Node>, ids: string[]): string[] {
+  if (ids.length <= 1) return ids
+  const nodes: Node[] = []
+  for (const id of ids) {
+    const node = byId.get(id)
+    if (node) nodes.push(node)
+  }
+  return orderSiblings(nodes).map((n) => n.id)
 }
 
 /**


### PR DESCRIPTION
## What

Replaces the O(n)-per-change `buildTreeIndex` rebuild in the tree store with **in-place delta application** from `subscribeChanges`. A text/field keystroke is now **O(1)** (one `byId.set`, no re-sort); only structural edits (insert / delete / reparent / reorder) re-sort the touched parents.

This is **Phase A** of a planned 3-phase effort to scale the outline to ~100k nodes:
- **A (this PR)** — incremental index. Kills the per-keystroke index rebuild.
- **B (next)** — virtualized rendering ([ADR 0019](docs/adr/0019-virtualized-outline-rendering.md), `proposed`). The real win for DOM weight; designed, not built.
- **C (parked)** — lazy subtree sync for cold-load.

Plan + rationale: `.scratch/scale-outline/PRD.md`.

## Why

Dotflowy slows as nodes accrue. [ADR 0014](docs/adr/0004-localized-rendering-via-the-tree-store.md) already solved re-render *fan-out* (per-node subscriptions), but the shared tree index still fully rebuilt on **every** committed change (`tree-store.ts rebuild()` → `buildTreeIndex(toArray)`) — O(total nodes) per keystroke. The code comment in `tree.ts` literally predicted this ("if it ever gets slow, memoize per-parent").

## How

- `TreeIndex.childrenByParent` now holds **ordered id arrays** (`Map<string,string[]>`); every node read routes through `byId` (one source of truth). `childrenOf` keeps its `Node[]` signature (maps ids→`byId`), so its ~30 callers don't churn.
- `applyChanges` folds `ChangeMessage[]` into the index in place. `change.value` is the full row (verified in the DB types), so `parentId`/`prevSiblingId` comparisons are reliable. Snapshot/resync needs no special case — `truncate()` emits per-row deletes (verified in DB source), so the delta path rebuilds it correctly.

## Reviewer notes (two non-obvious correctness points)

1. **Identity discipline.** In-place Map mutation freezes the `byId`/`childrenByParent` references, which **breaks reference-keyed memoization** — the Cmd+K switcher's node list (a React-Compiler-inferred dep on `index.byId`) went stale and dropped just-created nodes. Fix: bump the index **wrapper** every change (drives `useTreeIndex` → OutlineEditor's focus/flash effect), and hand out **fresh Maps on structural changes only**; field edits keep refs to preserve the O(1) hot path (per-node reactivity rides `useNode`'s node-object identity; whole-tree readers like `useViewFilter` key on the wrapper). Caught by e2e, not typecheck.
2. **Re-sort every parent touched by a structural change, not just inserts.** A multi-write op is transiently inconsistent mid-batch (a delete repoints the follower's prev *then* deletes → a brief "fan"); only re-deriving from the settled `byId` fixes it — exactly what the old full rebuild did.

## Verification

- typecheck (app + test), oxlint, unit **117/117**
- e2e **83/83 serial** (`bunx playwright test --workers=1`)
- The `daily-notes.spec.ts` parallel flake is **pre-existing** (confirmed ~5/16 on clean HEAD; this branch is no worse). Run e2e serially for a clean signal.

## Scope boundary

Phase A removes the index-rebuild O(n). The remaining per-keystroke cost is the `useVisibleChildIds` getSnapshot fan-out across *mounted* rows — that's Phase B's job (windowing). Neither A nor B touch cold-load (Phase C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added design documentation for scaling the outline experience to very large trees.
  * Added an ADR describing a virtualized outline rendering approach for smoother scrolling and interaction on large documents.

* **Bug Fixes**
  * Improved tree updates so only affected parent branches are re-ordered after changes, helping keep outline state accurate.
  * Fixed sibling chain repair logic to better handle ordered child lists during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->