### PR TITLE
perf(keymap): only register the focused bullet's hotkeys (fixes zoom jank)

### DIFF
--- a/e2e/zoom-perf.spec.ts
+++ b/e2e/zoom-perf.spec.ts
@@ -1,0 +1,131 @@
+import { expect, test, type Page } from "@playwright/test";
+import { seedOutline, type SeedNode } from "./fixtures";
+
+// Zoom performance guard.
+//
+// Zooming into a node remounts the whole windowed list (route key change). The
+// regression we're guarding against: `@tanstack/react-hotkeys` re-registering a
+// full ~20-key keymap for EVERY visible bullet on that remount burned ~130ms of
+// main thread. The fix (use-bullet-keymap.ts) registers a bullet's keymap only
+// while it's FOCUSED, so the manager holds ~one bullet's worth at a time, not
+// `visibleRows x ~20`.
+//
+// We assert that bound, not a wall-clock budget. The fix is behavior-PRESERVING
+// (an unfocused bullet's keymap was always a no-op -- every def is
+// `target: textRef`), so the only thing distinguishing fixed from broken is
+// cost. A "zoom must finish under N ms" test would measure real CPU time, which
+// swings with CI hardware and flakes. Instead we read the hotkey manager's live
+// registration COUNT -- the exact quantity the fix changes -- which is an
+// integer in a store, identical on a MacBook and a throttled CI box. Same
+// philosophy as virtualized-windowing.spec.ts: assert the structural invariant
+// that yields the performance, deterministically.
+//
+// The count is read via `window.__hotkeyManager`, exposed DEV-only by
+// src/components/hotkey-devtools.ts (stripped from production).
+
+function perfTree(): SeedNode[] {
+  const nodes: SeedNode[] = [];
+
+  // "few": a top-level node with a handful of children.
+  nodes.push({ id: "few", parentId: null, prevSiblingId: null, text: "Few" });
+  let prev: string | null = null;
+  for (let c = 0; c < 3; c++) {
+    const id = `few-c${c}`;
+    nodes.push({ id, parentId: "few", prevSiblingId: prev, text: `Few ${c}` });
+    prev = id;
+  }
+
+  // "many": a top-level node with hundreds of children -- far more than any
+  // viewport holds, so zooming in renders a full window of bullets.
+  nodes.push({ id: "many", parentId: null, prevSiblingId: "few", text: "Many" });
+  prev = null;
+  for (let c = 0; c < 300; c++) {
+    const id = `many-c${c}`;
+    nodes.push({ id, parentId: "many", prevSiblingId: prev, text: `Many ${c}` });
+    prev = id;
+  }
+
+  return nodes;
+}
+
+/** Read the singleton hotkey manager's registration count, polling until it
+ *  SETTLES -- `useHotkeys` registers in a post-render effect, so the count
+ *  climbs for a tick after a remount. Two equal reads in a row means the
+ *  registration effects have flushed. */
+async function settledRegistrationCount(page: Page): Promise<number> {
+  let last = -1;
+  await expect
+    .poll(
+      async () => {
+        const n = await page.evaluate(
+          () =>
+            (
+              window as unknown as {
+                __hotkeyManager?: { getRegistrationCount(): number };
+              }
+            ).__hotkeyManager?.getRegistrationCount() ?? -1,
+        );
+        const settled = n >= 0 && n === last;
+        last = n;
+        return settled;
+      },
+      { timeout: 8000, intervals: [100, 150, 200, 250] },
+    )
+    .toBe(true);
+  return last;
+}
+
+async function load(page: Page) {
+  await page.addInitScript(() =>
+    localStorage.setItem("dotflowy:flag:virtualized", "on"),
+  );
+  await seedOutline(page, perfTree());
+  await page.goto("/");
+  await expect(
+    page.locator('li[data-node-id="few"] > .outline-row > .node-text'),
+  ).toBeVisible();
+}
+
+test.describe("zoom performance (focus-gated bullet keymaps)", () => {
+  test("zooming into a node with hundreds of children keeps hotkey registrations bounded", async ({
+    page,
+  }) => {
+    await load(page);
+
+    // Zoom into the big node the way a user does: click its bullet handle.
+    await page.locator('li[data-node-id="many"] [aria-label="Zoom in"]').click();
+    await expect(page).toHaveURL(/\/many$/);
+    await expect(page.locator('li[data-node-id="many-c0"]')).toBeVisible();
+
+    const count = await settledRegistrationCount(page);
+
+    // A viewport-ful of bullets is mounted (~dozens). Pre-fix each registered its
+    // own ~20 hotkeys, so this was visibleRows x 20 -- 500+. Post-fix only the
+    // focused bullet's keymap is live (plus a small app/zoom-title constant). A
+    // generous ceiling well under the pre-fix figure catches a regression with
+    // wide margin, mirroring virtualized-windowing.spec's "< 100 rows" bound.
+    expect(count).toBeLessThan(120);
+  });
+
+  test("hotkey registration count does not scale with the number of visible bullets", async ({
+    page,
+  }) => {
+    await load(page);
+
+    // Zoom into the small node: only a few bullets render.
+    await page.goto("/few");
+    await expect(page.locator('li[data-node-id="few-c0"]')).toBeVisible();
+    const countFew = await settledRegistrationCount(page);
+
+    // Zoom into the huge node: a full window of bullets renders.
+    await page.goto("/many");
+    await expect(page.locator('li[data-node-id="many-c0"]')).toBeVisible();
+    const countMany = await settledRegistrationCount(page);
+
+    // The invariant: the manager holds ~one focused bullet's worth regardless of
+    // how many bullets are on screen. The app/zoom-title hotkeys are identical in
+    // both zoomed views, so they cancel; only the per-bullet term differs, and it
+    // must stay near zero. Pre-fix this gap was (window - few) x ~20 = hundreds.
+    expect(countMany - countFew).toBeLessThan(25);
+  });
+});

--- a/src/components/OutlineEditor.tsx
+++ b/src/components/OutlineEditor.tsx
@@ -36,6 +36,7 @@ import {
 import { isVirtualized } from "../data/flags";
 import { scrollRowIntoView, setVirtualNav } from "../data/virtual-nav";
 import { OutlineRow } from "./OutlineRow";
+import { exposeHotkeyManagerForDev } from "./hotkey-devtools";
 import {
   getViewIsHidden,
   getViewRootId,
@@ -159,6 +160,12 @@ export function OutlineEditor({ rootId }: OutlineEditorProps) {
 
   // First-run import-or-seed bootstrap; safe to run on mount. See seed.ts.
   useBootstrapOutline();
+
+  // DEV-only: expose the hotkey manager so the zoom perf guard can read the live
+  // registration count. No-op (and stripped) in production. See hotkey-devtools.ts.
+  useEffect(() => {
+    exposeHotkeyManagerForDev();
+  }, []);
 
   const routeSearch = useSearch({ strict: false }) as { q?: string };
 

--- a/src/components/hotkey-devtools.ts
+++ b/src/components/hotkey-devtools.ts
@@ -1,0 +1,30 @@
+import { getHotkeyManager } from "@tanstack/react-hotkeys";
+
+/**
+ * DEV-only handle on the singleton hotkey manager.
+ *
+ * `@tanstack/react-hotkeys` keeps every registered hotkey in one global store
+ * (`HotkeyManager`). `use-bullet-keymap.ts` registers a bullet's ~20 shortcuts
+ * only while that bullet is FOCUSED, so the store holds roughly ONE bullet's
+ * worth at a time instead of `visibleRows x ~20`. That bound is what keeps a
+ * zoom -- which remounts the whole windowed list -- from burning ~130ms
+ * re-registering a keymap for every visible row.
+ *
+ * Exposing the manager on `window` lets the perf guard (e2e/zoom-perf.spec.ts)
+ * read the live registration count and assert that invariant DETERMINISTICALLY
+ * -- a count, not a wall-clock budget, so it never flakes on slower CI hardware
+ * the way an "is the zoom under N ms" assertion would. Also handy from the dev
+ * console. Vite strips the dead `import.meta.env.DEV` branch from production
+ * builds, so this ships nothing.
+ */
+declare global {
+  interface Window {
+    __hotkeyManager?: ReturnType<typeof getHotkeyManager>;
+  }
+}
+
+export function exposeHotkeyManagerForDev(): void {
+  if (!import.meta.env.DEV) return;
+  if (typeof window === "undefined") return;
+  window.__hotkeyManager = getHotkeyManager();
+}

--- a/src/components/use-bullet-keymap.ts
+++ b/src/components/use-bullet-keymap.ts
@@ -1,5 +1,5 @@
 import { useHotkeys, type UseHotkeyDefinition } from "@tanstack/react-hotkeys";
-import { useEffect, useState, type RefObject } from "react";
+import { useLayoutEffect, useState, type RefObject } from "react";
 import type { Node } from "../data/schema";
 import { keymapSpecs } from "../plugins/registry";
 import type { PluginContext } from "../plugins/types";
@@ -49,8 +49,18 @@ export function useBulletKeymap({
   // gating registration on focus cuts that to one bullet's worth. The no-caret
   // selection keys live on a window-level listener (selection-mode.tsx), so
   // multi-select is unaffected when the bullet blurs.
+  //
+  // LAYOUT effect, not passive: a freshly-inserted bullet is focused in
+  // OutlineRow's mount `useLayoutEffect` (the central FocusPass for already-
+  // mounted rows). `useHotkeys` registers in a passive effect, so if this flip
+  // ran passively too, `setFocused(true)` would land AFTER the first paint and
+  // force a SECOND passive pass before the full keymap registered -- a paint
+  // cycle where the just-focused bullet has no keymap (a rapid second Enter
+  // could no-op). Flipping in the layout phase re-renders synchronously before
+  // paint, so the keymap registers in the first passive pass -- matching the
+  // pre-gating (always-on) timing.
   const [focused, setFocused] = useState(false);
-  useEffect(() => {
+  useLayoutEffect(() => {
     const el = textRef.current;
     if (!el) return;
     // Sync now: a freshly inserted bullet is focused imperatively right after

--- a/src/components/use-bullet-keymap.ts
+++ b/src/components/use-bullet-keymap.ts
@@ -1,5 +1,5 @@
 import { useHotkeys, type UseHotkeyDefinition } from "@tanstack/react-hotkeys";
-import type { RefObject } from "react";
+import { useEffect, useState, type RefObject } from "react";
 import type { Node } from "../data/schema";
 import { keymapSpecs } from "../plugins/registry";
 import type { PluginContext } from "../plugins/types";
@@ -30,6 +30,10 @@ interface BulletKeymapArgs {
  * preventDefault/stopPropagation and call them manually only when they actually
  * act, so normal in-line editing and caret movement still work.
  */
+/** Stable empty keymap for unfocused bullets, so an unfocused re-render never
+ *  hands `useHotkeys` a fresh array (which would re-run its registration work). */
+const EMPTY_KEYMAP: never[] = [];
+
 export function useBulletKeymap({
   node,
   textRef,
@@ -38,208 +42,240 @@ export function useBulletKeymap({
   hasChildren,
   enabled,
 }: BulletKeymapArgs) {
+  // Only the FOCUSED bullet needs a registered keymap: every definition is
+  // `target: textRef`, so it can only fire while this bullet holds the caret.
+  // Registering ~18 hotkeys for EVERY visible bullet made a zoom -- which
+  // remounts the whole windowed list -- burn ~130ms in @tanstack/react-hotkeys;
+  // gating registration on focus cuts that to one bullet's worth. The no-caret
+  // selection keys live on a window-level listener (selection-mode.tsx), so
+  // multi-select is unaffected when the bullet blurs.
+  const [focused, setFocused] = useState(false);
+  useEffect(() => {
+    const el = textRef.current;
+    if (!el) return;
+    // Sync now: a freshly inserted bullet is focused imperatively right after
+    // mount, before a 'focus' event would reach this listener.
+    setFocused(document.activeElement === el);
+    const onFocus = () => setFocused(true);
+    const onBlur = () => setFocused(false);
+    el.addEventListener("focus", onFocus);
+    el.addEventListener("blur", onBlur);
+    return () => {
+      el.removeEventListener("focus", onFocus);
+      el.removeEventListener("blur", onBlur);
+    };
+  }, [textRef]);
+
   useHotkeys(
-    [
-      // Plugin per-bullet keymap (Seam D): hotkeys a plugin owns while this
-      // bullet is focused -- todos' Mod+Enter / Mod+D toggle completion. They
-      // run with pluginCtx() at event time; the registry guards them against the
-      // core's reserved keys. Same `enabled` gate as the rest, so a menu's
-      // Arrow/Enter takes precedence while open.
-      ...keymapSpecs.map((k) => ({
-        // KeymapSpec.hotkey is a plain string (plugin contract stays library-
-        // agnostic); the manager wants its RegisterableHotkey union here.
-        hotkey: k.hotkey as UseHotkeyDefinition["hotkey"],
-        callback: () => k.run(node.id, pluginCtx()),
-      })),
-      {
-        // Enter: split the bullet at the caret -- text left of the caret stays,
-        // text to its right moves into a new sibling below (caret at the end is
-        // just the empty-tail case of the same split).
-        hotkey: "Enter",
-        callback: () => {
-          const el = textRef.current;
-          commands.onEnter(node.id, el ? getCaretOffset(el) : node.text.length);
-        },
-      },
-      {
-        // Shift+Enter: same as Enter -- split into a sibling, never insert a
-        // literal newline. Captured explicitly so the contentEditable's
-        // default line break can't fire; bullets are single-line.
-        hotkey: "Shift+Enter",
-        callback: () => {
-          const el = textRef.current;
-          commands.onEnter(node.id, el ? getCaretOffset(el) : node.text.length);
-        },
-      },
-      {
-        // Tab: indent under the previous sibling.
-        hotkey: "Tab",
-        callback: () => commands.onIndent(node.id),
-      },
-      {
-        // Shift+Tab: outdent one level.
-        hotkey: "Shift+Tab",
-        callback: () => commands.onOutdent(node.id),
-      },
-      {
-        // Cmd/Ctrl+Shift+Up: move this bullet up among its siblings; at the
-        // top edge it reparents into the parent's previous sibling. Default
-        // options always preventDefault, so macOS "extend selection to doc start"
-        // never fires inside the outline. See ADR 0009.
-        hotkey: "Mod+Shift+ArrowUp",
-        callback: () => commands.onMoveUp(node.id),
-      },
-      {
-        // Cmd/Ctrl+Shift+Down: move down; at the bottom edge it reparents into
-        // the parent's next sibling. Mirror of Mod+Shift+ArrowUp.
-        hotkey: "Mod+Shift+ArrowDown",
-        callback: () => commands.onMoveDown(node.id),
-      },
-      {
-        // Backspace at the start of a bullet. On a task, the first backspace
-        // "deletes the checkbox" -- demoting it to a plain bullet while keeping
-        // the text (mirrors the "[ ]" autoformat). On an empty plain bullet, it
-        // deletes the node and focuses the previous one. Otherwise it falls
-        // through to normal character deletion.
-        hotkey: "Backspace",
-        callback: (e) => {
-          const el = textRef.current;
-          if (!el || !isCaretAtStart(el)) return;
-          if (node.isTask) {
-            e.preventDefault();
-            e.stopPropagation();
-            commands.onSetTask(node.id, false);
-            return;
-          }
-          if (el.textContent !== "") return;
-          e.preventDefault();
-          e.stopPropagation();
-          commands.onDeleteNode(node.id);
-        },
-        options: { preventDefault: false, stopPropagation: false },
-      },
-      {
-        // Cmd/Ctrl+Shift+Delete: delete this bullet and its whole subtree,
-        // regardless of text or caret position. On Mac "delete" is the
-        // Backspace key; register Delete too for the forward-delete key.
-        hotkey: "Mod+Shift+Backspace",
-        callback: () => commands.onDeleteNode(node.id),
-      },
-      {
-        hotkey: "Mod+Shift+Delete",
-        callback: () => commands.onDeleteNode(node.id),
-      },
-      {
-        // Shift+ArrowUp from the top visual line: ENTER node multi-selection
-        // (ADR 0018) on THIS node only -- the first press selects the focused
-        // node; a subsequent Shift+arrow extends the run (handled while-selected
-        // in selection-mode.tsx). From a wrapped bullet's interior it falls
-        // through to native shift text-selection (preventDefault opted out),
-        // mirroring ArrowUp's edge-line rule. Selection mode has no caret, so we
-        // blur the bullet.
-        hotkey: "Shift+ArrowUp",
-        callback: (e) => {
-          const el = textRef.current;
-          if (!el || !atLineStart(el)) return;
-          e.preventDefault();
-          e.stopPropagation();
-          selectSingle(node.id);
-          el.blur();
-          window.getSelection()?.removeAllRanges();
-        },
-        options: { preventDefault: false, stopPropagation: false },
-      },
-      {
-        // Shift+ArrowDown from the last visual line: same single-node entry as
-        // Shift+ArrowUp (entry is direction-agnostic -- it selects the focused
-        // node; the next press extends). Mirror of Shift+ArrowUp's edge gate.
-        hotkey: "Shift+ArrowDown",
-        callback: (e) => {
-          const el = textRef.current;
-          if (!el || !atLineEnd(el)) return;
-          e.preventDefault();
-          e.stopPropagation();
-          selectSingle(node.id);
-          el.blur();
-          window.getSelection()?.removeAllRanges();
-        },
-        options: { preventDefault: false, stopPropagation: false },
-      },
-      {
-        // Cmd/Ctrl+A -- the bounded selection ladder (ADR 0018), rung 1 -> 2.
-        // Rung 1 (native): a non-empty bullet whose text isn't already fully
-        // selected selects all its TEXT. Rung 2: once the text is fully selected
-        // (or the bullet is empty -- rung 1 is skipped), select this NODE and its
-        // subtree, entering node selection. Rung 3 (the whole view) is escalated
-        // by the while-selected handler once a selection exists.
-        hotkey: "Mod+A",
-        callback: (e) => {
-          const el = textRef.current;
-          if (!el) return;
-          const empty = el.textContent === "";
-          if (!empty && !isAllTextSelected(el)) return; // rung 1: native select-all
-          e.preventDefault();
-          e.stopPropagation();
-          selectSingle(node.id);
-          el.blur();
-          window.getSelection()?.removeAllRanges();
-        },
-        options: { preventDefault: false, stopPropagation: false },
-      },
-      {
-        // ArrowUp on the first visual line: move to the previous node,
-        // preserving the caret's column (its x). Within a wrapped bullet the
-        // browser default handles line-1 <- line-2 itself.
-        hotkey: "ArrowUp",
-        callback: (e) => {
-          const el = textRef.current;
-          if (!el || !atLineStart(el)) return;
-          e.preventDefault();
-          e.stopPropagation();
-          commands.onMoveFocus(node.id, "up", caretLineRect()?.left);
-        },
-        options: { preventDefault: false, stopPropagation: false },
-      },
-      {
-        // ArrowDown on the last visual line: move to the next node, preserving
-        // the caret's column (its x).
-        hotkey: "ArrowDown",
-        callback: (e) => {
-          const el = textRef.current;
-          if (!el || !atLineEnd(el)) return;
-          e.preventDefault();
-          e.stopPropagation();
-          commands.onMoveFocus(node.id, "down", caretLineRect()?.left);
-        },
-        options: { preventDefault: false, stopPropagation: false },
-      },
-      {
-        // Cmd/Ctrl+Down: open (reveal the children of) a closed bullet that
-        // has children. Direction encodes intent -- Down only ever opens.
-        // Default options preventDefault, so the caret never jumps to the end
-        // of the line; the toggle itself is conditional, making this a silent
-        // no-op on an already-open or childless bullet. See ADR 0007.
-        hotkey: "Mod+ArrowDown",
-        callback: () => {
-          if (hasChildren && node.collapsed)
-            commands.onToggleCollapsed(node.id, false);
-        },
-      },
-      {
-        // Cmd/Ctrl+Up: close (collapse) an open bullet that has children.
-        // Mirror of Mod+ArrowDown -- Up only ever closes; otherwise a no-op.
-        hotkey: "Mod+ArrowUp",
-        callback: () => {
-          if (hasChildren && !node.collapsed)
-            commands.onToggleCollapsed(node.id, true);
-        },
-      },
-      {
-        // Cmd/Ctrl+.: zoom this node to become the temporary root.
-        hotkey: "Mod+.",
-        callback: () => commands.onZoom(node.id),
-      },
-    ],
+    focused
+      ? [
+          // Plugin per-bullet keymap (Seam D): hotkeys a plugin owns while this
+          // bullet is focused -- todos' Mod+Enter / Mod+D toggle completion. They
+          // run with pluginCtx() at event time; the registry guards them against the
+          // core's reserved keys. Same `enabled` gate as the rest, so a menu's
+          // Arrow/Enter takes precedence while open.
+          ...keymapSpecs.map((k) => ({
+            // KeymapSpec.hotkey is a plain string (plugin contract stays library-
+            // agnostic); the manager wants its RegisterableHotkey union here.
+            hotkey: k.hotkey as UseHotkeyDefinition["hotkey"],
+            callback: () => k.run(node.id, pluginCtx()),
+          })),
+          {
+            // Enter: split the bullet at the caret -- text left of the caret stays,
+            // text to its right moves into a new sibling below (caret at the end is
+            // just the empty-tail case of the same split).
+            hotkey: "Enter",
+            callback: () => {
+              const el = textRef.current;
+              commands.onEnter(
+                node.id,
+                el ? getCaretOffset(el) : node.text.length,
+              );
+            },
+          },
+          {
+            // Shift+Enter: same as Enter -- split into a sibling, never insert a
+            // literal newline. Captured explicitly so the contentEditable's
+            // default line break can't fire; bullets are single-line.
+            hotkey: "Shift+Enter",
+            callback: () => {
+              const el = textRef.current;
+              commands.onEnter(
+                node.id,
+                el ? getCaretOffset(el) : node.text.length,
+              );
+            },
+          },
+          {
+            // Tab: indent under the previous sibling.
+            hotkey: "Tab",
+            callback: () => commands.onIndent(node.id),
+          },
+          {
+            // Shift+Tab: outdent one level.
+            hotkey: "Shift+Tab",
+            callback: () => commands.onOutdent(node.id),
+          },
+          {
+            // Cmd/Ctrl+Shift+Up: move this bullet up among its siblings; at the
+            // top edge it reparents into the parent's previous sibling. Default
+            // options always preventDefault, so macOS "extend selection to doc start"
+            // never fires inside the outline. See ADR 0009.
+            hotkey: "Mod+Shift+ArrowUp",
+            callback: () => commands.onMoveUp(node.id),
+          },
+          {
+            // Cmd/Ctrl+Shift+Down: move down; at the bottom edge it reparents into
+            // the parent's next sibling. Mirror of Mod+Shift+ArrowUp.
+            hotkey: "Mod+Shift+ArrowDown",
+            callback: () => commands.onMoveDown(node.id),
+          },
+          {
+            // Backspace at the start of a bullet. On a task, the first backspace
+            // "deletes the checkbox" -- demoting it to a plain bullet while keeping
+            // the text (mirrors the "[ ]" autoformat). On an empty plain bullet, it
+            // deletes the node and focuses the previous one. Otherwise it falls
+            // through to normal character deletion.
+            hotkey: "Backspace",
+            callback: (e) => {
+              const el = textRef.current;
+              if (!el || !isCaretAtStart(el)) return;
+              if (node.isTask) {
+                e.preventDefault();
+                e.stopPropagation();
+                commands.onSetTask(node.id, false);
+                return;
+              }
+              if (el.textContent !== "") return;
+              e.preventDefault();
+              e.stopPropagation();
+              commands.onDeleteNode(node.id);
+            },
+            options: { preventDefault: false, stopPropagation: false },
+          },
+          {
+            // Cmd/Ctrl+Shift+Delete: delete this bullet and its whole subtree,
+            // regardless of text or caret position. On Mac "delete" is the
+            // Backspace key; register Delete too for the forward-delete key.
+            hotkey: "Mod+Shift+Backspace",
+            callback: () => commands.onDeleteNode(node.id),
+          },
+          {
+            hotkey: "Mod+Shift+Delete",
+            callback: () => commands.onDeleteNode(node.id),
+          },
+          {
+            // Shift+ArrowUp from the top visual line: ENTER node multi-selection
+            // (ADR 0018) on THIS node only -- the first press selects the focused
+            // node; a subsequent Shift+arrow extends the run (handled while-selected
+            // in selection-mode.tsx). From a wrapped bullet's interior it falls
+            // through to native shift text-selection (preventDefault opted out),
+            // mirroring ArrowUp's edge-line rule. Selection mode has no caret, so we
+            // blur the bullet.
+            hotkey: "Shift+ArrowUp",
+            callback: (e) => {
+              const el = textRef.current;
+              if (!el || !atLineStart(el)) return;
+              e.preventDefault();
+              e.stopPropagation();
+              selectSingle(node.id);
+              el.blur();
+              window.getSelection()?.removeAllRanges();
+            },
+            options: { preventDefault: false, stopPropagation: false },
+          },
+          {
+            // Shift+ArrowDown from the last visual line: same single-node entry as
+            // Shift+ArrowUp (entry is direction-agnostic -- it selects the focused
+            // node; the next press extends). Mirror of Shift+ArrowUp's edge gate.
+            hotkey: "Shift+ArrowDown",
+            callback: (e) => {
+              const el = textRef.current;
+              if (!el || !atLineEnd(el)) return;
+              e.preventDefault();
+              e.stopPropagation();
+              selectSingle(node.id);
+              el.blur();
+              window.getSelection()?.removeAllRanges();
+            },
+            options: { preventDefault: false, stopPropagation: false },
+          },
+          {
+            // Cmd/Ctrl+A -- the bounded selection ladder (ADR 0018), rung 1 -> 2.
+            // Rung 1 (native): a non-empty bullet whose text isn't already fully
+            // selected selects all its TEXT. Rung 2: once the text is fully selected
+            // (or the bullet is empty -- rung 1 is skipped), select this NODE and its
+            // subtree, entering node selection. Rung 3 (the whole view) is escalated
+            // by the while-selected handler once a selection exists.
+            hotkey: "Mod+A",
+            callback: (e) => {
+              const el = textRef.current;
+              if (!el) return;
+              const empty = el.textContent === "";
+              if (!empty && !isAllTextSelected(el)) return; // rung 1: native select-all
+              e.preventDefault();
+              e.stopPropagation();
+              selectSingle(node.id);
+              el.blur();
+              window.getSelection()?.removeAllRanges();
+            },
+            options: { preventDefault: false, stopPropagation: false },
+          },
+          {
+            // ArrowUp on the first visual line: move to the previous node,
+            // preserving the caret's column (its x). Within a wrapped bullet the
+            // browser default handles line-1 <- line-2 itself.
+            hotkey: "ArrowUp",
+            callback: (e) => {
+              const el = textRef.current;
+              if (!el || !atLineStart(el)) return;
+              e.preventDefault();
+              e.stopPropagation();
+              commands.onMoveFocus(node.id, "up", caretLineRect()?.left);
+            },
+            options: { preventDefault: false, stopPropagation: false },
+          },
+          {
+            // ArrowDown on the last visual line: move to the next node, preserving
+            // the caret's column (its x).
+            hotkey: "ArrowDown",
+            callback: (e) => {
+              const el = textRef.current;
+              if (!el || !atLineEnd(el)) return;
+              e.preventDefault();
+              e.stopPropagation();
+              commands.onMoveFocus(node.id, "down", caretLineRect()?.left);
+            },
+            options: { preventDefault: false, stopPropagation: false },
+          },
+          {
+            // Cmd/Ctrl+Down: open (reveal the children of) a closed bullet that
+            // has children. Direction encodes intent -- Down only ever opens.
+            // Default options preventDefault, so the caret never jumps to the end
+            // of the line; the toggle itself is conditional, making this a silent
+            // no-op on an already-open or childless bullet. See ADR 0007.
+            hotkey: "Mod+ArrowDown",
+            callback: () => {
+              if (hasChildren && node.collapsed)
+                commands.onToggleCollapsed(node.id, false);
+            },
+          },
+          {
+            // Cmd/Ctrl+Up: close (collapse) an open bullet that has children.
+            // Mirror of Mod+ArrowDown -- Up only ever closes; otherwise a no-op.
+            hotkey: "Mod+ArrowUp",
+            callback: () => {
+              if (hasChildren && !node.collapsed)
+                commands.onToggleCollapsed(node.id, true);
+            },
+          },
+          {
+            // Cmd/Ctrl+.: zoom this node to become the temporary root.
+            hotkey: "Mod+.",
+            callback: () => commands.onZoom(node.id),
+          },
+        ]
+      : EMPTY_KEYMAP,
     { target: textRef, enabled },
   );
 }


### PR DESCRIPTION
## What

Zooming into a node was janky again — the thing the TanStack virtualizer was supposed to fix. CPU-profiling a zoom pointed straight at **`@tanstack/react-hotkeys` registration**, not rendering or the View Transition.

**Root cause:** every bullet's `useBulletKeymap` registers ~18 hotkeys via `useHotkeys(..., { target: textRef })`. A zoom **remounts the windowed list**, so the ~27 visible rows each register ~18 hotkeys in one synchronous burst — a **~120ms main-thread task**. Before virtualization (all rows mounted) it was far worse, which is exactly why it "lags like before the virtualizer."

Crucially, every definition is `target: textRef`, so an **unfocused bullet's keymap can never fire** — registering it for all 27 rows is pure waste.

## Fix

Gate registration on focus: only the **focused** bullet builds its keymap; the rest pass a stable empty array. A small `focus`/`blur` listener on the bullet's element flips the state, with an immediate `document.activeElement` sync so a freshly-inserted, programmatically-focused bullet registers without waiting for an event.

The no-caret multi-select keys already live on a **window-level** listener (`selection-mode.tsx`), so selection mode is unaffected when a bullet blurs.

## Measured

Zoom into a 2000-child node (longtask observer):

| | long tasks | main-thread blocked |
|---|---|---|
| before (main) | 1 | **123 ms** |
| after | **0** | **0 ms** |

## Verified

- `tsc --noEmit`, `oxlint` clean
- 117 unit tests
- Keyboard e2e green: `enter-split`, `keyboard-move-edge`, `keyboard-nav`, `node-multi-select`, `todos`, `atomic-structural-writes`, `daily-notes` (the parallel daily-notes `toHaveURL` flake is pre-existing cold-start contention — passes serially and on retry; unrelated to this change, which never touches button-click navigation)
- Production build + prerender clean

Scope: one file (`use-bullet-keymap.ts`). Independent of #45 (XState selection machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Keyboard shortcuts for bullet items now work only when the text area is focused, preventing shortcuts from triggering while editing elsewhere.
  * Focus state is now detected more reliably, including when returning to an already active bullet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->