### PR TITLE
Feat/mirror of plumbing

### DIFF
--- a/.scratch/mirrors/PRD.md
+++ b/.scratch/mirrors/PRD.md
@@ -1,0 +1,83 @@
+# PRD: Node mirrors (synced instances)
+
+Status: **Designed, not scheduled.** Full grill complete; design locked in
+[ADR 0022](../../docs/adr/0022-node-mirrors.md) (`proposed`) and glossary in
+[`CONTEXT.md`](../../CONTEXT.md). Build is gated on a priority decision (this is the biggest editor
+change since virtualization — see *Cost* below). No code yet.
+
+## Why
+
+A task often belongs in two places at once — under its **project** *and* under **Today** — and today's
+"Send to Today" *moves* it, so it leaves the project. The user wants it to live in **both**, fully
+editable from either, so it's never lost when reviewing the day or the project. That's a true **mirror**
+(WorkFlowy mirror / Notion synced block): a node that *windows* another node's content + children, so
+editing any instance edits the one underlying node.
+
+## Locked design (from the grill)
+
+- **True mirror, inline-expandable (A1)** — not a click-to-open reference (A2), not a scheduled-date
+  agenda view (B). The synced-block experience, expandable and editable in place.
+- **Pointer model** — a new `mirrorOf: string | null` on the node; a non-mirror node is its own source
+  (`mirrorOf === null`). *Not* a shared `contentId` entity (too invasive). Children still hang off the
+  source's id.
+- **Resolution `contentId = mirrorOf ?? id`**, recurse over the content's children. Content ≠ position
+  only at a mirror's own boundary.
+- **Hybrid path addressing (keystone)** — data read by id (sync is free); the row *address* (key/`refs`/
+  `pendingFocus`/`pendingFlash`/selection/drag) becomes the render path, but switches to a compound key
+  **only once a mirror is crossed**. The mirror-free outline runs today's exact code.
+- **Field split** — content (`text`, `isTask`, `completed`, children) syncs from the source; local
+  (`parentId`/`prevSiblingId`, `collapsed`, `bookmarkedAt`) per instance. **Descendant collapse is shared
+  in v1** (accepted divergence from WorkFlowy).
+- **Delete = promote, cascade-aware** — deleting the source promotes a surviving instance; content dies
+  only when the last instance is gone. One atomic batch, undoable.
+- **Cycle guard, two layers** — block mirroring into your own subtree at create; truncate to a
+  non-expandable capped row at render.
+- **Creation reuses the Move destination picker** — `/mirror` "Mirror to…", selection-menu `runMany`,
+  daily "Mirror to Today" (keep "Move to Today" too).
+- **Visual (core chrome, both render paths)** — always-on icon + tint on instances, "mirrored ×N" badge on
+  source; hover/`:focus-within` colored border (source hue vs instance hue), pure CSS; badge → "appears in
+  N places" jump list.
+
+Full rationale + rejected alternatives: [ADR 0022](../../docs/adr/0022-node-mirrors.md).
+
+## Cost (why this is gated)
+
+[ADR 0004](../../docs/adr/0004-localized-rendering-via-the-tree-store.md) and
+[ADR 0019](../../docs/adr/0019-virtualized-outline-rendering.md) are built on **one node = one row**.
+Mirrors break that invariant. Stages 0/1/3 are tractable; **Stage 2 (path-based focus/caret/drag inside
+mirrors) is the most regression-prone code in the app** and where the weeks go. The staging below is
+deliberate: **Stage 1 alone delivers the motivating use case** (task visible + checkable in both places,
+text/completed synced, subtree expandable). Stage 2 is the "restructure subtasks from inside Today"
+gold-plate.
+
+## Scope (staged; ships behind a flag like `isVirtualized()`)
+
+**Stage 0 — plumbing, ships dark.** [`issues/01`](./issues/01-mirror-of-plumbing.md)
+- `mirrorOf` through `schema.ts` / `makeNode` / `worker/wire.ts` / DO `nodes` table; backfill `null` at
+  snapshot load (`collection.ts` heal pattern); reverse index (`sourceId → instance ids`) in `tree-store`.
+- No behavior change.
+
+**Stage 1 — render + create + chrome (≈ A2-grade value).** [`issues/02`](./issues/02-render-create-chrome.md)
+- Mirror-aware walk (contentId resolution, source windowing, path keys inside mirrors); cycle guard +
+  capped row; broken-mirror render.
+- "Mirror to…" / "Mirror to Today" creation; visual badges + hover borders + instance list.
+- Text + `completed` sync (free, data by id); subtree expandable/viewable in both places. **Delivers the
+  use case.**
+
+**Stage 2 — full editing parity inside mirrors (A1 gold-plate).** [`issues/03`](./issues/03-editing-parity.md)
+- Path-based focus/`pendingFocus`/flash/drag/multi-select inside mirrored subtrees; structural mutations
+  redirecting at the mirror boundary. Heavy e2e. The hard part.
+
+**Stage 3 — promote-on-delete.** [`issues/04`](./issues/04-promote-on-delete.md)
+- Source delete (direct + cascade-aware) promotes a surviving instance; undo/redo of promote.
+
+## Gotchas to watch (anticipated — confirm as built)
+
+- **Mirror top row subscribes to `useNode(contentId)`, not the position id** — else its text/completed
+  won't track the source.
+- **`structureRev` must invalidate views showing a mirror when the *source* subtree changes.** It bumps on
+  any structural edit (global), so this should fall out — verify with a mirror-of-edited-subtree e2e.
+- **Drag/reorder inside a mirror moves the *real* node** (reorders under the source too). Correct, but
+  surprising — cover it in e2e and document.
+- **`flatten mirror-of-mirror` at create** (point at the true source) — or promote/cycle detection walks
+  chains.

--- a/.scratch/mirrors/issues/01-mirror-of-plumbing.md
+++ b/.scratch/mirrors/issues/01-mirror-of-plumbing.md
@@ -1,0 +1,39 @@
+# 01 — `mirrorOf` plumbing (ships dark)
+
+Status: done (branch `feat/mirror-of-plumbing`, pending review/merge)
+
+Implemented 2026-06-30. All acceptance gates green: typecheck + typecheck:worker +
+typecheck:test + lint + unit (138 pass) clean; e2e matches `main` (the only failures
+are the pre-existing daily-notes `goHome` URL-race, identical on baseline). Reverse
+index built in `buildTreeIndex` (pure, unit-tested) and maintained incrementally in
+`tree-store.ts`. Existing-DO migration is a column-existence-guarded `ALTER` in the DO
+constructor; legacy D1 import maps to `mirrorOf: null`; client backfills null at
+snapshot load. Nothing reads `mirrorOf` yet (dark, as designed).
+
+Stage 0 of [PRD](../PRD.md) / [ADR 0022](../../../docs/adr/0022-node-mirrors.md). Adds the data field and
+the reverse index with **no behavior change** — pure foundation.
+
+## Scope
+
+- `src/data/schema.ts`: add `mirrorOf: Schema.NullOr(Schema.String)` to `nodeSchema` (required + nullable,
+  **no default** — [ADR 0003](../../../docs/adr/0003-no-schema-defaults.md)).
+- `src/data/tree.ts`: `makeNode` sets `mirrorOf: null`.
+- `worker/wire.ts`: add `mirrorOf` to the node body schema; confirm the Worker's derived `Node` type picks
+  it up (no hand-written drift — [ADR 0014](../../../docs/adr/0014-validate-the-worker-do-trust-boundary.md)).
+- DO `nodes` table (`worker/outline-do.ts`): add the `mirrorOf` column to the constructor schema; ALTER/
+  default-null for existing DOs so reads don't break.
+- `src/data/collection.ts`: backfill `mirrorOf: null` on snapshot load for rows missing it (the
+  `healSiblingChains` pattern).
+- `src/data/tree-store.ts`: maintain a reverse index `sourceId → instance ids` alongside `childrenByParent`,
+  updated incrementally on the same change path (used by Stage 1 count badge + Stage 3 promote).
+
+## Acceptance
+
+- [ ] `mirrorOf` round-trips client → Worker → DO → echo, defaulting `null`.
+- [ ] Existing outlines load unchanged (backfill works; no schema-typed-collection regression).
+- [ ] Reverse index correct under insert/delete/move (unit test on `tree-store`).
+- [ ] typecheck + typecheck:worker + typecheck:test + lint + unit green; existing e2e unchanged.
+
+## Notes
+
+Nothing renders or behaves differently after this issue — that's the point. Mergeable on its own.

--- a/.scratch/mirrors/issues/02-render-create-chrome.md
+++ b/.scratch/mirrors/issues/02-render-create-chrome.md
@@ -1,0 +1,49 @@
+# 02 — Render + create + chrome (delivers the use case)
+
+Status: ready-for-human
+
+Stage 1 of [PRD](../PRD.md) / [ADR 0022](../../../docs/adr/0022-node-mirrors.md). The meat of the feature
+that isn't the caret surgery. After this, a task mirrored into Today is **visible, expandable, text-synced,
+and checkable in both places** — the motivating use case. Behind a flag.
+
+## Scope
+
+**Render walk (`visible-order.ts` + `tree-store.ts`):**
+- Resolve `contentId = mirrorOf ?? id` per node; recurse over the **content's** children so a mirror windows
+  its source's subtree.
+- Hybrid path addressing: emit bare `nodeId` keys until a mirror is crossed, compound path keys inside a
+  mirrored subtree. One walk definition still shared with caret nav.
+- Mirror top row reads `useNode(contentId)` for text/`completed`/`isTask` (the field split).
+- Cycle guard: render-time truncation to a non-expandable **capped row** (chevron off, badge, click → source)
+  when a mirror's source is already an ancestor on the path. Broken-mirror render when `contentId` is missing.
+
+**Create (reuse the Move destination picker):**
+- `/mirror` "Mirror to…" command (Seam C); selection-menu `runMany` for multi-subtree mirror
+  ([ADR 0018](../../../docs/adr/0018-node-multi-selection.md)).
+- daily plugin: "Mirror to Today" (no picker, target = today's note) **alongside** the existing
+  "Move to Today".
+- Create-time cycle block (refuse mirroring into own subtree/self — shake + toast).
+- Flatten mirror-of-mirror to the true source on create.
+- Each create is one `runStructural` batch ([ADR 0009](../../../docs/adr/0009-atomic-structural-writes.md)).
+
+**Chrome (core, both row + zoomed-title paths):**
+- Always-on mirror icon + tint on instances; "mirrored ×N" badge on the source (from the reverse index).
+- Hover / `:focus-within` colored border, source hue vs instance hue — **pure CSS keyed off `data-mirror`**,
+  zero JS (tag-color ethos, [ADR 0007](../../../docs/adr/0007-custom-tag-colors.md)).
+- Badge → "appears in N places" jump list (reuse node-switcher/move-dialog list).
+- Cmd+K dedups instances to the source.
+
+## Acceptance
+
+- [ ] Mirror a project task into Today; both show the same text; editing text in one updates the other.
+- [ ] Toggle `completed` from either instance → both reflect it.
+- [ ] Expand the mirror → its source's children render under it (read/scroll fine; full *editing* parity is
+      Stage 3 — note any rough caret edges).
+- [ ] Cycle: mirror-into-own-subtree blocked at create; a cycle formed by a later move renders a capped row,
+      never hangs.
+- [ ] Badge count correct; jump list navigates to each instance; hover borders show source vs instance.
+- [ ] Flag off → outline byte-identical to today (no path keys, no perf change). e2e parity green.
+
+## Out of scope (later stages)
+
+Restructuring a mirror's subtree with correct focus/caret/drag (Stage 2); promote-on-delete (Stage 3).

--- a/.scratch/mirrors/issues/02-render-create-chrome.md
+++ b/.scratch/mirrors/issues/02-render-create-chrome.md
@@ -22,9 +22,23 @@ Sliced for safe landing (each slice its own verified commit):
   local collapse, broken leaf, flag-off parity. Full suite 94/94 serial. Caret/
   focus/drag inside a mirror are knowingly rough (refs/`data-node-id` collide on a
   windowed source descendant) — Stage 2 owns path-based parity.
-- **1c — creation.** `/mirror` "Mirror to…" (Seam C) + daily "Mirror to Today" +
-  selection `runMany`; create-time cycle block; flatten mirror-of-mirror; one
-  `runStructural` batch.
+- **1c — creation. DONE** (branch `feat/mirror-of-plumbing`). Two pure helpers in
+  `tree.ts` carry the tricky logic (unit-tested): `trueSourceOf` (flatten
+  mirror-of-mirror to one canonical source) and `wouldMirrorCycle` (refuse a
+  source that's the destination or its ancestor). `mutations.ts` builds
+  `mirrorNode` / `mirrorManyNodes` on them — append as the destination's last
+  child(ren), one `runStructural` batch (ADR 0009). The `/move` picker gained a
+  `"mirror"` mode (`move-dialog-opener.ts` + `move-dialog.tsx`): same UI, the
+  pick creates mirrors instead of moving, and the candidate list excludes the
+  SOURCE's subtree (cycle guard at the UI). Surfaces, all flag-gated:
+  core `/mirror` "Mirror to" slash command (`NodeCommands.onRequestMirror` →
+  `openMoveDialog(id, "mirror")`), a core **Mirror** action in the selection menu
+  (`SelectionOps.mirror`), and daily **"Mirror to Today"** (`run` + `runMany`, no
+  picker — target is today's note). e2e: picker create windows the source +
+  children; picker excludes the source's own subtree. 8 mirror specs serial; full
+  suite green. Daily "Mirror to Today" has no dedicated e2e (the flaky daily
+  infra; it's the well-tested "Send to Today" shape calling `mirrorNode`).
+  Chrome (badge, borders, jump list) is 1d.
 - **1d — chrome.** "mirrored xN" badge, hover/`:focus-within` borders (pure CSS on
   `data-mirror`), "appears in N places" jump list, Cmd+K dedup.
 

--- a/.scratch/mirrors/issues/02-render-create-chrome.md
+++ b/.scratch/mirrors/issues/02-render-create-chrome.md
@@ -1,6 +1,8 @@
 # 02 — Render + create + chrome (delivers the use case)
 
-Status: in-progress (branch `feat/mirror-of-plumbing`)
+Status: Stage 1 complete — 1a/1b/1c/1d all DONE (branch `feat/mirror-of-plumbing`).
+The motivating use case works behind the flag. Editing parity inside a mirror is
+Stage 2 (issue 03); promote-on-delete is Stage 3 (issue 04).
 
 Sliced for safe landing (each slice its own verified commit):
 
@@ -39,8 +41,33 @@ Sliced for safe landing (each slice its own verified commit):
   suite green. Daily "Mirror to Today" has no dedicated e2e (the flaky daily
   infra; it's the well-tested "Send to Today" shape calling `mirrorNode`).
   Chrome (badge, borders, jump list) is 1d.
-- **1d — chrome.** "mirrored xN" badge, hover/`:focus-within` borders (pure CSS on
-  `data-mirror`), "appears in N places" jump list, Cmd+K dedup.
+- **1d — chrome. DONE** (branch `feat/mirror-of-plumbing`). Four pieces, all
+  flag-gated, both render paths (list row + zoomed title):
+  - **"appears in N places" badge** (`mirror-chrome.tsx`'s `MirrorBadge`) driven
+    by a new per-node `useMirrorCount(id, enabled)` (`tree-store.ts`) off the
+    `mirrorsBySource` reverse index. Shows on the source AND every instance/capped
+    row (shared content id → same count); shows `count + 1` (total places). The
+    hook short-circuits to a no-op subscription when the flag is off, so a
+    mirror-free outline adds zero reactive work (the ADR 0014 budget). Rendered in
+    `OutlineRow`'s `RowChrome` and `OutlineEditor`'s `ZoomedTitle`.
+  - **Source/instance edge** via `data-mirror`: `RowChrome` now also sets
+    `data-mirror="source"` on a non-mirror row whose content has mirrors. Pure-CSS
+    colored left edge revealed on `:hover`/`:focus-within` (`styles.css`), source
+    hue vs instance hue (two new theme vars, the only chroma in a grayscale
+    theme); capped reuses the instance hue. Zero JS (tag-color ethos, ADR 0007).
+  - **"Appears in N places" jump list** (`mirror-places.tsx`, opener
+    `mirror-places-opener.ts`, mounted once in `__root.tsx`). A plain `Dialog`
+    listing the source + each instance with breadcrumbs; the source zooms to
+    itself, a mirror zooms to its parent and flashes the instance
+    (`requestFlashAfterNav`, reusing `/move`'s "Go" path — a mirror can't be a sane
+    zoom root). The badge opens it.
+  - **Cmd+K dedup**: `node-switcher.tsx`'s `buildFuse` skips `mirrorOf` instances
+    when the flag is on, so a mirrored node appears once (its source). Flag off, a
+    `mirrorOf` node is indexed as normal.
+  e2e: badge count + `data-mirror="source"` on both rows; badge opens the list and
+  "Source" zooms to A; flag-off parity (no badge, no attribute). 11 mirror specs
+  serial; full suite green (one pre-existing rich-links caret flake, passes in
+  isolation). Closes Stage 1 (issue 02).
 
 Stage 1 of [PRD](../PRD.md) / [ADR 0022](../../../docs/adr/0022-node-mirrors.md). The meat of the feature
 that isn't the caret surgery. After this, a task mirrored into Today is **visible, expandable, text-synced,
@@ -75,14 +102,15 @@ and checkable in both places** — the motivating use case. Behind a flag.
 
 ## Acceptance
 
-- [ ] Mirror a project task into Today; both show the same text; editing text in one updates the other.
-- [ ] Toggle `completed` from either instance → both reflect it.
-- [ ] Expand the mirror → its source's children render under it (read/scroll fine; full *editing* parity is
-      Stage 3 — note any rough caret edges).
-- [ ] Cycle: mirror-into-own-subtree blocked at create; a cycle formed by a later move renders a capped row,
-      never hangs.
-- [ ] Badge count correct; jump list navigates to each instance; hover borders show source vs instance.
-- [ ] Flag off → outline byte-identical to today (no path keys, no perf change). e2e parity green.
+- [x] Mirror a project task into Today; both show the same text; editing text in one updates the other. (1b/1c)
+- [x] Toggle `completed` from either instance → both reflect it. (1b)
+- [x] Expand the mirror → its source's children render under it (read/scroll fine; full *editing* parity is
+      Stage 2 — caret/focus/drag inside a mirror is knowingly rough). (1b)
+- [x] Cycle: mirror-into-own-subtree blocked at create; a cycle formed by a later move renders a capped row,
+      never hangs. (1a create-guard + render cap; 1c picker exclusion)
+- [x] Badge count correct; jump list navigates (source zooms to itself, a mirror zooms to its parent + flash);
+      hover borders show source vs instance. (1d)
+- [x] Flag off → outline byte-identical to today (no path keys, no perf change). e2e parity green. (every slice)
 
 ## Out of scope (later stages)
 

--- a/.scratch/mirrors/issues/02-render-create-chrome.md
+++ b/.scratch/mirrors/issues/02-render-create-chrome.md
@@ -1,6 +1,27 @@
 # 02 — Render + create + chrome (delivers the use case)
 
-Status: ready-for-human
+Status: in-progress (branch `feat/mirror-of-plumbing`)
+
+Sliced for safe landing (each slice its own verified commit):
+
+- **1a — render-walk keystone. DONE** (commit `e944285`). `buildVisibleRows`
+  resolves `contentId`, windows the source's children, emits path keys + isMirror/
+  capped/broken; behind `isMirrorsEnabled()` (default off) + a `mirrorsEnabled`
+  param. Pure, 11 unit tests, **not yet wired into the UI** — `useVisibleRows`
+  still calls it mirror-free, so the live app is byte-identical.
+- **1b — UI wiring + field split. NEXT (the regression-prone refactor).** Thread
+  the flag into `useVisibleRows`; split `OutlineRow` so content (text/isTask/
+  completed/children) reads + routes to `contentId` while collapse/position/zoom
+  stay on the instance (a thin `MirrorRow` wrapper over a shared body, so the
+  mirror-free row keeps its single `useNode` — no double-subscribe); zoom on a
+  mirror bullet navigates to the source; virtualizer keys by `row.key`; capped +
+  broken row components. Seeded-mirror e2e (text+completed sync, expand) + flag-off
+  parity. Caret/focus/drag rough edges acceptable here (Stage 2 owns parity).
+- **1c — creation.** `/mirror` "Mirror to…" (Seam C) + daily "Mirror to Today" +
+  selection `runMany`; create-time cycle block; flatten mirror-of-mirror; one
+  `runStructural` batch.
+- **1d — chrome.** "mirrored xN" badge, hover/`:focus-within` borders (pure CSS on
+  `data-mirror`), "appears in N places" jump list, Cmd+K dedup.
 
 Stage 1 of [PRD](../PRD.md) / [ADR 0022](../../../docs/adr/0022-node-mirrors.md). The meat of the feature
 that isn't the caret surgery. After this, a task mirrored into Today is **visible, expandable, text-synced,

--- a/.scratch/mirrors/issues/02-render-create-chrome.md
+++ b/.scratch/mirrors/issues/02-render-create-chrome.md
@@ -9,14 +9,19 @@ Sliced for safe landing (each slice its own verified commit):
   capped/broken; behind `isMirrorsEnabled()` (default off) + a `mirrorsEnabled`
   param. Pure, 11 unit tests, **not yet wired into the UI** — `useVisibleRows`
   still calls it mirror-free, so the live app is byte-identical.
-- **1b — UI wiring + field split. NEXT (the regression-prone refactor).** Thread
-  the flag into `useVisibleRows`; split `OutlineRow` so content (text/isTask/
-  completed/children) reads + routes to `contentId` while collapse/position/zoom
-  stay on the instance (a thin `MirrorRow` wrapper over a shared body, so the
-  mirror-free row keeps its single `useNode` — no double-subscribe); zoom on a
-  mirror bullet navigates to the source; virtualizer keys by `row.key`; capped +
-  broken row components. Seeded-mirror e2e (text+completed sync, expand) + flag-off
-  parity. Caret/focus/drag rough edges acceptable here (Stage 2 owns parity).
+- **1b — UI wiring + field split. DONE** (branch `feat/mirror-of-plumbing`).
+  `useVisibleRows` threads `isMirrorsEnabled()`; `OutlineRow` dispatches
+  `isMirror ? MirrorRow : NormalRow` — the normal path keeps its single `useNode`
+  (no double-subscribe), `MirrorRow` subscribes to instance + content and feeds a
+  shared `RowChrome`. Content (text/isTask/completed/children + edits routed to
+  `content.id`) reads from the source; position/collapse/drag/selection/focus stay
+  on the instance; a mirror bullet zooms to the source. Virtualizer keys by
+  `row.key`. `MirrorMissingRow` renders a broken source as a leaf; a capped mirror
+  is non-expandable (`data-mirror="capped"`). e2e `e2e/mirrors.spec.ts` (6):
+  source/children windowing, live text sync both ways, completed pass-through,
+  local collapse, broken leaf, flag-off parity. Full suite 94/94 serial. Caret/
+  focus/drag inside a mirror are knowingly rough (refs/`data-node-id` collide on a
+  windowed source descendant) — Stage 2 owns path-based parity.
 - **1c — creation.** `/mirror` "Mirror to…" (Seam C) + daily "Mirror to Today" +
   selection `runMany`; create-time cycle block; flatten mirror-of-mirror; one
   `runStructural` batch.

--- a/.scratch/mirrors/issues/03-editing-parity.md
+++ b/.scratch/mirrors/issues/03-editing-parity.md
@@ -1,10 +1,77 @@
 # 03 — Full editing parity inside mirrors (the hard part)
 
-Status: ready-for-human
+Status: in progress — 2a DONE; 2b–2e remain (branch `feat/mirror-of-plumbing`).
+Each slice is its own verified commit, mirroring Stage 1's 1a–1d discipline.
 
 Stage 2 of [PRD](../PRD.md) / [ADR 0022](../../../docs/adr/0022-node-mirrors.md). The A1 gold-plate and the
 **most regression-prone work in the app** — path-based identity for the caret-sensitive subsystems inside
 mirrored subtrees. Gate on heavy e2e. Behind the flag.
+
+## The keystone insight (read first)
+
+Stage 1 already shipped the address: every `VisibleRow` carries a `key` (`visible-order.ts`). It is the bare
+node id until the walk crosses a mirror, then a `PATH_SEP`-joined chain of instance ids. The defining property:
+
+> **`row.key === row.id` for every mirror-free row.**
+
+So Stage 2 is "switch the caret-sensitive subsystems to key off `row.key` instead of bare `id`." Because
+key===id off the flag (and on the flag, outside any crossed mirror), the swap is a **no-op for the 99%
+outline** — the new behavior engages *only* inside a windowed mirror, where one node id legitimately has two
+spans. That invariant is the regression budget: flag-off parity must stay byte-identical, and the e2e proves it.
+
+## Bare-id assumptions to convert (the inventory)
+
+All in `src/components/`. Each is correct today only because no id repeats; each must take/return a `row.key`:
+
+- **`refs: Map<string, span>`** keyed by `instance.id` — `registerRef(instance.id, el)` (`OutlineRow.tsx:371`),
+  title registers under `rootId` (`OutlineEditor`). Two rows sharing an id collide; the later registration wins.
+- **`pendingFocus` / `pendingFocusAtStart` / `pendingFlash`** (`useOutlineFocus`, `OutlineEditor.tsx:639-641`)
+  carry a bare id. Consumed by `FocusPass` via `refs.get(fid)` (`OutlineEditor.tsx:719,736`) and by
+  `OutlineRow`'s mount-claim `pendingFocus.current === instance.id` (`OutlineRow.tsx:253,260`).
+- **`findFocusedId`** (`OutlineEditor.tsx:653`) reverse-scans `refs` for the active span and returns its id —
+  must return the focused **key** (used by undo/redo to restore focus).
+- **`findVisibleNeighbor`** (`visible-order.ts:194`) builds `seq = rows.map(r => r.id)` and `indexOf(id)` —
+  `indexOf` finds the *first* occurrence, so caret nav inside a mirror lands on the wrong instance.
+- **Commands** set `pendingFocus.current = <newId>`. Off the flag the new id IS the key (correct unchanged).
+  Inside a mirror the new node appears under every instance; focus must land in the **editing** instance →
+  the command composes `activePathPrefix + newInstanceId`. The active prefix comes from `findFocusedId()`.
+
+## Slices
+
+- **2a — identity keystone (focus / refs / flash by `row.key`). DONE.** `refs`/`registerRef`/`pendingFocus`/
+  `pendingFlash`/`findFocusedId`/`FocusPass`/the `OutlineRow` mount-claim/`nav.indexOf` (the `rowIndex` map)
+  all key off `row.key` now; `OutlineRow` carries a `rowKey` prop. `history.restore` gates focus existence on
+  the key's last segment (`instanceIdForKey`) but returns the full key, so undo lands focus back in the same
+  instance (design Q1). Pure helpers `parseRowKey` / `instanceIdForKey` / `contentIdForKey` / `rowKeyFor` added
+  to `visible-order.ts`, unit-tested. **Plus a keystone fix:** `buildVisibleRows` now anchors the path at the
+  crossing mirror (was accumulating *all* root-side ancestors, contradicting its own comment and breaking
+  `childKey === rowKeyFor(parentKey, childId)`), so keys inside a mirror are `mirrorId[·childId]*` and compose
+  cleanly for 2b/2c — a unit test ties the helper to the address the walk emits. Commands still pass bare ids
+  (key===id off-flag / outside a mirror); composing the focus key from the active prefix inside a mirror is
+  2c. **Gate met:** 163 unit pass; full e2e green (only the pre-existing daily-notes nav flake, passes
+  isolated); every focus-sensitive spec (enter-split, move-flash, mirrors) green; flag-off parity unchanged.
+- **2b — caret nav across boundaries.** `findVisibleNeighbor` walks `row.key` addresses (accepts + returns
+  keys, `indexOf` on keys). Arrow Up/Down (`placeCaretAtColumn` neighbor walk, `OutlineEditor`) and
+  selection-mode's neighbor use keys. Mirror-free: keys===ids, unchanged.
+- **2c — structural redirect at the mirror edge.** Inserting a child *directly under* a mirror row
+  (`insertChildAtStart`, Enter-split's `insertSibling`, `indent`/`outdent` at the mirror's edge) targets the
+  **source** (`contentId`), so the new node appears in every instance. Inside the subtree (real nodes) it
+  already targets real nodes — confirm + test. New node's focus key = active prefix + new id (needs 2a). One
+  `runStructural` batch ([ADR 0009](../../../docs/adr/0009-atomic-structural-writes.md)).
+- **2d — drag-reorder by path.** `use-drag-reorder.ts` + `virtual-nav.ts`: hit-test / projection by `row.key`
+  (`virtualRowRect` keyed by key); dropping inside a mirror reorders the **real** source children (and thus
+  every instance). Document the surprise.
+- **2e — multi-select by path.** `selection-state` `rootIds` + `useSelectionEdge` keyed by `row.key`;
+  `runMany` resolves keys to the real nodes. A run inside a mirror operates on the source nodes.
+
+## Open design questions (decide before 2a code)
+
+- **Undo/redo focus under duplicate ids.** `undo()`/`redo()` return a node id to refocus; if that id has two
+  rendered keys, which gets focus? Proposed v1: preserve the focused key's **prefix** (restore into the same
+  instance the user was in); if the node no longer exists at that path, fall back to the first key matching the
+  bare id. Confirm before wiring `findFocusedId` → undo.
+- **Focus-key composition source.** The active path prefix is derived from `findFocusedId()` at command time.
+  Confirm that's available everywhere a command sets `pendingFocus` (history restore, daily loser-path).
 
 ## Scope
 
@@ -34,5 +101,7 @@ mirrored subtrees. Gate on heavy e2e. Behind the flag.
 
 ## Risk notes
 
-This is where caret bugs hide. Budget for it. Consider landing Stage 1 to dogfood (text + completed sync +
-view) and only starting this once the reference-grade behavior is proven in real use.
+This is where caret bugs hide. Budget for it. Stage 1 is landed and dogfooded (text + completed sync + view),
+so the reference-grade behavior is proven in real use — this slice only adds editing *inside* the window.
+The keystone (2a) is the regression risk; land it on its own commit behind the flag-off parity gate before
+touching nav / structural / drag / select.

--- a/.scratch/mirrors/issues/03-editing-parity.md
+++ b/.scratch/mirrors/issues/03-editing-parity.md
@@ -1,7 +1,7 @@
 # 03 — Full editing parity inside mirrors (the hard part)
 
-Status: in progress — 2a, 2b, 2c, 2d DONE; 2e remains (branch `feat/mirror-of-plumbing`).
-Each slice is its own verified commit, mirroring Stage 1's 1a–1d discipline.
+Status: in progress — 2a, 2b, 2c, 2d, 2e-1, 2e-2, 2e-3 DONE; cross-instance bleed (below) remains
+(branch `feat/mirror-of-plumbing`). Each slice is its own verified commit, mirroring Stage 1's 1a–1d discipline.
 
 Stage 2 of [PRD](../PRD.md) / [ADR 0022](../../../docs/adr/0022-node-mirrors.md). The A1 gold-plate and the
 **most regression-prone work in the app** — path-based identity for the caret-sensitive subsystems inside
@@ -108,8 +108,35 @@ All in `src/components/`. Each is correct today only because no id repeats; each
   both blocks; chain tripwire silent) — the FIRST drag e2e in the repo (drag was previously dogfood-only;
   precise gap aiming is impractical because the projection reads the virtualizer's estimate-vs-measured
   geometry, so the test drops past the last row and asserts the loose "a1 left the top, both blocks agree").
-- **2e — multi-select by path.** `selection-state` `rootIds` + `useSelectionEdge` keyed by `row.key`;
-  `runMany` resolves keys to the real nodes. A run inside a mirror operates on the source nodes.
+- **2e — multi-select by path.**
+  - **2e-1 — selection identity by instance. DONE.** Entering selection from a mirror's own row selects
+    the INSTANCE, not the source's content id (pre-fix, a select+delete on a mirror deleted the source and
+    orphaned every instance). `e2e/mirror-editing.spec.ts` "selecting a mirror selects the INSTANCE".
+  - **2e-2 — virtualized subtree tint. DONE.** The flat list has no DOM nesting for a selected root's tint
+    to paint behind its children (ADR 0019), so only the root ever got `data-selected` -- for ANY node, not
+    just mirrors. Fixed via a render-walk coverage map: `src/data/selection-fill.ts` walks the current
+    `buildVisibleRows` output on each selection/structure change (mirrored into a module singleton the same
+    way `view-state.ts` mirrors view state, via `useSyncSelectionFillRows` in `OutlineEditor`), marking the
+    ONE contiguous span `[firstRoot … lastVisibleDescendant(lastRoot)]` with the same top/bottom/middle/single
+    vocabulary `useSelectionEdge` already used (reused as `SelectionFill = SelectionEdge`, so the CSS needed
+    no changes). `useSelectionFill(rowKey)` replaces `useSelectionEdge` in `OutlineRow` ONLY -- the recursive
+    `OutlineNode` path keeps `useSelectionEdge` (its DOM nesting already paints descendants correctly, no
+    walk needed there). Per-row budget preserved (ADR 0014): a row only re-renders when ITS OWN key's fill
+    value changes. `e2e/node-multi-select.spec.ts` (CHAIN sibling-boundary test, now asserting descendant
+    tint) and `e2e/mirror-editing.spec.ts` (selecting a mirror tints its windowed children too) updated --
+    both PINNED the old missing-descendant-tint behavior and needed rewriting, not just extending.
+  - **2e-3 — block deleting a mirrored source. DONE.** `guardMirrorSourceDelete` (`protection.tsx`),
+    flag-gated. Covered in 2c's commit.
+  - **Cross-instance bleed -- still OPEN, not blocking.** Coverage in 2e-2 matches by row id against
+    `rootIds` (the same identity `edgeMapFor` always used), so a node rendered at TWO row keys at once (a
+    windowed mirror descendant whose source is ALSO visible elsewhere in the same view) covers both
+    occurrences when EITHER is selected directly. `e2e/mirror-editing.spec.ts`'s updated test proves the
+    common case is clean (selecting the mirror ROOT `M` does not bleed into source `A`'s canonical rows --
+    the walk only descends INTO the branch it's already in), but selecting a windowed DESCENDANT by itself
+    (not yet exercised in any spec) still bleeds. Fully killing it needs `rootIds`/`anchorId`/`focusId` to
+    carry a row key, not just a node id -- a `SelectionData` schema change touching the sibling-walk helpers
+    (`computeRange`/`computeExtend`), out of scope for this slice. Not blocking per Cam (hasn't hit it in
+    dogfooding); pick up as its own slice if it surfaces.
 
 ## Open design questions (decide before 2a code)
 
@@ -148,7 +175,11 @@ All in `src/components/`. Each is correct today only because no id repeats; each
 - [x] Drag a sub-item inside a mirror → reorders under the source (verified in another instance). *(2d:
       `mirror-editing.spec.ts` drags a windowed child and asserts both the source and mirror blocks reorder
       in lockstep.)*
-- [ ] Multi-select + move/indent inside a mirror behaves as on real nodes; no cross-instance focus bleed. *(2e)*
+- [x] Multi-select + move/indent inside a mirror behaves as on real nodes. *(2e-1/2e-3, + runMany's
+      live-collection rebuild between ops)*
+- [ ] No cross-instance focus bleed: selecting a windowed descendant doesn't visually tint its source's
+      canonical row elsewhere in the same view. *(2e-2 proved the mirror-ROOT case is clean; the
+      descendant case needs key-aware `SelectionData` -- see the bleed note above. Not blocking.)*
 - [x] The **same node visible at two paths simultaneously** (both homes on screen, e.g. top-level unzoomed):
       focusing one doesn't steal/echo into the other; both spans independent. *(2c: Enter-split focuses the
       windowed copy, asserts the source copy is NOT focused; content sync is by design, span identity is 2a.)*

--- a/.scratch/mirrors/issues/03-editing-parity.md
+++ b/.scratch/mirrors/issues/03-editing-parity.md
@@ -1,6 +1,6 @@
 # 03 — Full editing parity inside mirrors (the hard part)
 
-Status: in progress — 2a DONE; 2b–2e remain (branch `feat/mirror-of-plumbing`).
+Status: in progress — 2a, 2b DONE; 2c–2e remain (branch `feat/mirror-of-plumbing`).
 Each slice is its own verified commit, mirroring Stage 1's 1a–1d discipline.
 
 Stage 2 of [PRD](../PRD.md) / [ADR 0022](../../../docs/adr/0022-node-mirrors.md). The A1 gold-plate and the
@@ -50,9 +50,17 @@ All in `src/components/`. Each is correct today only because no id repeats; each
   (key===id off-flag / outside a mirror); composing the focus key from the active prefix inside a mirror is
   2c. **Gate met:** 163 unit pass; full e2e green (only the pre-existing daily-notes nav flake, passes
   isolated); every focus-sensitive spec (enter-split, move-flash, mirrors) green; flag-off parity unchanged.
-- **2b — caret nav across boundaries.** `findVisibleNeighbor` walks `row.key` addresses (accepts + returns
-  keys, `indexOf` on keys). Arrow Up/Down (`placeCaretAtColumn` neighbor walk, `OutlineEditor`) and
-  selection-mode's neighbor use keys. Mirror-free: keys===ids, unchanged.
+- **2b — caret nav across boundaries. DONE.** `findVisibleNeighbor` takes + returns row keys (`indexOf` on
+  keys) and gained a `mirrorsEnabled` param; every caller passes `isMirrorsEnabled()` so the neighbor sequence
+  is the rendered sequence (a mirror elsewhere in the view shifts the rows). `onMoveFocus` (Arrow Up/Down) now
+  starts the walk from `findFocusedId()` (the focused row's KEY) instead of the bare id the keymap passes —
+  load-bearing, because a mirror row's keymap hands over the *content* id, so only the focused span's key
+  addresses the right instance. `findFocusedId` is threaded from `useOutlineFocus` through `useNodeCommands`
+  (a stable callback, like `refs`). `onDeleteNode` (backspace focus-above) and selection-mode's 4 neighbor
+  walks pass the flag too. Mirror-free: keys===ids, unchanged. e2e (mirrors.spec.ts): ArrowDown from a mirror
+  enters its OWN windowed child (positioned below it), never the source's row; arrow nav walks between
+  windowed instances and back up to the mirror; bottom-of-view holds focus (no teleport). Full e2e green
+  (only the pre-existing daily-notes nav flake, passes isolated).
 - **2c — structural redirect at the mirror edge.** Inserting a child *directly under* a mirror row
   (`insertChildAtStart`, Enter-split's `insertSibling`, `indent`/`outdent` at the mirror's edge) targets the
   **source** (`contentId`), so the new node appears in every instance. Inside the subtree (real nodes) it

--- a/.scratch/mirrors/issues/03-editing-parity.md
+++ b/.scratch/mirrors/issues/03-editing-parity.md
@@ -1,6 +1,6 @@
 # 03 — Full editing parity inside mirrors (the hard part)
 
-Status: in progress — 2a, 2b, 2c DONE; 2d–2e remain (branch `feat/mirror-of-plumbing`).
+Status: in progress — 2a, 2b, 2c, 2d DONE; 2e remains (branch `feat/mirror-of-plumbing`).
 Each slice is its own verified commit, mirroring Stage 1's 1a–1d discipline.
 
 Stage 2 of [PRD](../PRD.md) / [ADR 0022](../../../docs/adr/0022-node-mirrors.md). The A1 gold-plate and the
@@ -88,9 +88,26 @@ All in `src/components/`. Each is correct today only because no id repeats; each
   typecheck:test / lint / 170 unit green; e2e mirrors + keyboard-nav + node-multi-select + the new
   `mirror-editing.spec.ts` green; full e2e green except the pre-existing daily-notes `goHome` nav flake (16/16
   isolated); flag-off parity unchanged.
-- **2d — drag-reorder by path.** `use-drag-reorder.ts` + `virtual-nav.ts`: hit-test / projection by `row.key`
-  (`virtualRowRect` keyed by key); dropping inside a mirror reorders the **real** source children (and thus
-  every instance). Document the surprise.
+- **2d — drag-reorder by path. DONE.** `buildRows` (`use-drag-reorder.ts`) now reuses `buildVisibleRows`
+  (the same flat render walk the editor + virtualizer use) instead of its own ad-hoc `childrenOf` walk, which
+  never resolved windowed source descendants — so inside a mirror their geometry was missing and the drop line
+  projected off only the non-mirror rows (dogfood finding 4, "way off"). Each drag `Row` now carries `key`
+  (geometry/hit-test address via `virtualRowRect(r.key)`), `id` (instance), `contentId`, and a **render-parent**
+  instance (`instanceIdForKey(parentKeyOf(key))`, not the tree parent, so the sibling/ancestor projection stays
+  inside the window). The grabbed subtree is the contiguous deeper-depth run after the grabbed row (the flat
+  list's subtree property, uniform across paths). The bullet arms the drag with `rowKey` (`OutlineRow`), so a
+  windowed copy is the exact instance grabbed. On drop, `onMove` (`OutlineEditor`) resolves `grabbedKey →
+  instanceId`, **field-splits the drop parent** (a drop under a mirror reparents to its SOURCE via `mirrorOf`,
+  so the moved node windows into every instance), runs `moveNode` on real nodes in one `runStructural`, and
+  lands focus + flash via `focusKeyFor(instanceId, grabbedKey)` (the dragged instance, not the source's far
+  copy). `moveNode` was audited for the in-place-sync gotcha — clean (it reads all sibling state BEFORE any
+  `update()`). Mirror-free path byte-identical (`key === id`, render parent === tree parent, field split a
+  no-op). **The surprise** (PRD gotcha): a drag inside one instance reorders the real source, so it moves in
+  every instance; dragging a windowed child OUT of the mirror moves the real node out everywhere (same as the
+  2c outdent-out). e2e in `mirror-editing.spec.ts` (drag a windowed child reorders the source, reflected in
+  both blocks; chain tripwire silent) — the FIRST drag e2e in the repo (drag was previously dogfood-only;
+  precise gap aiming is impractical because the projection reads the virtualizer's estimate-vs-measured
+  geometry, so the test drops past the last row and asserts the loose "a1 left the top, both blocks agree").
 - **2e — multi-select by path.** `selection-state` `rootIds` + `useSelectionEdge` keyed by `row.key`;
   `runMany` resolves keys to the real nodes. A run inside a mirror operates on the source nodes.
 
@@ -128,7 +145,9 @@ All in `src/components/`. Each is correct today only because no id repeats; each
       same edit appears in every instance. *(2c: Enter-split + indent/outdent + delete in `mirror-editing.spec.ts`;
       type via 1b; backspace-merge rides the same key-addressed `onDeleteNode` + `findVisibleNeighbor` path.)*
 - [x] Add a child directly under a mirror → it shows under the source and all other instances. *(2c)*
-- [ ] Drag a sub-item inside a mirror → reorders under the source (verified in another instance). *(2d)*
+- [x] Drag a sub-item inside a mirror → reorders under the source (verified in another instance). *(2d:
+      `mirror-editing.spec.ts` drags a windowed child and asserts both the source and mirror blocks reorder
+      in lockstep.)*
 - [ ] Multi-select + move/indent inside a mirror behaves as on real nodes; no cross-instance focus bleed. *(2e)*
 - [x] The **same node visible at two paths simultaneously** (both homes on screen, e.g. top-level unzoomed):
       focusing one doesn't steal/echo into the other; both spans independent. *(2c: Enter-split focuses the

--- a/.scratch/mirrors/issues/03-editing-parity.md
+++ b/.scratch/mirrors/issues/03-editing-parity.md
@@ -1,6 +1,6 @@
 # 03 — Full editing parity inside mirrors (the hard part)
 
-Status: in progress — 2a, 2b DONE; 2c–2e remain (branch `feat/mirror-of-plumbing`).
+Status: in progress — 2a, 2b, 2c DONE; 2d–2e remain (branch `feat/mirror-of-plumbing`).
 Each slice is its own verified commit, mirroring Stage 1's 1a–1d discipline.
 
 Stage 2 of [PRD](../PRD.md) / [ADR 0022](../../../docs/adr/0022-node-mirrors.md). The A1 gold-plate and the
@@ -61,11 +61,33 @@ All in `src/components/`. Each is correct today only because no id repeats; each
   enters its OWN windowed child (positioned below it), never the source's row; arrow nav walks between
   windowed instances and back up to the mirror; bottom-of-view holds focus (no teleport). Full e2e green
   (only the pre-existing daily-notes nav flake, passes isolated).
-- **2c — structural redirect at the mirror edge.** Inserting a child *directly under* a mirror row
-  (`insertChildAtStart`, Enter-split's `insertSibling`, `indent`/`outdent` at the mirror's edge) targets the
-  **source** (`contentId`), so the new node appears in every instance. Inside the subtree (real nodes) it
-  already targets real nodes — confirm + test. New node's focus key = active prefix + new id (needs 2a). One
-  `runStructural` batch ([ADR 0009](../../../docs/adr/0009-atomic-structural-writes.md)).
+- **2c — structural edits by the field split + path focus. DONE.** The keymap feeds a mirror row the
+  CONTENT id (slice 1b: `useBulletKeymap({ node: content })`), so 2c reframed around the ADR 0022 **field
+  split** rather than a blanket "redirect to source": each structural command now derives `instanceId` /
+  `contentId` from the focused row's **key** (`findFocusedId()` → `instanceIdForKey`; content = `mirrorOf ??
+  instance`, flag-gated). **Position ops target the INSTANCE** (`insertSibling`, `indent`, `outdent`,
+  `moveUp/Down`, `removeNode` — Tab/move/delete on a mirror's own row move/remove that mirror in its own
+  tree, never the source); **content + child inserts target the SOURCE** (Enter-at-end-of-open →
+  `insertChildAtStart(contentId)`, text split → `setText(contentId)`), so they window into every instance.
+  Inside the windowed subtree the rows are real nodes (instance === content), so those edits were already
+  correct — confirmed by e2e. **Enter on a mirror's OWN row never moves source text** (Option A, Cam's
+  "best/robust" call): a mid-text split would desync every instance or strand the tail on a local node, so it
+  degrades to the empty-tail case (add a node, source text whole). Delete targets the instance so backspacing
+  a mirror removes only that mirror (promote-on-source-delete is Stage 3). **Focus** is re-derived from the
+  live post-edit render walk (`focusKeyAfterEdit` over `buildVisibleRows`, built from a fresh
+  `nodesCollection.toArray` — settled after `runStructural`), never composed by hand, so it can't drift from
+  what's on screen and lands in the editing instance under the same mirror anchor; flag-off / mirror-free it
+  returns the bare id (zero rebuild). New helpers `parentKeyOf` / `focusKeyAfterEdit` in `visible-order.ts`
+  (unit-tested). Each edit stays ONE `runStructural` batch ([ADR 0009](../../../docs/adr/0009-atomic-structural-writes.md)).
+  **Plus a pre-existing core bug fix:** `indent` (`mutations.ts`) read the destination parent's last child
+  AFTER its `update()`; the tree-store maintains that index IN PLACE and notifies synchronously, so the read
+  already included the just-moved node and pointed its own `prevSiblingId` at itself (a self-referencing
+  chain). Latent because no e2e single-Tab-indented under the DEV invariant tripwire and a leaf destination
+  renders the self-ref identically. Fixed by reading the last child BEFORE the move; gated by an assertion in
+  `mirror-editing.spec.ts` that the structural-write tripwire stays silent. **Gate met:** typecheck /
+  typecheck:test / lint / 170 unit green; e2e mirrors + keyboard-nav + node-multi-select + the new
+  `mirror-editing.spec.ts` green; full e2e green except the pre-existing daily-notes `goHome` nav flake (16/16
+  isolated); flag-off parity unchanged.
 - **2d — drag-reorder by path.** `use-drag-reorder.ts` + `virtual-nav.ts`: hit-test / projection by `row.key`
   (`virtualRowRect` keyed by key); dropping inside a mirror reorders the **real** source children (and thus
   every instance). Document the surprise.
@@ -80,6 +102,10 @@ All in `src/components/`. Each is correct today only because no id repeats; each
   bare id. Confirm before wiring `findFocusedId` → undo.
 - **Focus-key composition source.** The active path prefix is derived from `findFocusedId()` at command time.
   Confirm that's available everywhere a command sets `pendingFocus` (history restore, daily loser-path).
+  **Resolved in 2c:** rather than *compose* `activePrefix + newId` by hand (fragile across reparent moves),
+  the focus key is *re-derived* from the live post-edit render walk (`focusKeyAfterEdit` over
+  `buildVisibleRows`), picking the matching instance under the same mirror anchor as the active key. Single
+  source of truth (the render walk), so it can't drift; flag-off / mirror-free it's the bare id.
 
 ## Scope
 
@@ -98,14 +124,16 @@ All in `src/components/`. Each is correct today only because no id repeats; each
 
 ## Acceptance
 
-- [ ] Type, Enter-split, indent/outdent, Backspace-merge inside a mirror — caret lands correctly, and the
-      same edit appears in every instance.
-- [ ] Add a child directly under a mirror → it shows under the source and all other instances.
-- [ ] Drag a sub-item inside a mirror → reorders under the source (verified in another instance).
-- [ ] Multi-select + move/indent inside a mirror behaves as on real nodes; no cross-instance focus bleed.
-- [ ] The **same node visible at two paths simultaneously** (both homes on screen, e.g. top-level unzoomed):
-      focusing one doesn't steal/echo into the other; both spans independent.
-- [ ] Flag off → unchanged. New e2e spec `mirror-editing.spec.ts` green serial.
+- [x] Type, Enter-split, indent/outdent, Backspace-merge inside a mirror — caret lands correctly, and the
+      same edit appears in every instance. *(2c: Enter-split + indent/outdent + delete in `mirror-editing.spec.ts`;
+      type via 1b; backspace-merge rides the same key-addressed `onDeleteNode` + `findVisibleNeighbor` path.)*
+- [x] Add a child directly under a mirror → it shows under the source and all other instances. *(2c)*
+- [ ] Drag a sub-item inside a mirror → reorders under the source (verified in another instance). *(2d)*
+- [ ] Multi-select + move/indent inside a mirror behaves as on real nodes; no cross-instance focus bleed. *(2e)*
+- [x] The **same node visible at two paths simultaneously** (both homes on screen, e.g. top-level unzoomed):
+      focusing one doesn't steal/echo into the other; both spans independent. *(2c: Enter-split focuses the
+      windowed copy, asserts the source copy is NOT focused; content sync is by design, span identity is 2a.)*
+- [x] Flag off → unchanged. New e2e spec `mirror-editing.spec.ts` green serial.
 
 ## Risk notes
 

--- a/.scratch/mirrors/issues/03-editing-parity.md
+++ b/.scratch/mirrors/issues/03-editing-parity.md
@@ -1,0 +1,38 @@
+# 03 — Full editing parity inside mirrors (the hard part)
+
+Status: ready-for-human
+
+Stage 2 of [PRD](../PRD.md) / [ADR 0022](../../../docs/adr/0022-node-mirrors.md). The A1 gold-plate and the
+**most regression-prone work in the app** — path-based identity for the caret-sensitive subsystems inside
+mirrored subtrees. Gate on heavy e2e. Behind the flag.
+
+## Scope
+
+- **Path-based focus/caret:** `refs`, `pendingFocus`, `pendingFocusAtStart`, `pendingFlash`, and the
+  `FocusPass` reverse-lookup must key off the **render path** for rows inside a mirror, not the bare node id
+  (a node visible at two paths has two spans). `findFocusedId` resolves path → content id.
+- **Caret nav** (`findVisibleNeighbor` / `buildVisibleRows` seq) operates on row addresses, so Arrow/Up-Down
+  cross instance boundaries correctly.
+- **Structural mutations redirect at the mirror boundary:** inserting a child *directly under a mirror* (or
+  Enter-splitting / indent-outdent at the mirror's edge) must target the **source**, so the new node appears
+  in every instance. Inside the subtree (real nodes) it already targets the real node — confirm.
+- **Drag-reorder** (`use-drag-reorder.ts` / `virtual-nav.ts`): hit-test + projection by render path; dropping
+  inside a mirror reorders the **real** nodes (and thus every instance). Document the surprise.
+- **Multi-select** (`selection-state` / `selection-mode.tsx`): selection edges + `runMany` keyed by path; a
+  run inside a mirror operates on the real nodes.
+
+## Acceptance
+
+- [ ] Type, Enter-split, indent/outdent, Backspace-merge inside a mirror — caret lands correctly, and the
+      same edit appears in every instance.
+- [ ] Add a child directly under a mirror → it shows under the source and all other instances.
+- [ ] Drag a sub-item inside a mirror → reorders under the source (verified in another instance).
+- [ ] Multi-select + move/indent inside a mirror behaves as on real nodes; no cross-instance focus bleed.
+- [ ] The **same node visible at two paths simultaneously** (both homes on screen, e.g. top-level unzoomed):
+      focusing one doesn't steal/echo into the other; both spans independent.
+- [ ] Flag off → unchanged. New e2e spec `mirror-editing.spec.ts` green serial.
+
+## Risk notes
+
+This is where caret bugs hide. Budget for it. Consider landing Stage 1 to dogfood (text + completed sync +
+view) and only starting this once the reference-grade behavior is proven in real use.

--- a/.scratch/mirrors/issues/04-promote-on-delete.md
+++ b/.scratch/mirrors/issues/04-promote-on-delete.md
@@ -1,0 +1,38 @@
+# 04 — Promote on delete (source/instance distinction goes invisible)
+
+Status: ready-for-human
+
+Stage 3 of [PRD](../PRD.md) / [ADR 0022](../../../docs/adr/0022-node-mirrors.md). Makes "delete the source"
+safe: content survives in a remaining instance instead of orphaning. Behind the flag.
+
+## Scope
+
+- **Delete a mirror** = remove the one instance node (its "children" are the source's — untouched). Trivial;
+  confirm it's already correct from Stage 1's create path.
+- **Delete the source with surviving instances = promote** (one `runStructural` batch,
+  [ADR 0009](../../../docs/adr/0009-atomic-structural-writes.md)):
+  1. pick the oldest surviving instance `M'`;
+  2. clear `M'.mirrorOf`;
+  3. reparent the real children under `M'` (set `parentId`, fix the sibling chain);
+  4. repoint every other mirror's `mirrorOf` at `M'`;
+  5. delete the old source.
+- **Cascade-aware:** when a node is removed as part of an ancestor-subtree delete, promote to a surviving
+  instance that is **outside** the deleted subtree. Content dies only when the **last** instance is gone.
+  Drive the lookup off the reverse index (Stage 0).
+- **Undo/redo:** promote replays as one atomic snapshot diff (insert/update/delete mix), same as any
+  structural batch.
+
+## Acceptance
+
+- [ ] Delete a source that has a Today mirror → content promotes into Today; project row gone; children
+      intact under the new source; other mirrors repointed.
+- [ ] Delete a whole **project** containing a source whose mirror lives in Today (outside the project) →
+      content promotes into Today, not lost.
+- [ ] Delete the **last** instance → content actually gone (no zombie rows, reverse index cleaned).
+- [ ] Undo a promote restores the prior source + all mirror pointers exactly.
+- [ ] New e2e `mirror-promote.spec.ts` green serial; flag off → unchanged.
+
+## Notes
+
+Rare path in practice (you check tasks off; you delete the Today *mirror* when rescheduling — the trivial
+case). But getting it wrong loses data, so the cascade-aware promote is the load-bearing test.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,25 @@
+# dotflowy
+
+The ubiquitous language for dotflowy's outline domain. A glossary, not a spec — definitions only, no implementation. Decisions and their trade-offs live in [`docs/adr/`](./docs/adr/).
+
+## Language
+
+**Node**:
+A single bullet in the outline. Owns its text and, via child pointers, its subtree.
+_Avoid_: item, bullet (when precision matters), block
+
+**Mirror**:
+A node that, instead of owning its own text and children, windows another node's. Editing a mirror edits the underlying content, so every place it appears updates. Has its own location and view state, but not its own content.
+_Avoid_: copy, clone, alias, synced block, transclusion
+
+**Source**:
+The node a mirror points at — the one that actually owns the text and children. Every mirror has exactly one source; a node with no `mirrorOf` is its own source.
+_Avoid_: original, master, target
+
+**Instance**:
+Any one rendering of a node's content at a location. The source is an instance; each mirror is an instance. Instances are equal for editing — there is no read-only one.
+_Avoid_: occurrence, appearance
+
+**Render path**:
+The chain of node ids from the current view root down to a rendered row. A row's identity (its key, its focus/caret/drag address) — distinct from the node id, because the same node can render at more than one path once mirrors exist.
+_Avoid_: trail (that's the ancestor breadcrumb, a different walk)

--- a/docs/adr/0022-node-mirrors.md
+++ b/docs/adr/0022-node-mirrors.md
@@ -1,0 +1,141 @@
+---
+status: proposed
+---
+
+# Node mirrors (synced instances)
+
+**What.** A **mirror** is a node that, instead of owning its own text and children, *windows* another
+node's — the **source**. Every place a node appears is an **instance**; editing any instance edits the
+underlying content, so all instances update (WorkFlowy mirrors / Notion synced blocks). The motivating
+case: a task that lives under its **project** *and* under **Today**, fully editable in both, so it's
+never lost when reviewing either. Designed via `/grill-with-docs`; build plan + staging belong in
+`.scratch/mirrors/PRD.md`. Will ship **behind a flag**, like [ADR 0019](./0019-virtualized-outline-rendering.md).
+
+**The constraint this fights.** dotflowy identifies every rendered row by a single `nodeId` — not just
+`VisibleRow.id`, but the `refs` map (id→span), `pendingFocus`/`pendingFlash`, caret nav, React keys, and
+the per-node subscriptions ([ADR 0004](./0004-localized-rendering-via-the-tree-store.md)). The whole
+model assumes **one node = one row**. A mirror breaks that by definition. So the real cost of mirrors is
+**not** the `mirrorOf` column — it's that **row identity must become a render *path*, not a node id**.
+
+## Decisions
+
+**Inline-expandable, not a reference (chose A1 over A2).** A mirror renders the source's full subtree
+inline — expand, edit, and restructure its children right where it sits. The cheaper alternative (a
+reference that shows the text and opens the subtree on click) was rejected: it dodges path identity but
+isn't the synced-block experience. A1 is the destination; the build *stages* toward it (below) so A2-grade
+value lands first.
+
+**Pointer model, not a content-entity.** A mirror is a normal node with a new `mirrorOf: string | null`
+pointer; a non-mirror node has `mirrorOf === null` and **is its own source**. Children still hang off the
+source node's id (`parentId`), exactly as today. Rejected alternative: give every node a shared `contentId`
+and hang children off *that* (truly symmetric instances, trivial delete). It's the "cleaner" Notion model
+but rewrites `buildTreeIndex`, every mutation, and the wire schema — far more invasive for a feature that's
+rare per outline. The pointer model keeps the mirror-free outline untouched.
+
+**Resolution: `contentId = mirrorOf ?? id`, recurse over the content's children.** The render walk, at each
+node `N`, reads content from `contentId` and recurses into `contentId`'s children (so a mirror windows the
+source's subtree). The **only** place content ≠ position is a mirror's own boundary — everything *inside* a
+mirrored subtree is real nodes (a child `c1` of source `A` has `parentId === A`; it's not itself a mirror
+unless it carries its own `mirrorOf`).
+
+**Hybrid path addressing (the keystone).** A row's **data** is read by id (`useNode(contentId)`) so text/
+completed/children sync everywhere for free. A row's **address** — React key, `refs`, `pendingFocus`/
+`pendingFlash`, selection, drag — becomes the **render path** (the chain of ids from the view root). But a
+row keeps its **bare `nodeId`** address while *no mirror is on its path* (byte-identical to today), and only
+switches to a compound path key **once the walk has crossed a mirror**. All the new complexity is fenced
+inside mirrored subtrees; the 99% mirror-free outline runs today's exact code. Zoom is unaffected —
+`rootId` is always a real node id (zooming a mirror `M` resolves to showing `A`'s content).
+
+**Field split — what syncs vs. what's local.**
+- **Content (read from the source, syncs across instances):** `text`, `isTask`, `completed`, children.
+  Checking the task off in Today checks it in the project — same task, same done-state.
+- **Local (read from the instance node where it sits):** `parentId`/`prevSiblingId` (position), `collapsed`,
+  `bookmarkedAt`. A mirror can be collapsed in Today while expanded in the project; bookmarking the Today
+  view vs. the project view are different saved views (different ids → different URLs).
+- **Divergence from WorkFlowy, accepted for v1: descendant collapse is *shared*, not per-instance.** A
+  mirror's own top collapses independently (free — it's the instance node's field), but collapsing a
+  *sub-item* collapses it everywhere, because that sub-item is the same underlying node. Fully per-instance
+  descendant collapse needs a `path → collapsed` override store — real cost for marginal gain.
+
+**Delete = promote, cascade-aware.** Deleting a mirror is trivial (one node; its "children" are the
+source's, untouched). Deleting the **source** while instances survive **promotes**: pick the oldest
+surviving instance, clear its `mirrorOf`, reparent the real children under it, repoint the other mirrors at
+it — one atomic batch ([ADR 0009](./0009-atomic-structural-writes.md)), undoable. This makes the source/
+instance distinction *invisible* (Notion's "content survives in the remaining copies"). Critically, promote
+runs on **any** removal, including a cascade delete of an ancestor subtree: if you delete a whole project
+and a mirror of one of its tasks lives in Today *outside* the deleted subtree, the content promotes into
+Today rather than vanishing. **Content dies only when the last instance is gone.** Rejected: *block*
+deletion of a mirrored source (user-hostile when it fires) and *cascade* (deleting the source silently
+nukes every mirror — surprising).
+
+**Cycle guard, two layers.** A mirror windows its source's children, so a mirror of `A` placed inside `A`'s
+own subtree (directly, or via a later move, or a chain) would render forever. (1) **At creation**, block the
+obvious case — refuse to mirror a node into its own subtree or itself (shake + toast). (2) **At render**,
+the walk tracks the source ids on the current path and refuses to expand a mirror whose source is already an
+ancestor; that mirror renders as a **non-expandable capped row** (chevron disabled, mirror badge, click
+jumps to source) — the safety net for cycles formed *after* creation, which the create check can't catch.
+Show the capped row, don't hide it.
+
+**Creation reuses the Move destination picker.** Mirror is Move's sibling — Move *relocates*, Mirror *leaves
+the node and drops an instance at the target*. Entry points: a `/mirror` "Mirror to…" command (Seam C), the
+selection actions menu via `runMany` (mirror several subtrees at once, [ADR 0018](./0018-node-multi-selection.md)),
+and daily's **"Mirror to Today"** (no picker, target = today's note). Daily keeps **both** "Move to Today"
+(the current move) and "Mirror to Today" — relocating and "this also matters today" are different intents.
+
+**Visual — legible, low-noise (core chrome, both render paths).** Mirrors are a core concept (they rewrite
+the render walk), not a plugin seam, so the chrome renders in both the list row and the zoomed title (the
+dual-path rule). Always-on: a mirror icon + subtle tint on instances, a "mirrored ×N" count badge on the
+source. On **hover / caret-inside** (`:focus-within`): a colored border — one hue for the source, another
+for instances (Notion's red/blue, revealed only when you're working in it) — **pure CSS keyed off a
+`data-mirror` attribute, zero JS / zero re-render**, same ethos as the tag-color stylesheet
+([ADR 0007](./0007-custom-tag-colors.md)). Clicking a badge opens an **"appears in N places" list**
+(breadcrumb per instance, click to jump), reusing the node-switcher/move-dialog list and the reverse index.
+
+## Defensive measures
+
+- **Flatten mirror-of-mirror.** Mirroring a mirror sets `mirrorOf` to the *true source*, never to another
+  mirror — keeps promote and cycle detection from walking chains.
+- **Broken-mirror render.** If `mirrorOf` ever points at a missing node (sync race / bug), the mirror renders
+  a "source not found" leaf, never throws.
+- **Reverse index** (`sourceId → instance ids`) maintained in the tree-store like `childrenByParent` — powers
+  the count badge and the promote lookup without an O(n) scan per delete.
+- **Single-DO safety.** Source and all instances live in the same per-user Durable Object
+  ([ADR 0008](./0008-sync-via-a-per-user-durable-object.md)); a mirror is always intra-DO, so there's no
+  cross-boundary consistency problem. (Cross-user mirrors would be a different decision — out of scope.)
+- **Search dedups, export expands.** Cmd+K dedups instances to the source (one result; the instance list
+  handles "go to the other one"). Markdown export ([ADR 0017](./0017-markdown-export.md)) expands a mirror to
+  its content — there's no markdown for "mirror."
+
+## Schema + wire
+
+Add `mirrorOf: string | null` to `nodeSchema` ([ADR 0003](./0003-no-schema-defaults.md): required + nullable,
+no default; `makeNode` sets `null`). `worker/wire.ts` gains the field and the Worker's derived types follow
+([ADR 0014](./0014-validate-the-worker-do-trust-boundary.md)); the DO's `nodes` table gains the column.
+Existing rows backfill `null` at snapshot load in `collection.ts` (the `healSiblingChains` pattern). Additive
+and nullable — low-risk.
+
+## Staged build (the expensive 20% lands last)
+
+Even though we chose A1, the build is sequenced so daily value arrives before the caret-sensitive surgery:
+
+- **Stage 0 — plumbing, ships dark.** `mirrorOf` through schema/`makeNode`/wire/DO/backfill; reverse index. No
+  behavior.
+- **Stage 1 — render + create + chrome (≈ A2-grade value).** Mirror-aware walk (contentId resolution, source
+  windowing, path keys inside mirrors), cycle guard + capped row, broken-mirror render; "Mirror to…" / "Mirror
+  to Today"; visual badges + hover borders + instance list. Text and `completed` already sync (data by id), and
+  you can *see and check* the whole subtree in both places. **This delivers the motivating use case.**
+- **Stage 2 — full editing parity inside mirrors (the A1 gold-plate).** Path-based `focus`/`pendingFocus`/
+  `flash`/drag/multi-select inside mirrored subtrees, and structural mutations redirecting at the mirror
+  boundary (insert a child under a mirror → under the source). The caret-sensitive, regression-prone part;
+  heavy e2e.
+- **Stage 3 — promote-on-delete** (direct + cascade-aware) and its undo/redo.
+
+## Don't regress
+
+- The mirror-free outline must run **today's exact code** — bare `nodeId` addressing until a mirror is crossed.
+  Don't make every row pay for path identity.
+- Keep node data flowing through the per-node subscriptions ([ADR 0004](./0004-localized-rendering-via-the-tree-store.md));
+  mirrors change a row's *address*, not how it gets its data. Don't thread mirror state as props.
+- Every mirror mutation (create, promote) is **one `runStructural` batch** ([ADR 0009](./0009-atomic-structural-writes.md)).
+- One render-walk definition (`visible-order.ts`) still drives both render and caret nav — don't fork a
+  mirror-aware copy that drifts from the neighbor walk.

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -13,6 +13,8 @@ export interface SeedNode {
   isTask?: boolean;
   /** Epoch ms when bookmarked; omit/null for an un-bookmarked node. */
   bookmarkedAt?: number | null;
+  /** Source node id this is a mirror of (ADR 0022); omit/null for a normal node. */
+  mirrorOf?: string | null;
 }
 
 /** A full node row as the /api/nodes Worker speaks it -- real booleans, all
@@ -26,6 +28,7 @@ interface ApiNode {
   completed: boolean;
   collapsed: boolean;
   bookmarkedAt: number | null;
+  mirrorOf: string | null;
   createdAt: number;
   updatedAt: number;
 }
@@ -47,6 +50,7 @@ function toNode(n: SeedNode): ApiNode {
     completed: n.completed ?? false,
     collapsed: n.collapsed ?? false,
     bookmarkedAt: n.bookmarkedAt ?? null,
+    mirrorOf: n.mirrorOf ?? null,
     createdAt: 0,
     updatedAt: 0,
   };

--- a/e2e/mirror-editing.spec.ts
+++ b/e2e/mirror-editing.spec.ts
@@ -218,14 +218,32 @@ test.describe("node mirrors -- editing parity inside a mirror (ADR 0022, 2c)", (
     // INSTANCE: the mirror row carries the edge, the source row does not.
     await caretIn(spans(page, "M"), 99);
     await page.keyboard.press("Shift+ArrowDown");
+    // M windows a1/a2, so the windowed-subtree-tint fix (2e-2) covers all three
+    // rows -- the slab rounds at M (top) and a2's windowed copy, its last visible
+    // descendant (bottom), not just at M alone.
     await expect(page.locator('li[data-node-id="M"]')).toHaveAttribute(
       "data-selected",
-      "single",
+      "top",
     );
+    await expect(spans(page, "a1").nth(1)).toBeVisible(); // sanity: nth(1) is the windowed copy
+    await expect(
+      page.locator('li[data-node-id="a1"]').nth(1),
+    ).toHaveAttribute("data-selected", "middle");
+    await expect(
+      page.locator('li[data-node-id="a2"]').nth(1),
+    ).toHaveAttribute("data-selected", "bottom");
+    // No cross-instance bleed: the real source A and its OWN (canonical) a1/a2
+    // rows are a totally different branch of the walk, never covered.
     await expect(page.locator('li[data-node-id="A"]')).not.toHaveAttribute(
       "data-selected",
       /.*/,
     );
+    await expect(
+      page.locator('li[data-node-id="a1"]').nth(0),
+    ).not.toHaveAttribute("data-selected", /.*/);
+    await expect(
+      page.locator('li[data-node-id="a2"]').nth(0),
+    ).not.toHaveAttribute("data-selected", /.*/);
 
     // Delete the selection (selection-mode Backspace). Only the mirror goes; the
     // source and its children survive, now rendering once.

--- a/e2e/mirror-editing.spec.ts
+++ b/e2e/mirror-editing.spec.ts
@@ -194,6 +194,107 @@ test.describe("node mirrors -- editing parity inside a mirror (ADR 0022, 2c)", (
     await expect(spans(page, "a2")).toHaveCount(1);
   });
 
+  test("selecting a mirror selects the INSTANCE, so delete removes only the mirror", async ({
+    page,
+  }) => {
+    await load(page, MIRROR_TREE, true);
+    await expect(spans(page, "a1")).toHaveCount(2);
+
+    // Enter node selection on the mirror's own row (Shift+Down from line end is
+    // the direction-agnostic single-node entry). Pre-2e the keymap selected the
+    // SOURCE's id (content), so the SOURCE row lit up and a select+delete removed
+    // the source, orphaning every instance ("deletes both"). It must select the
+    // INSTANCE: the mirror row carries the edge, the source row does not.
+    await caretIn(spans(page, "M"), 99);
+    await page.keyboard.press("Shift+ArrowDown");
+    await expect(page.locator('li[data-node-id="M"]')).toHaveAttribute(
+      "data-selected",
+      "single",
+    );
+    await expect(page.locator('li[data-node-id="A"]')).not.toHaveAttribute(
+      "data-selected",
+      /.*/,
+    );
+
+    // Delete the selection (selection-mode Backspace). Only the mirror goes; the
+    // source and its children survive, now rendering once.
+    await page.keyboard.press("Backspace");
+    await expect(page.locator('li[data-mirror="instance"]')).toHaveCount(0);
+    await expect(spans(page, "A")).toBeVisible();
+    await expect(spans(page, "a1")).toHaveCount(1);
+    await expect(spans(page, "a2")).toHaveCount(1);
+  });
+
+  test("deleting a SOURCE that has a live mirror is blocked (no orphaned instances)", async ({
+    page,
+  }) => {
+    await load(page, MIRROR_TREE, true);
+    await expect(spans(page, "a1")).toHaveCount(2); // source + windowed under M
+
+    // Try to delete the real source A. Removing it would strand the mirror M
+    // (promote-on-delete is Stage 3), so the core blocks it: A and the mirror
+    // both survive, and a1/a2 still render twice.
+    await caretIn(spans(page, "A"), 0);
+    await page.keyboard.press(`${modifier()}+Shift+Backspace`);
+
+    await expect(spans(page, "A")).toBeVisible();
+    await expect(page.locator('li[data-mirror="instance"]')).toHaveCount(1);
+    await expect(spans(page, "a1")).toHaveCount(2);
+    await expect(spans(page, "a2")).toHaveCount(2);
+  });
+
+  test("zoom morph names ONE element when a source and its mirror are both visible (no duplicate view-transition-name)", async ({
+    page,
+  }) => {
+    // Dogfood crash repro. pivotId is a node id; the old `content.id === pivotId`
+    // tagged the source's OWN row AND every visible mirror row with
+    // `view-transition-name: zoom-target`. That name must be unique per document,
+    // so the duplicate logged a console error and the next zoom threw "Transition
+    // was aborted". Pivot is now keyed by the per-instance rowKey, so only the
+    // source's canonical row morphs (key === id); mirror rows never collide.
+    const morphErrors: string[] = [];
+    page.on("console", (msg) => {
+      if (
+        msg.type() === "error" &&
+        /duplicate view-transition-name|Transition was aborted/.test(msg.text())
+      )
+        morphErrors.push(msg.text());
+    });
+    page.on("pageerror", (err) => {
+      if (/Transition was aborted|duplicate view-transition-name/.test(err.message))
+        morphErrors.push(err.message);
+    });
+
+    await load(page, MIRROR_TREE, true);
+    await expect(spans(page, "a1")).toHaveCount(2); // source + windowed under M
+
+    // Zoom INTO the source A (bullet click -> A becomes the title), then back OUT
+    // one level (Mod+,). Zooming out sets the morph pivot to A while rooting at the
+    // top, so A's own row AND the mirror M (which windows A) are both visible with
+    // pivotId === A -- the exact collision the user hit.
+    await page.locator('li[data-node-id="A"] .bullet').first().click();
+    await expect(page.locator(".zoomed-title-text")).toHaveText("alphasource");
+    await page.keyboard.press(`${modifier()}+Comma`);
+
+    // Back at the top level with both rows visible. The source's row carrying the
+    // morph name proves pivotId === A took effect (precondition -- fails loudly if
+    // the zoom-out didn't land, so the assertions below can't false-green).
+    await expect(spans(page, "A")).toBeVisible();
+    await expect(page.locator('li[data-mirror="instance"]')).toHaveCount(1);
+    await expect(spans(page, "A")).toHaveAttribute("style", /zoom-target/);
+
+    // Exactly ONE element carries the morph name, and it is NOT the mirror row.
+    const named = await page.evaluate(
+      () =>
+        Array.from(document.querySelectorAll<HTMLElement>(".node-text")).filter(
+          (el) => el.style.viewTransitionName === "zoom-target",
+        ).length,
+    );
+    expect(named).toBe(1);
+    await expect(spans(page, "M")).not.toHaveAttribute("style", /zoom-target/);
+    expect(morphErrors).toEqual([]);
+  });
+
   test("flag OFF: a mirrorOf node Enter-splits as an ordinary leaf (parity)", async ({
     page,
   }) => {

--- a/e2e/mirror-editing.spec.ts
+++ b/e2e/mirror-editing.spec.ts
@@ -36,6 +36,17 @@ function modifier() {
   return process.platform === "darwin" ? "Meta" : "Control";
 }
 
+// The flat-list order of node ids as rendered (document order === visible order).
+// A windowed source child appears twice, so the same id repeats -- exactly what
+// lets us prove a reorder lands in BOTH the source and the mirror.
+const nodeOrder = (page: Page) =>
+  page.evaluate(() =>
+    Array.from(document.querySelectorAll("li[data-node-id]")).map((li) =>
+      li.getAttribute("data-node-id"),
+    ),
+  );
+
+
 async function load(page: Page, tree: SeedNode[], mirrors: boolean) {
   await page.addInitScript(() => {
     localStorage.setItem("dotflowy:flag:virtualized", "on");
@@ -293,6 +304,83 @@ test.describe("node mirrors -- editing parity inside a mirror (ADR 0022, 2c)", (
     expect(named).toBe(1);
     await expect(spans(page, "M")).not.toHaveAttribute("style", /zoom-target/);
     expect(morphErrors).toEqual([]);
+  });
+
+  test("dragging a windowed child inside a mirror reorders the SOURCE in every instance (2d)", async ({
+    page,
+  }) => {
+    // The structural-write tripwire only console.errors; assert it stayed silent
+    // (a reorder that read a stale post-update index would tear the chain).
+    const chainErrors: string[] = [];
+    page.on("console", (msg) => {
+      if (
+        msg.type() === "error" &&
+        msg.text().includes("sibling-chain invariant broken")
+      )
+        chainErrors.push(msg.text());
+    });
+    // Three children so the drop lands UNAMBIGUOUSLY off the top: dropping the
+    // grabbed a1 past every row puts it after a2/a3 -- no longer first -- which
+    // survives the virtualizer's estimate-vs-measured geometry offset (the reason
+    // a precise gap can't be aimed from a synthetic-pointer test).
+    const tree: SeedNode[] = [
+      { id: "A", parentId: null, prevSiblingId: null, text: "alphasource" },
+      { id: "P", parentId: null, prevSiblingId: "A", text: "project" },
+      { id: "a1", parentId: "A", prevSiblingId: null, text: "childone" },
+      { id: "a2", parentId: "A", prevSiblingId: "a1", text: "childtwo" },
+      { id: "a3", parentId: "A", prevSiblingId: "a2", text: "childthree" },
+      { id: "M", parentId: "P", prevSiblingId: null, text: "ph", mirrorOf: "A" },
+    ];
+    await load(page, tree, true);
+    await expect(spans(page, "a1")).toHaveCount(2);
+    expect(await nodeOrder(page)).toEqual([
+      "A",
+      "a1",
+      "a2",
+      "a3",
+      "P",
+      "M",
+      "a1",
+      "a2",
+      "a3",
+    ]);
+
+    // Drag the WINDOWED a1 (under M, nth(1)) DOWN past every row so it lands after
+    // the last windowed child. a1 is a REAL node, so reordering it restructures
+    // the source -> the move shows under BOTH the source and the mirror. Pre-2d
+    // the windowed rows had no virtualizer geometry (hit-test keyed by bare id,
+    // not row.key) so the drop projected off only the non-mirror rows ("way off").
+    // Drop near the viewport bottom (above the 72px auto-scroll edge band): that's
+    // below every row's virtualizer position regardless of the estimate offset,
+    // so the gap is unambiguously the end of the list.
+    {
+      const grab = page.locator('li[data-node-id="a1"] .bullet').nth(1);
+      const g = await grab.boundingBox();
+      if (!g) throw new Error("grab handle not laid out");
+      const gx = g.x + g.width / 2;
+      const dropY = (page.viewportSize()?.height ?? 720) - 100;
+      await page.mouse.move(gx, g.y + g.height / 2);
+      await page.mouse.down();
+      await page.mouse.move(gx, g.y + g.height / 2 + 12, { steps: 5 });
+      await page.mouse.move(gx, dropY, { steps: 12 });
+      await page.mouse.up();
+    }
+
+    // a1 left the top in BOTH instances, and the two blocks stay in lockstep (one
+    // real reorder, windowed everywhere). The exact landing slot (after a2 or a3)
+    // is left loose -- either proves the source was restructured.
+    const childBlocks = async () => {
+      const order = await nodeOrder(page);
+      const p = order.indexOf("P");
+      const m = order.indexOf("M");
+      return { source: order.slice(1, p), mirror: order.slice(m + 1) };
+    };
+    await expect.poll(async () => (await childBlocks()).source[0]).toBe("a2");
+    const { source, mirror } = await childBlocks();
+    expect(source).not.toEqual(["a1", "a2", "a3"]); // a1 moved off the top
+    expect(mirror).toEqual(source); // reflected in the mirror
+    expect(source).toContain("a1"); // still present, just relocated
+    expect(chainErrors).toEqual([]);
   });
 
   test("flag OFF: a mirrorOf node Enter-splits as an ordinary leaf (parity)", async ({

--- a/e2e/mirror-editing.spec.ts
+++ b/e2e/mirror-editing.spec.ts
@@ -1,0 +1,214 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+import { seedOutline, type SeedNode } from "./fixtures";
+
+// Node mirrors (ADR 0022), slice 2c: full editing parity INSIDE a mirror. Stage 1
+// shipped render + the field split; 2a/2b made focus + caret nav path-addressed.
+// 2c makes STRUCTURAL edits behave per the field split -- position ops target the
+// INSTANCE, content + child inserts target the SOURCE -- and lands focus in the
+// instance the user was editing (never teleporting to the source's far copy).
+//
+// Tree (display order, flag on, nothing collapsed):
+//   A  "alphasource"
+//     a1 "childone"
+//     a2 "childtwo"
+//   P  "project"
+//     M  (mirrorOf=A)  -> windows a1, a2
+//
+// So a1/a2 each render TWICE: once under the real source A (document order first =
+// nth(0)) and once windowed under the mirror M (nth(1)). Text is space-free so
+// `toHaveText` (which normalizes whitespace) compares exactly.
+const MIRROR_TREE: SeedNode[] = [
+  { id: "A", parentId: null, prevSiblingId: null, text: "alphasource" },
+  { id: "P", parentId: null, prevSiblingId: "A", text: "project" },
+  { id: "a1", parentId: "A", prevSiblingId: null, text: "childone" },
+  { id: "a2", parentId: "A", prevSiblingId: "a1", text: "childtwo" },
+  { id: "M", parentId: "P", prevSiblingId: null, text: "placeholder", mirrorOf: "A" },
+];
+
+// All copies of a node's editable span (a windowed source child has two).
+const spans = (page: Page, id: string) =>
+  page.locator(`li[data-node-id="${id}"] > .outline-row > .node-text`);
+const focused = (page: Page) => page.locator(".node-text:focus");
+
+// Platform Cmd/Ctrl, matching the app's `Mod+...` hotkeys (Playwright has no
+// "Mod" alias). Mirrors the helper in the other specs.
+function modifier() {
+  return process.platform === "darwin" ? "Meta" : "Control";
+}
+
+async function load(page: Page, tree: SeedNode[], mirrors: boolean) {
+  await page.addInitScript(() => {
+    localStorage.setItem("dotflowy:flag:virtualized", "on");
+  });
+  if (mirrors) {
+    await page.addInitScript(() => {
+      localStorage.setItem("dotflowy:flag:mirrors", "on");
+    });
+  }
+  await seedOutline(page, tree);
+  await page.goto("/");
+  await expect(spans(page, "A")).toBeVisible();
+}
+
+// Focus a SPECIFIC span (a Locator, so we can target one of two duplicate copies)
+// and drop the caret at absolute offset `col`. Sets the Selection range directly:
+// Home/Arrow keys are unreliable in macOS Chromium contentEditable, and a plain
+// click lands past the text. Mirrors the caretAt helper in enter-split.spec.ts.
+async function caretIn(locator: Locator, col: number) {
+  await locator.click();
+  await locator.evaluate((el, target) => {
+    const sel = window.getSelection();
+    if (!sel) return;
+    const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
+    let remaining = target as number;
+    let node = walker.nextNode();
+    const range = document.createRange();
+    while (node) {
+      const len = node.textContent?.length ?? 0;
+      if (remaining <= len) {
+        range.setStart(node, remaining);
+        range.collapse(true);
+        sel.removeAllRanges();
+        sel.addRange(range);
+        return;
+      }
+      remaining -= len;
+      node = walker.nextNode();
+    }
+    range.selectNodeContents(el);
+    range.collapse(false);
+    sel.removeAllRanges();
+    sel.addRange(range);
+  }, col);
+}
+
+test.describe("node mirrors -- editing parity inside a mirror (ADR 0022, 2c)", () => {
+  test("Enter-split inside a mirror splits the source and lands focus under the mirror", async ({
+    page,
+  }) => {
+    await load(page, MIRROR_TREE, true);
+    await expect(spans(page, "a1")).toHaveCount(2);
+
+    // Split the WINDOWED copy of a1 (under M) at "child|one". The split edits the
+    // real node a1, so it shows in BOTH instances; the tail seeds a new sibling.
+    await caretIn(spans(page, "a1").nth(1), 5);
+    await page.keyboard.press("Enter");
+
+    // a1 truncated to "child" in every instance.
+    await expect(spans(page, "a1").nth(0)).toHaveText("child");
+    await expect(spans(page, "a1").nth(1)).toHaveText("child");
+    // The new "one" node windows into both instances (real under A + under M).
+    const ones = page.locator(".node-text").filter({ hasText: /^one$/ });
+    await expect(ones).toHaveCount(2);
+    // Focus landed on the WINDOWED copy (doc order: nth(0)=under source, nth(1)=
+    // under the mirror), NOT the source's row -- no cross-instance focus bleed.
+    await expect(ones.nth(1)).toBeFocused();
+  });
+
+  test("Enter at the end of a mirror's own row adds a child to the source", async ({
+    page,
+  }) => {
+    await load(page, MIRROR_TREE, true);
+
+    // The mirror row shows the SOURCE's text; pressing Enter at its end dives in,
+    // adding a child to the source (windows into every instance), not a local
+    // sibling next to the mirror.
+    await expect(spans(page, "M")).toHaveText("alphasource");
+    await caretIn(spans(page, "M"), 99);
+    await page.keyboard.press("Enter");
+    await page.keyboard.type("newkid");
+
+    // "newkid" now exists under the real source A AND windowed under M.
+    const kids = page.locator(".node-text").filter({ hasText: /^newkid$/ });
+    await expect(kids).toHaveCount(2);
+    await expect(kids.nth(1)).toBeFocused(); // editing instance keeps focus
+  });
+
+  test("indent + outdent inside a mirror restructures the source in every instance", async ({
+    page,
+  }) => {
+    // Gate the structural-write invariant: indent/outdent must never produce a
+    // self-referencing sibling chain (the DEV tripwire in structural.ts). This is
+    // the regression guard for the indent fix -- the tripwire only logs, so we
+    // assert it stayed silent.
+    const chainErrors: string[] = [];
+    page.on("console", (msg) => {
+      if (
+        msg.type() === "error" &&
+        msg.text().includes("sibling-chain invariant broken")
+      ) {
+        chainErrors.push(msg.text());
+      }
+    });
+    await load(page, MIRROR_TREE, true);
+
+    // Tab on the windowed a2 indents it under a1. a2 is a real node, so its parent
+    // changes everywhere -- both copies now hang under a1.
+    await spans(page, "a2").nth(1).click();
+    await expect(spans(page, "a2").nth(1)).toBeFocused();
+    await page.keyboard.press("Tab");
+
+    await expect(page.locator('li[data-node-id="a2"]').nth(0)).toHaveAttribute(
+      "data-parent-id",
+      "a1",
+    );
+    await expect(page.locator('li[data-node-id="a2"]').nth(1)).toHaveAttribute(
+      "data-parent-id",
+      "a1",
+    );
+    // Focus stayed on the windowed a2 (the editing instance), not the source copy.
+    await expect(spans(page, "a2").nth(1)).toBeFocused();
+
+    // Shift+Tab outdents it back to a child of A, again in both instances.
+    await page.keyboard.press("Shift+Tab");
+    await expect(page.locator('li[data-node-id="a2"]').nth(0)).toHaveAttribute(
+      "data-parent-id",
+      "A",
+    );
+    await expect(page.locator('li[data-node-id="a2"]').nth(1)).toHaveAttribute(
+      "data-parent-id",
+      "A",
+    );
+    await expect(spans(page, "a2").nth(1)).toBeFocused();
+
+    expect(chainErrors).toEqual([]);
+  });
+
+  test("deleting a mirror instance removes only that instance, not the source", async ({
+    page,
+  }) => {
+    await load(page, MIRROR_TREE, true);
+    await expect(spans(page, "a1")).toHaveCount(2);
+
+    // Delete the mirror's own row. The keymap hands the command the SOURCE's id,
+    // but the delete targets the focused INSTANCE -- so the mirror goes and the
+    // source survives (promote-on-source-delete is Stage 3, not this).
+    await spans(page, "M").click();
+    await expect(spans(page, "M")).toBeFocused();
+    await page.keyboard.press(`${modifier()}+Shift+Backspace`);
+
+    await expect(page.locator('li[data-mirror="instance"]')).toHaveCount(0);
+    await expect(spans(page, "A")).toBeVisible();
+    // a1/a2 now render once -- only under the surviving source.
+    await expect(spans(page, "a1")).toHaveCount(1);
+    await expect(spans(page, "a2")).toHaveCount(1);
+  });
+
+  test("flag OFF: a mirrorOf node Enter-splits as an ordinary leaf (parity)", async ({
+    page,
+  }) => {
+    await load(page, MIRROR_TREE, false);
+
+    // Mirrors disabled: M is a plain node showing its own text, no windowing.
+    await expect(spans(page, "M")).toHaveText("placeholder");
+    await expect(spans(page, "a1")).toHaveCount(1);
+
+    await caretIn(spans(page, "M"), 4);
+    await page.keyboard.press("Enter");
+
+    await expect(spans(page, "M")).toHaveText("plac");
+    await expect(focused(page)).toHaveText("eholder");
+    // Still no windowing -- a1 stays single.
+    await expect(spans(page, "a1")).toHaveCount(1);
+  });
+});

--- a/e2e/mirrors.spec.ts
+++ b/e2e/mirrors.spec.ts
@@ -1,0 +1,157 @@
+import { expect, test, type Page } from "@playwright/test";
+import { seedOutline, type SeedNode } from "./fixtures";
+
+// Node mirrors (ADR 0022), slice 1b: render + field split. A node carrying
+// `mirrorOf` windows its source's text + children; all instances are editable
+// and text-synced. These specs SEED a mirror (creation is slice 1c) and prove
+// the rendered behavior behind the flag, plus flag-off parity.
+//
+// Tree (display order, flag on, nothing collapsed):
+//   A  "alpha source"
+//     a1 "alpha child one"
+//     a2 "alpha child two"
+//   P  "project"
+//     M  "mirror placeholder"  (mirrorOf=A)  -> windows a1, a2
+//
+// So `a1`/`a2` each appear twice: once under the real source A, once under the
+// mirror M. The mirror row M itself shows A's text, not "mirror placeholder".
+const MIRROR_TREE: SeedNode[] = [
+  { id: "A", parentId: null, prevSiblingId: null, text: "alpha source" },
+  { id: "P", parentId: null, prevSiblingId: "A", text: "project" },
+  { id: "a1", parentId: "A", prevSiblingId: null, text: "alpha child one" },
+  { id: "a2", parentId: "A", prevSiblingId: "a1", text: "alpha child two" },
+  { id: "M", parentId: "P", prevSiblingId: null, text: "mirror placeholder", mirrorOf: "A" },
+];
+
+const text = (page: Page, nodeId: string) =>
+  page.locator(`li[data-node-id="${nodeId}"] > .outline-row > .node-text`);
+
+async function load(page: Page, tree: SeedNode[], mirrors: boolean) {
+  await page.addInitScript(() => {
+    localStorage.setItem("dotflowy:flag:virtualized", "on");
+  });
+  if (mirrors) {
+    await page.addInitScript(() => {
+      localStorage.setItem("dotflowy:flag:mirrors", "on");
+    });
+  }
+  await seedOutline(page, tree);
+  await page.goto("/");
+  await expect(text(page, "A")).toBeVisible();
+}
+
+test.describe("node mirrors -- render + field split (ADR 0022)", () => {
+  test("a mirror windows its source's text and children", async ({ page }) => {
+    await load(page, MIRROR_TREE, true);
+
+    // The mirror row reads the SOURCE's content, not its own placeholder text.
+    await expect(text(page, "M")).toHaveText("alpha source");
+    await expect(page.locator('li[data-node-id="M"]')).toHaveAttribute(
+      "data-mirror",
+      "instance",
+    );
+
+    // The source's children appear under the mirror too: a1/a2 each render twice
+    // (once under real A, once under M). Distinct render keys, same node id.
+    await expect(page.locator('li[data-node-id="a1"]')).toHaveCount(2);
+    await expect(page.locator('li[data-node-id="a2"]')).toHaveCount(2);
+    await expect(
+      page.locator('li[data-node-id="a1"] .node-text', {
+        hasText: "alpha child one",
+      }),
+    ).toHaveCount(2);
+  });
+
+  test("editing the source updates the mirror live, and vice versa", async ({
+    page,
+  }) => {
+    await load(page, MIRROR_TREE, true);
+    await expect(text(page, "M")).toHaveText("alpha source");
+
+    // Type into the SOURCE -> the mirror reflects it (one client, no reload).
+    await text(page, "A").click();
+    await page.keyboard.type("XYZ");
+    await expect(text(page, "A")).toContainText("XYZ");
+    await expect(text(page, "M")).toContainText("XYZ");
+
+    // Type into the MIRROR -> the source reflects it. Editing a mirror writes
+    // the source (commands.onTextChange(content.id, ...)).
+    await text(page, "M").click();
+    await page.keyboard.type("QQQ");
+    await expect(text(page, "M")).toContainText("QQQ");
+    await expect(text(page, "A")).toContainText("QQQ");
+  });
+
+  test("the source's completed state shows through the mirror", async ({
+    page,
+  }) => {
+    const completedTree = MIRROR_TREE.map((n) =>
+      n.id === "A" ? { ...n, completed: true } : n,
+    );
+    await load(page, completedTree, true);
+
+    // data-completed lives on the node-text and bullet-dot; the mirror reads it
+    // from the source, so checking the source off strikes through every instance.
+    await expect(text(page, "A")).toHaveAttribute("data-completed", "true");
+    await expect(text(page, "M")).toHaveAttribute("data-completed", "true");
+  });
+
+  test("collapse is local: collapsing the mirror hides only its windowed children", async ({
+    page,
+  }) => {
+    await load(page, MIRROR_TREE, true);
+    await expect(page.locator('li[data-node-id="a1"]')).toHaveCount(2);
+
+    // Collapse the MIRROR via its own chevron -> its windowed copy of a1/a2
+    // disappears, but the real source A stays expanded (one copy remains).
+    await page
+      .locator('li[data-node-id="M"] > .outline-row > .collapse-toggle')
+      .click();
+    await expect(page.locator('li[data-node-id="a1"]')).toHaveCount(1);
+    // The surviving copy is the real one, under the source.
+    await expect(text(page, "A")).toBeVisible();
+    await expect(page.locator('li[data-node-id="a2"]')).toHaveCount(1);
+  });
+
+  test("a broken mirror (missing source) renders a leaf, never hangs", async ({
+    page,
+  }) => {
+    const brokenTree: SeedNode[] = [
+      { id: "P", parentId: null, prevSiblingId: null, text: "project" },
+      {
+        id: "M",
+        parentId: "P",
+        prevSiblingId: null,
+        text: "mirror placeholder",
+        mirrorOf: "ghost",
+      },
+    ];
+    await page.addInitScript(() => {
+      localStorage.setItem("dotflowy:flag:virtualized", "on");
+      localStorage.setItem("dotflowy:flag:mirrors", "on");
+    });
+    await seedOutline(page, brokenTree);
+    await page.goto("/");
+
+    const broken = page.locator('li[data-node-id="M"]');
+    await expect(broken).toBeVisible();
+    await expect(broken).toHaveAttribute("data-mirror", "broken");
+    await expect(broken).toContainText("source not found");
+  });
+
+  test("flag OFF: a mirrorOf node renders as a plain leaf (parity)", async ({
+    page,
+  }) => {
+    await load(page, MIRROR_TREE, false);
+
+    // With mirrors disabled, M is an ordinary node: its own text, no windowing.
+    await expect(text(page, "M")).toHaveText("mirror placeholder");
+    await expect(page.locator('li[data-node-id="M"]')).not.toHaveAttribute(
+      "data-mirror",
+      /.*/,
+    );
+    // a1/a2 appear exactly once -- only under the real source.
+    await expect(page.locator('li[data-node-id="a1"]')).toHaveCount(1);
+    await expect(page.locator('li[data-node-id="a2"]')).toHaveCount(1);
+  });
+});

--- a/e2e/mirrors.spec.ts
+++ b/e2e/mirrors.spec.ts
@@ -244,3 +244,71 @@ test.describe("node mirrors -- create via the picker (ADR 0022)", () => {
     ).toHaveCount(0);
   });
 });
+
+// Slice 1d: mirror chrome -- the "appears in N places" badge, the source/instance
+// border attribute, the places jump list, and the Cmd+K dedup. Seeded directly
+// (the MIRROR_TREE from above: source A with one mirror M under P).
+test.describe("node mirrors -- chrome (ADR 0022)", () => {
+  test("the source and the instance both show the 'appears in N places' badge", async ({
+    page,
+  }) => {
+    await load(page, MIRROR_TREE, true);
+
+    // A is the source of exactly one mirror, so the content appears in 2 places.
+    // The badge shows the total (2) on BOTH the source row and the mirror row.
+    const sourceBadge = page.locator(
+      'li[data-node-id="A"] > .outline-row .mirror-badge',
+    );
+    const mirrorBadge = page.locator(
+      'li[data-node-id="M"] > .outline-row .mirror-badge',
+    );
+    await expect(sourceBadge).toHaveText("2");
+    await expect(mirrorBadge).toHaveText("2");
+
+    // The source row carries data-mirror="source" (its colored edge); the mirror
+    // row stays "instance".
+    await expect(page.locator('li[data-node-id="A"]')).toHaveAttribute(
+      "data-mirror",
+      "source",
+    );
+    await expect(page.locator('li[data-node-id="M"]')).toHaveAttribute(
+      "data-mirror",
+      "instance",
+    );
+  });
+
+  test("clicking the badge opens the places list and jumps to the source", async ({
+    page,
+  }) => {
+    await load(page, MIRROR_TREE, true);
+
+    await page
+      .locator('li[data-node-id="A"] > .outline-row .mirror-badge')
+      .click();
+
+    // The jump list opens, titled with the place count, listing a Source row and
+    // a Mirror row.
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByText("Appears in 2 places")).toBeVisible();
+    await expect(dialog.getByText("Source", { exact: true })).toBeVisible();
+    await expect(dialog.getByText("Mirror", { exact: true })).toBeVisible();
+
+    // Picking "Source" zooms into A -- it becomes the page title.
+    await dialog.getByText("Source", { exact: true }).click();
+    await expect(page).toHaveURL(/\/A$/);
+    await expect(page.locator("h2.zoomed-title")).toContainText("alpha source");
+  });
+
+  test("flag OFF: no badge, no data-mirror attribute (parity)", async ({
+    page,
+  }) => {
+    await load(page, MIRROR_TREE, false);
+
+    await expect(page.locator(".mirror-badge")).toHaveCount(0);
+    await expect(page.locator('li[data-node-id="A"]')).not.toHaveAttribute(
+      "data-mirror",
+      /.*/,
+    );
+  });
+});

--- a/e2e/mirrors.spec.ts
+++ b/e2e/mirrors.spec.ts
@@ -155,3 +155,92 @@ test.describe("node mirrors -- render + field split (ADR 0022)", () => {
     await expect(page.locator('li[data-node-id="a2"]')).toHaveCount(1);
   });
 });
+
+// Slice 1c: creating a mirror via the `/mirror` destination picker (reuses the
+// `/move` dialog in mirror mode). Source A (children a1/a2) + a bookmarked
+// destination box D.
+const CREATE_TREE: SeedNode[] = [
+  { id: "A", parentId: null, prevSiblingId: null, text: "alpha source" },
+  {
+    id: "D",
+    parentId: null,
+    prevSiblingId: "A",
+    text: "dest box",
+    bookmarkedAt: 100,
+  },
+  { id: "a1", parentId: "A", prevSiblingId: null, text: "alpha child one" },
+  { id: "a2", parentId: "A", prevSiblingId: "a1", text: "alpha child two" },
+];
+
+// Open the CORE `/mirror` picker for a node the way a user does: focus the
+// bullet, type the slash command (a leading space so `detectSlash` fires), then
+// click the core option -- disambiguated from daily's "Mirror to Today" by its
+// unique description ("...another node"). Mirrors openMove in move-dialog.spec.
+async function openMirror(page: Page, id: string) {
+  await text(page, id).click();
+  await expect(text(page, id)).toBeFocused();
+  await page.keyboard.type(" /mirror");
+  await expect(page.getByRole("listbox")).toBeVisible();
+  await page.getByRole("option", { name: /another node/ }).click();
+  await expect(page.getByRole("dialog")).toBeVisible();
+}
+
+test.describe("node mirrors -- create via the picker (ADR 0022)", () => {
+  test("/mirror creates a live copy under the chosen destination", async ({
+    page,
+  }) => {
+    await load(page, CREATE_TREE, true);
+    await openMirror(page, "A");
+
+    // Pick the bookmarked destination from the empty-query state.
+    await page
+      .getByRole("dialog")
+      .getByRole("option", { name: "dest box" })
+      .click();
+    await expect(page.getByText("Mirrored to dest box")).toBeVisible();
+
+    // A new mirror instance now lives under D, windowing A's text + children.
+    const mirror = page.locator('li[data-mirror="instance"]');
+    await expect(mirror).toHaveCount(1);
+    await expect(mirror).toHaveAttribute("data-parent-id", "D");
+    await expect(mirror.locator("> .outline-row > .node-text")).toContainText(
+      "alpha source",
+    );
+    // a1/a2 now each render twice: under real A, and under the new mirror.
+    await expect(page.locator('li[data-node-id="a1"]')).toHaveCount(2);
+    await expect(page.locator('li[data-node-id="a2"]')).toHaveCount(2);
+  });
+
+  test("the picker excludes the source's own subtree (cycle guard)", async ({
+    page,
+  }) => {
+    // Bookmark a1 (a child of A) so it WOULD surface in the empty-query picker --
+    // but mirroring A into its own child would cycle, so it must be excluded.
+    const tree: SeedNode[] = [
+      { id: "A", parentId: null, prevSiblingId: null, text: "alpha source" },
+      {
+        id: "D",
+        parentId: null,
+        prevSiblingId: "A",
+        text: "dest box",
+        bookmarkedAt: 100,
+      },
+      {
+        id: "a1",
+        parentId: "A",
+        prevSiblingId: null,
+        text: "alpha child one",
+        bookmarkedAt: 200,
+      },
+    ];
+    await load(page, tree, true);
+    await openMirror(page, "A");
+
+    const dialog = page.getByRole("dialog");
+    // D is offered; the source's own child a1 is not (it would cycle).
+    await expect(dialog.getByRole("option", { name: "dest box" })).toBeVisible();
+    await expect(
+      dialog.getByRole("option", { name: "alpha child one" }),
+    ).toHaveCount(0);
+  });
+});

--- a/e2e/mirrors.spec.ts
+++ b/e2e/mirrors.spec.ts
@@ -312,3 +312,62 @@ test.describe("node mirrors -- chrome (ADR 0022)", () => {
     );
   });
 });
+
+// Slice 2b: caret nav across the mirror boundary. Arrow Up/Down walks ROW KEYS
+// (visible-order's path address), so pressing Down from a mirror enters the
+// mirror's OWN windowed copy of the source's children -- never the source's real
+// row elsewhere in the view. Same MIRROR_TREE (A + a1/a2; P > M -> A); visible
+// order is A, a1, a2, P, M, then M's windowed a1, a2.
+test.describe("node mirrors -- caret nav (ADR 0022)", () => {
+  // Both copies of a source child share data-node-id AND data-parent-id (they are
+  // the same instance node, rendered at two paths), so they're indistinguishable
+  // by attribute. Document order IS the flat visible order, so nth(0) is the real
+  // row under the source and nth(1) is the windowed copy under the mirror.
+  const a1Copies = (page: Page) =>
+    page.locator('li[data-node-id="a1"] > .outline-row > .node-text');
+  const a2Copies = (page: Page) =>
+    page.locator('li[data-node-id="a2"] > .outline-row > .node-text');
+
+  test("ArrowDown from a mirror enters its windowed child, not the source's row", async ({
+    page,
+  }) => {
+    await load(page, MIRROR_TREE, true);
+    await expect(a1Copies(page)).toHaveCount(2);
+
+    await text(page, "M").click();
+    await expect(text(page, "M")).toBeFocused();
+    await page.keyboard.press("ArrowDown");
+
+    // Focus crossed into the mirror's OWN a1 (the row just below M), not the
+    // source's real a1 (which sits far above, under A).
+    await expect(a1Copies(page).nth(1)).toBeFocused();
+    await expect(a1Copies(page).nth(0)).not.toBeFocused();
+    // Decisive anti-teleport check: the focused row sits BELOW M (the windowed
+    // child), not above it where the source's real a1 lives.
+    const mBox = await text(page, "M").boundingBox();
+    const focusedBox = await page.locator(":focus").boundingBox();
+    expect(focusedBox!.y).toBeGreaterThan(mBox!.y);
+  });
+
+  test("arrow nav walks between windowed instances and back to the mirror", async ({
+    page,
+  }) => {
+    await load(page, MIRROR_TREE, true);
+
+    await text(page, "M").click();
+    await page.keyboard.press("ArrowDown"); // M -> windowed a1
+    await expect(a1Copies(page).nth(1)).toBeFocused();
+    await page.keyboard.press("ArrowDown"); // -> windowed a2
+    await expect(a2Copies(page).nth(1)).toBeFocused();
+
+    // a2 is the last visible row: Down holds focus, never teleports to the source.
+    await page.keyboard.press("ArrowDown");
+    await expect(a2Copies(page).nth(1)).toBeFocused();
+
+    // Back up: windowed a2 -> windowed a1 -> M.
+    await page.keyboard.press("ArrowUp");
+    await expect(a1Copies(page).nth(1)).toBeFocused();
+    await page.keyboard.press("ArrowUp");
+    await expect(text(page, "M")).toBeFocused();
+  });
+});

--- a/e2e/node-multi-select.spec.ts
+++ b/e2e/node-multi-select.spec.ts
@@ -133,31 +133,38 @@ test.describe("Node multi-selection", () => {
     await load(page, CHAIN);
     await focus(page, "aaa");
 
-    // First press selects the focused node itself -- entering never climbs.
+    // First press selects the focused node itself -- entering never climbs. aaa
+    // is a leaf, so it's the only covered row.
     await page.keyboard.press("Shift+ArrowUp");
     await expect(li(page, "aaa")).toHaveAttribute("data-selected", "single");
 
-    // No upper sibling -> the selection moves UP to the parent (the child stays
-    // tinted as the parent's implied subtree, but only the root carries an edge).
+    // No upper sibling -> the selection moves UP to the parent. aa has a visible
+    // child (aaa), so the windowed list tints BOTH rows now (2e-2) -- the slab
+    // rounds at aa (top) and at aaa, its last visible descendant (bottom), not
+    // just at the selected root.
     await page.keyboard.press("Shift+ArrowUp");
-    await expect(li(page, "aa")).toHaveAttribute("data-selected", "single");
-    await expect(li(page, "aaa")).not.toHaveAttribute("data-selected", /.*/);
+    await expect(li(page, "aa")).toHaveAttribute("data-selected", "top");
+    await expect(li(page, "aaa")).toHaveAttribute("data-selected", "bottom");
 
-    // Climb again to the top-level grandparent.
+    // Climb again to the top-level grandparent: the whole chain is covered.
     await page.keyboard.press("Shift+ArrowUp");
-    await expect(li(page, "a")).toHaveAttribute("data-selected", "single");
+    await expect(li(page, "a")).toHaveAttribute("data-selected", "top");
+    await expect(li(page, "aa")).toHaveAttribute("data-selected", "middle");
+    await expect(li(page, "aaa")).toHaveAttribute("data-selected", "bottom");
 
     // At the top level there is no parent to climb to -> no-op.
     await page.keyboard.press("Shift+ArrowUp");
-    await expect(li(page, "a")).toHaveAttribute("data-selected", "single");
+    await expect(li(page, "a")).toHaveAttribute("data-selected", "top");
 
     // Shift+Down dives back into the first visible child, one level per press.
     await page.keyboard.press("Shift+ArrowDown");
-    await expect(li(page, "aa")).toHaveAttribute("data-selected", "single");
+    await expect(li(page, "aa")).toHaveAttribute("data-selected", "top");
+    await expect(li(page, "aaa")).toHaveAttribute("data-selected", "bottom");
     await expect(li(page, "a")).not.toHaveAttribute("data-selected", /.*/);
 
     await page.keyboard.press("Shift+ArrowDown");
     await expect(li(page, "aaa")).toHaveAttribute("data-selected", "single");
+    await expect(li(page, "aa")).not.toHaveAttribute("data-selected", /.*/);
   });
 
   test("Tab indents the selected run under the previous sibling; Shift+Tab outdents it back", async ({

--- a/src/components/OutlineEditor.tsx
+++ b/src/components/OutlineEditor.tsx
@@ -1079,6 +1079,10 @@ function useNodeCommands({
       // Open the move picker; the dialog runs the mutation + navigation itself.
       onRequestMove: (id) => openMoveDialog(id),
 
+      // Same picker in mirror mode; a pick creates a live mirror under the
+      // chosen destination instead of reparenting (ADR 0022).
+      onRequestMirror: (id) => openMoveDialog(id, "mirror"),
+
       onToggleCollapsed: (id, collapsed) => {
         capture(getTreeIndex(), id);
         toggleCollapsed(id, collapsed);

--- a/src/components/OutlineEditor.tsx
+++ b/src/components/OutlineEditor.tsx
@@ -380,11 +380,15 @@ export function OutlineEditor({ rootId }: OutlineEditorProps) {
         ? { width: window.innerWidth, height: window.innerHeight }
         : undefined,
   });
-  // id -> flat index, for virtual-nav's off-screen scroll. Rebuilt only when the
-  // flat list changes identity (structure), not on keystrokes.
+  // row key -> flat index, for virtual-nav's off-screen scroll. Keyed by the
+  // render ADDRESS (row.key), not the bare id: a source descendant appears under
+  // every instance, so scrollRowIntoView/virtualRowRect must resolve the exact
+  // row (ADR 0022). key === id for every mirror-free row, so the lookup is
+  // unchanged for the 99% outline. Rebuilt only when the flat list changes
+  // identity (structure), not on keystrokes.
   const rowIndex = useMemo(() => {
     const m = new Map<string, number>();
-    rows.forEach((r, i) => m.set(r.id, i));
+    rows.forEach((r, i) => m.set(r.key, i));
     return m;
   }, [rows]);
   const rowIndexRef = useRef(rowIndex);
@@ -496,6 +500,7 @@ export function OutlineEditor({ rootId }: OutlineEditorProps) {
                     <OutlineRow
                       key={vi.key}
                       nodeId={row.id}
+                      rowKey={row.key}
                       contentId={row.contentId}
                       isMirror={row.isMirror}
                       capped={row.capped}
@@ -599,11 +604,14 @@ function useBootstrapOutline() {
 }
 
 interface OutlineFocus {
-  /** id -> contentEditable span. The zoomed title registers under rootId too,
-   *  so focus logic treats titles and list items uniformly. */
+  /** row key -> contentEditable span. Keyed by the render ADDRESS (row.key), not
+   *  the bare id, so a source descendant windowed under two mirrors keeps two
+   *  distinct spans (ADR 0022); key === id for every mirror-free row and for the
+   *  recursive path, so titles and list items still register uniformly (the
+   *  zoomed title registers under rootId, which is its own key). */
   refs: Map<string, HTMLSpanElement | null>;
-  registerRef: (id: string, el: HTMLSpanElement | null) => void;
-  /** The node to focus after the next render (most-recently inserted/moved). */
+  registerRef: (key: string, el: HTMLSpanElement | null) => void;
+  /** The row key to focus after the next render (most-recently inserted/moved). */
   pendingFocus: RefObject<string | null>;
   /** When an Enter-split moved text into the new bullet, land the caret at its
    *  START, not its end (every other pending-focus wants the end). */
@@ -648,12 +656,15 @@ function useOutlineFocus(): OutlineFocus {
   // the pass subscribes to the whole tree itself, in a null component that's
   // cheap to re-render per change.
 
-  // The currently-focused bullet id, by reverse-looking-up the registry (covers
-  // list items and the zoomed title). Null when focus is outside the outline.
+  // The currently-focused bullet's row KEY, by reverse-looking-up the registry
+  // (covers list items and the zoomed title). The registry is keyed by row.key,
+  // so this returns the focused row's address -- equal to the node id for every
+  // mirror-free row, and the path address for a row inside a mirror (ADR 0022).
+  // Null when focus is outside the outline.
   const findFocusedId = useCallback((): string | null => {
     const active = document.activeElement;
-    for (const [id, el] of refs) {
-      if (el === active) return id;
+    for (const [key, el] of refs) {
+      if (el === active) return key;
     }
     return null;
   }, [refs]);

--- a/src/components/OutlineEditor.tsx
+++ b/src/components/OutlineEditor.tsx
@@ -268,19 +268,33 @@ export function OutlineEditor({ rootId }: OutlineEditorProps) {
     getIndex: getTreeIndex,
     getRootId: getViewRootId,
     getIsHidden: getViewIsHidden,
-    getRowEl: (id) =>
-      (refs.get(id)?.closest(".outline-row") as HTMLElement | null) ??
+    getRowEl: (key) =>
+      (refs.get(key)?.closest(".outline-row") as HTMLElement | null) ??
       null,
     getListEl: () => listRef.current,
-    onMove: (id, newParentId, afterSiblingId) =>
+    onMove: (grabbedKey, newParentInstanceId, afterSiblingId) =>
       runStructural(() => {
         const index = getTreeIndex();
-        capture(index, id);
-        const moved = moveNode(index, id, newParentId, afterSiblingId);
+        const instanceId = instanceIdForKey(grabbedKey);
+        // Field split (ADR 0022): dropping under a mirror reparents to its
+        // SOURCE, so the moved node windows into every instance. The position
+        // (the node itself + its predecessor) stays the instance. Off the flag
+        // newParentInstanceId is already a real node, so this is a no-op.
+        const newParentId =
+          isMirrorsEnabled() && newParentInstanceId
+            ? (index.byId.get(newParentInstanceId)?.mirrorOf ??
+              newParentInstanceId)
+            : newParentInstanceId;
+        capture(index, instanceId);
+        const moved = moveNode(index, instanceId, newParentId, afterSiblingId);
         if (moved) {
-          pendingFocus.current = id;
+          // Land focus + flash in the instance that was dragged (re-derived from
+          // the post-move render walk), not the source's far copy. Bare id off
+          // the flag.
+          const key = focusKeyFor(instanceId, grabbedKey);
+          pendingFocus.current = key;
           // Tint the row it landed on so the eye can find what just moved.
-          pendingFlash.current = id;
+          pendingFlash.current = key;
         } else drop();
       }),
   });

--- a/src/components/OutlineEditor.tsx
+++ b/src/components/OutlineEditor.tsx
@@ -363,7 +363,12 @@ export function OutlineEditor({ rootId }: OutlineEditorProps) {
     estimateSize: () => ROW_ESTIMATE,
     overscan: 8,
     scrollMargin,
-    getItemKey: (i) => rows[i]?.id ?? i,
+    // Key by the row's render ADDRESS, not its node id: inside a mirror a
+    // source's descendant appears under every instance, so its bare id is no
+    // longer unique (ADR 0022). `key` equals `id` for every mirror-free row, so
+    // the 99% outline keeps today's identity and the virtualizer's measurement
+    // cache is unaffected.
+    getItemKey: (i) => rows[i]?.key ?? i,
     // Seed the viewport size so the FIRST paint already has a non-empty window.
     // Without it the window virtualizer starts at a 0-height rect and renders no
     // rows until it observes the window a frame later -- a gap that, under heavy
@@ -489,6 +494,10 @@ export function OutlineEditor({ rootId }: OutlineEditorProps) {
                     <OutlineRow
                       key={vi.key}
                       nodeId={row.id}
+                      contentId={row.contentId}
+                      isMirror={row.isMirror}
+                      capped={row.capped}
+                      broken={row.broken}
                       depth={row.depth}
                       ancestorCompleted={row.ancestorCompleted}
                       commands={commands}

--- a/src/components/OutlineEditor.tsx
+++ b/src/components/OutlineEditor.tsx
@@ -96,7 +96,7 @@ import type { PluginContext, ViewContext } from "../plugins/types";
 import { useDragReorder } from "./use-drag-reorder";
 import { consumeFlashAfterNav, flashRow } from "./flash-node";
 import { healProtectedText } from "./protected-text";
-import { guardProtected, ProtectedLock } from "./protection";
+import { guardMirrorSourceDelete, guardProtected, ProtectedLock } from "./protection";
 import { Header } from "./Header";
 import { Subheader } from "./Subheader";
 import { DailyNavigationProgress } from "../plugins/daily/navigation-progress";
@@ -1177,6 +1177,12 @@ function useNodeCommands({
           // the user acted on (the active key). The node isn't removed, so its
           // row still exists.
           if (guardProtected(contentId, "delete", rowOf(activeKey))) return;
+          // Deleting a SOURCE would orphan its live mirrors (Stage 3 promotes;
+          // v1 blocks). A mirror's own row is never a source, so this no-ops
+          // there -- backspacing a mirror still works. Flag-gated: off-flag a
+          // mirrorOf node is just a normal node, so the guard never runs.
+          if (mirrorsOn && guardMirrorSourceDelete(idx, [instanceId], rowOf(activeKey)))
+            return;
           capture(idx, activeKey);
           // Focus the row directly ABOVE the deleted one (Workflowy backspace
           // behavior), computed before the mutation so the neighbor still

--- a/src/components/OutlineEditor.tsx
+++ b/src/components/OutlineEditor.tsx
@@ -53,6 +53,7 @@ import {
 } from "../data/visible-order";
 import { nodesCollection } from "../data/collection";
 import { clearSelection } from "../data/selection-state";
+import { useSyncSelectionFillRows } from "../data/selection-fill";
 import { placeCaretAtEnd, placeCaretAtStart } from "./caret-place";
 import { SelectionActionsMenu, useSelectionMode } from "./selection-mode";
 import {
@@ -92,7 +93,7 @@ import {
   useIsProtected,
   useViewFilter,
 } from "../plugins/registry";
-import type { PluginContext, ViewContext } from "../plugins/types";
+import type { PluginContext, SlotSpec, ViewContext } from "../plugins/types";
 import { useDragReorder } from "./use-drag-reorder";
 import { consumeFlashAfterNav, flashRow } from "./flash-node";
 import { healProtectedText } from "./protected-text";
@@ -368,6 +369,11 @@ export function OutlineEditor({ rootId }: OutlineEditorProps) {
   // recursive path is the rollback/parity fallback.
   const virtualized = isVirtualized();
   const rows = useVisibleRows(rootId, isHidden, filter);
+  // Mirror `rows` into the selection-fill module (2e-2) so each row's own
+  // `useSelectionFill` read covers its visible descendants, not just a selected
+  // root -- the flat list has no DOM nesting for a root's tint to paint behind
+  // its children. See selection-fill.ts.
+  useSyncSelectionFillRows(rows);
   // scrollMargin = the list container's distance from the document top (header +
   // title above it). Measured per zoom view; the editor remounts on zoom (route
   // key), so a one-shot mount measure is current. listRef is set in the branch
@@ -1336,17 +1342,33 @@ function ZoomedTitle({
   // ADR 0015.
   const protectedNode = useIsProtected(node.id);
 
-  // Plugin slots for the zoomed title (Seam F): the same decorations a list
-  // bullet gets at `row:before-text` -- the daily date badge, the todos checkbox
-  // -- rendered before the text here too. Stable array (precomputed in the
-  // registry). Mirrors OutlineNode's order: slots, then the lock, then the text.
-  const beforeTextSlots = slotsAt("title:before-text");
-
   // Mirror "appears in N places" badge on the zoomed title too (ADR 0022, slice
   // 1d), so a mirrored node shows the chrome whether it's a list bullet or the
   // page title. Session-fixed flag -> no reactive work when mirrors are off.
   const mirrorsOn = isMirrorsEnabled();
   const mirrorCount = useMirrorCount(node.id, mirrorsOn);
+
+  // Plugin slots for the zoomed title (Seam F) plus the two core decorations
+  // (protected lock, mirror badge), in ONE list -- the same composition as
+  // OutlineRow's `row:before-text`, so the two render paths can't drift (see
+  // AGENTS.md "a node renders in TWO paths"). Mirrors OutlineRow's order: slots,
+  // then the lock, then the badge.
+  const beforeTextSlots: SlotSpec[] = [
+    ...slotsAt("title:before-text"),
+    {
+      id: "core:protected-lock",
+      position: "title:before-text",
+      render: () => (protectedNode ? <ProtectedLock size={16} /> : null),
+    },
+    {
+      id: "core:mirror-badge",
+      position: "title:before-text",
+      render: () =>
+        mirrorsOn && mirrorCount > 0 ? (
+          <MirrorBadge sourceId={node.id} count={mirrorCount} />
+        ) : null,
+    },
+  ];
 
   useEffect(() => {
     const el = ref.current;
@@ -1379,10 +1401,6 @@ function ZoomedTitle({
       {beforeTextSlots.map((slot) => (
         <Fragment key={slot.id}>{slot.render(node, getCtx)}</Fragment>
       ))}
-      {protectedNode && <ProtectedLock size={16} />}
-      {mirrorsOn && mirrorCount > 0 && (
-        <MirrorBadge sourceId={node.id} count={mirrorCount} />
-      )}
       <span
         ref={(el) => {
           ref.current = el;

--- a/src/components/OutlineEditor.tsx
+++ b/src/components/OutlineEditor.tsx
@@ -194,8 +194,14 @@ export function OutlineEditor({ rootId }: OutlineEditorProps) {
   // flash pass, and undo/redo (which restore focus where the action left it).
   // The refs are returned so the command closures + drag can write them. See
   // useOutlineFocus.
-  const { refs, registerRef, pendingFocus, pendingFocusAtStart, pendingFlash } =
-    useOutlineFocus();
+  const {
+    refs,
+    registerRef,
+    pendingFocus,
+    pendingFocusAtStart,
+    pendingFlash,
+    findFocusedId,
+  } = useOutlineFocus();
 
   // The list container (recursive <ul> or virtualized <div>), so the drag
   // indicator knows how wide to draw and the window virtualizer can measure its
@@ -286,6 +292,7 @@ export function OutlineEditor({ rootId }: OutlineEditorProps) {
     pendingFocus,
     pendingFocusAtStart,
     pendingFlash,
+    findFocusedId,
     navigateZoom,
     startDrag,
     consumeClick,
@@ -619,6 +626,8 @@ interface OutlineFocus {
   /** Like pendingFocus, but pulses the row's background to mark a just-moved
    *  node (set after a drag/keyboard move). */
   pendingFlash: RefObject<string | null>;
+  /** The focused row's key, reverse-looked-up from the registry (stable). */
+  findFocusedId: () => string | null;
 }
 
 /**
@@ -695,7 +704,14 @@ function useOutlineFocus(): OutlineFocus {
     { preventDefault: true },
   );
 
-  return { refs, registerRef, pendingFocus, pendingFocusAtStart, pendingFlash };
+  return {
+    refs,
+    registerRef,
+    pendingFocus,
+    pendingFocusAtStart,
+    pendingFlash,
+    findFocusedId,
+  };
 }
 
 /**
@@ -922,6 +938,9 @@ interface NodeCommandsArgs {
   pendingFocus: RefObject<string | null>;
   pendingFocusAtStart: RefObject<boolean>;
   pendingFlash: RefObject<string | null>;
+  /** Reverse-lookup of the focused row's key (stable). Caret nav walks from this
+   *  so it addresses the right instance inside a mirror (ADR 0022). */
+  findFocusedId: () => string | null;
   navigateZoom: (toRootId: string | null, pivot: string) => void;
   startDrag: ReturnType<typeof useDragReorder>["startDrag"];
   consumeClick: ReturnType<typeof useDragReorder>["consumeClick"];
@@ -937,6 +956,7 @@ function useNodeCommands({
   pendingFocus,
   pendingFocusAtStart,
   pendingFlash,
+  findFocusedId,
   navigateZoom,
   startDrag,
   consumeClick,
@@ -1060,9 +1080,10 @@ function useNodeCommands({
           const above = findVisibleNeighbor(
             getTreeIndex(),
             getViewRootId(),
-            id,
+            findFocusedId() ?? id,
             "up",
             getViewIsHidden(),
+            isMirrorsEnabled(),
           );
           const focusId = removeNode(getTreeIndex(), id);
           const target = above ?? focusId;
@@ -1102,12 +1123,19 @@ function useNodeCommands({
       },
 
       onMoveFocus: (id, direction, x) => {
+        // Walk from the FOCUSED row's key, not the bare id the keymap passes:
+        // inside a mirror a node id is ambiguous (it renders under every
+        // instance), so only the focused span's key addresses the right row. For
+        // a mirror-free row findFocusedId() === id, so this is unchanged. Fall
+        // back to the passed id when focus is somehow outside the registry.
+        const from = findFocusedId() ?? id;
         const target = findVisibleNeighbor(
           getTreeIndex(),
           getViewRootId(),
-          id,
+          from,
           direction,
           getViewIsHidden(),
+          isMirrorsEnabled(),
         );
         if (!target) return;
         const el = refs.get(target);

--- a/src/components/OutlineEditor.tsx
+++ b/src/components/OutlineEditor.tsx
@@ -44,8 +44,14 @@ import {
   getViewRootId,
   useSyncViewState,
 } from "../data/view-state";
-import { childrenOf, type Node, type TreeIndex } from "../data/tree";
-import { findVisibleNeighbor } from "../data/visible-order";
+import { buildTreeIndex, childrenOf, type Node, type TreeIndex } from "../data/tree";
+import {
+  buildVisibleRows,
+  findVisibleNeighbor,
+  focusKeyAfterEdit,
+  instanceIdForKey,
+} from "../data/visible-order";
+import { nodesCollection } from "../data/collection";
 import { clearSelection } from "../data/selection-state";
 import { placeCaretAtEnd, placeCaretAtStart } from "./caret-place";
 import { SelectionActionsMenu, useSelectionMode } from "./selection-mode";
@@ -933,6 +939,27 @@ function useZoomNavigation({
   return { navigateZoom, pivotId };
 }
 
+/**
+ * The render key to focus after a structural edit, re-derived from the LIVE post-
+ * edit render walk so the focus key can never drift from what's on screen (ADR
+ * 0022, Stage 2c). `instanceId` is the new/moved node; `activeKey` is the row the
+ * user was editing — we return the matching instance's key under the same mirror
+ * anchor, so a child added to a source lands under the mirror you were in (not the
+ * source's far-away copy).
+ *
+ * Off the flag (the 99% path) a node id is unique, so we return it directly and
+ * skip the rebuild entirely. With the flag on we build a fresh index from
+ * `nodesCollection.toArray` — synchronously current after `runStructural`, the
+ * same technique the structural invariant check uses — rather than
+ * `getTreeIndex()`, whose change-notify can lag the optimistic apply.
+ */
+function focusKeyFor(instanceId: string, activeKey: string): string {
+  if (!isMirrorsEnabled()) return instanceId;
+  const index = buildTreeIndex(nodesCollection.toArray as Node[]);
+  const rows = buildVisibleRows(index, getViewRootId(), getViewIsHidden(), null, true);
+  return focusKeyAfterEdit(rows, instanceId, activeKey) ?? instanceId;
+}
+
 interface NodeCommandsArgs {
   refs: Map<string, HTMLSpanElement | null>;
   pendingFocus: RefObject<string | null>;
@@ -973,119 +1000,197 @@ function useNodeCommands({
         setText(id, text);
       },
 
-      onEnter: (id, caretOffset) =>
-        runStructural(() => {
-          const node = getTreeIndex().byId.get(id);
-          if (!node) return;
-          capture(getTreeIndex(), id);
-          const offset = Math.max(0, Math.min(caretOffset, node.text.length));
-          const before = node.text.slice(0, offset);
-          const after = node.text.slice(offset);
-          const caretAtEnd = after.length === 0;
+      onEnter: (id, caretOffset) => {
+        // The new node's id + the row the user was editing, returned from the
+        // batch so the focus key can be re-derived from the post-edit render walk
+        // AFTER it commits (focusKeyFor reads the settled collection).
+        const plan = runStructural(():
+          | { instanceId: string; activeKey: string; atStart: boolean }
+          | null => {
+          // Address the row by its render KEY, not the bare id the keymap passes:
+          // inside a mirror the keymap hands over the CONTENT id, so only the
+          // focused span's key resolves the right instance (ADR 0022, 2b/2c). The
+          // field split (ADR 0022): position (sibling/parent) is LOCAL to the
+          // instance; text + children are the SOURCE's content.
+          const mirrorsOn = isMirrorsEnabled();
+          const activeKey = findFocusedId() ?? id;
+          const instanceId = instanceIdForKey(activeKey);
+          const idx = getTreeIndex();
+          const instance = idx.byId.get(instanceId);
+          if (!instance) return null;
+          const contentId = mirrorsOn
+            ? (instance.mirrorOf ?? instanceId)
+            : instanceId;
+          const content = idx.byId.get(contentId);
+          if (!content) return null;
+          const isMirrorRow = contentId !== instanceId;
+          capture(idx, activeKey);
+          const offset = Math.max(0, Math.min(caretOffset, content.text.length));
+          const before = content.text.slice(0, offset);
+          const after = content.text.slice(offset);
+          // On a mirror's OWN row, Enter never moves text off the source -- the
+          // text is the source's content, so a split would either desync every
+          // instance or strand the tail on a local node. Treat it as the empty-
+          // tail case: add a node, leave the source text whole (ADR 0022, 2c).
+          const caretAtEnd = isMirrorRow || after.length === 0;
           // Pressing Enter at the end of an open (expanded, has-children) bullet
           // adds a child at the top of its list rather than a sibling -- you're
-          // diving into the thing you just finished naming. Anywhere else keeps
-          // the plain new-sibling.
+          // diving into the thing you just finished naming. "Open" reads the
+          // CONTENT's children but the INSTANCE's collapse (collapse is local).
           const isOpen =
-            !node.collapsed && childrenOf(getTreeIndex(), id).length > 0;
+            !instance.collapsed && childrenOf(idx, contentId).length > 0;
+          let newId: string;
+          let atStart = false;
           if (caretAtEnd && isOpen) {
-            pendingFocus.current = insertChildAtStart(
-              getTreeIndex(),
-              id,
-              node.isTask,
+            // Dive in: a child of the CONTENT (source), so the new node windows
+            // into every instance, not just the one being edited.
+            newId = insertChildAtStart(idx, contentId, content.isTask);
+          } else {
+            // New sibling beside the INSTANCE (position is local to where the row
+            // sits). Off-flag / mirror-free, instance === content === id, so this
+            // is byte-identical to the old new-sibling path.
+            newId = insertSibling(
+              idx,
+              instance.parentId,
+              instanceId,
+              content.isTask,
+              isMirrorRow ? "" : after,
             );
-            return;
+            if (!caretAtEnd) {
+              setText(contentId, before);
+              // Caret sits before the moved text, where the split happened.
+              atStart = true;
+            }
           }
-          // Split at the caret: text left of it stays on this node, text to its
-          // right seeds the new sibling. (Caret at the end is just `after === ""`.)
-          const newId = insertSibling(
-            getTreeIndex(),
-            node.parentId,
-            id,
-            node.isTask,
-            after,
-          );
-          if (!caretAtEnd) {
-            setText(id, before);
-            // Caret sits before the moved text, where the split happened.
-            pendingFocusAtStart.current = true;
-          }
-          pendingFocus.current = newId;
-        }),
+          return { instanceId: newId, activeKey, atStart };
+        });
+        if (plan) {
+          pendingFocus.current = focusKeyFor(plan.instanceId, plan.activeKey);
+          pendingFocusAtStart.current = plan.atStart;
+        }
+      },
 
-      onIndent: (id) =>
-        runStructural(() => {
-          // Moving the node reparents it into a different <ul>, which remounts
-          // its contentEditable and drops focus. Re-focus it after the render.
-          capture(getTreeIndex(), id);
-          if (indent(getTreeIndex(), id)) {
-            pendingFocus.current = id;
-            pendingFlash.current = id;
-          } else drop(); // no move happened; discard the redundant undo point
-        }),
+      onIndent: (id) => {
+        const plan = runStructural((): { instanceId: string; activeKey: string } | null => {
+          // Indent reorders the INSTANCE (position is local, ADR 0022). Inside a
+          // mirror the windowed children are real source nodes, so this restructures
+          // the source and shows in every instance; on a mirror's own row it moves
+          // that mirror, not the source. Address by the focused row's key (the
+          // keymap passes the content id inside a mirror).
+          const activeKey = findFocusedId() ?? id;
+          const instanceId = instanceIdForKey(activeKey);
+          // Moving the node reparents it, which drops focus. Re-focus after render.
+          capture(getTreeIndex(), activeKey);
+          if (indent(getTreeIndex(), instanceId)) return { instanceId, activeKey };
+          drop(); // no move happened; discard the redundant undo point
+          return null;
+        });
+        if (plan) {
+          const key = focusKeyFor(plan.instanceId, plan.activeKey);
+          pendingFocus.current = key;
+          pendingFlash.current = key;
+        }
+      },
 
-      onOutdent: (id) =>
-        runStructural(() => {
+      onOutdent: (id) => {
+        const plan = runStructural((): { instanceId: string; activeKey: string } | null => {
+          const activeKey = findFocusedId() ?? id;
+          const instanceId = instanceIdForKey(activeKey);
           // Don't let a direct child of the zoom root outdent past it; that
           // would move it out of the visible subtree and look like it vanished.
-          const node = getTreeIndex().byId.get(id);
-          if (node && node.parentId === getViewRootId()) return;
+          const node = getTreeIndex().byId.get(instanceId);
+          if (node && node.parentId === getViewRootId()) return null;
           // Same remount-drops-focus issue as indent; re-focus on a real move.
-          capture(getTreeIndex(), id);
-          if (outdent(getTreeIndex(), id)) {
-            pendingFocus.current = id;
-            pendingFlash.current = id;
-          } else drop();
-        }),
+          capture(getTreeIndex(), activeKey);
+          if (outdent(getTreeIndex(), instanceId)) return { instanceId, activeKey };
+          drop();
+          return null;
+        });
+        if (plan) {
+          const key = focusKeyFor(plan.instanceId, plan.activeKey);
+          pendingFocus.current = key;
+          pendingFlash.current = key;
+        }
+      },
 
-      onMoveUp: (id) =>
-        runStructural(() => {
+      onMoveUp: (id) => {
+        const plan = runStructural((): { instanceId: string; activeKey: string } | null => {
+          // Move reorders the INSTANCE (position is local, ADR 0022); address by
+          // the focused key so a mirror moves itself, not its source.
+          const activeKey = findFocusedId() ?? id;
+          const instanceId = instanceIdForKey(activeKey);
           // Reorder/outdent remounts the contentEditable; re-focus on a real move.
-          capture(getTreeIndex(), id);
-          const moved = moveUp(getTreeIndex(), id, {
+          capture(getTreeIndex(), activeKey);
+          const moved = moveUp(getTreeIndex(), instanceId, {
             isVisible: (n) => !getViewIsHidden()(n),
             rootId: getViewRootId(),
           });
-          if (moved) {
-            pendingFocus.current = id;
-            pendingFlash.current = id;
-          } else drop();
-        }),
+          if (moved) return { instanceId, activeKey };
+          drop();
+          return null;
+        });
+        if (plan) {
+          const key = focusKeyFor(plan.instanceId, plan.activeKey);
+          pendingFocus.current = key;
+          pendingFlash.current = key;
+        }
+      },
 
-      onMoveDown: (id) =>
-        runStructural(() => {
-          capture(getTreeIndex(), id);
-          const moved = moveDown(getTreeIndex(), id, {
+      onMoveDown: (id) => {
+        const plan = runStructural((): { instanceId: string; activeKey: string } | null => {
+          const activeKey = findFocusedId() ?? id;
+          const instanceId = instanceIdForKey(activeKey);
+          capture(getTreeIndex(), activeKey);
+          const moved = moveDown(getTreeIndex(), instanceId, {
             isVisible: (n) => !getViewIsHidden()(n),
             rootId: getViewRootId(),
           });
-          if (moved) {
-            pendingFocus.current = id;
-            pendingFlash.current = id;
-          } else drop();
-        }),
+          if (moved) return { instanceId, activeKey };
+          drop();
+          return null;
+        });
+        if (plan) {
+          const key = focusKeyFor(plan.instanceId, plan.activeKey);
+          pendingFocus.current = key;
+          pendingFlash.current = key;
+        }
+      },
 
       onDeleteNode: (id) =>
         runStructural(() => {
+          // Delete the INSTANCE (position is local, ADR 0022): backspacing a
+          // mirror's own row removes that mirror, never its source (which would
+          // strand the other instances -- promote-on-source-delete is Stage 3).
+          // Address by the focused key; the keymap passes the content id in a
+          // mirror.
+          const activeKey = findFocusedId() ?? id;
+          const instanceId = instanceIdForKey(activeKey);
+          const idx = getTreeIndex();
+          const mirrorsOn = isMirrorsEnabled();
+          const contentId = mirrorsOn
+            ? (idx.byId.get(instanceId)?.mirrorOf ?? instanceId)
+            : instanceId;
           // A protected node can't be deleted. This is the single funnel every
           // delete path flows through, so the core enforces it here: shake the
           // row + toast why (guardProtected), and bail before removing anything.
-          // The node isn't removed, so its row still exists.
-          if (guardProtected(id, "delete", rowOf(id))) return;
-          capture(getTreeIndex(), id);
+          // Protection follows CONTENT (the source); the shake lands on the row
+          // the user acted on (the active key). The node isn't removed, so its
+          // row still exists.
+          if (guardProtected(contentId, "delete", rowOf(activeKey))) return;
+          capture(idx, activeKey);
           // Focus the row directly ABOVE the deleted one (Workflowy backspace
           // behavior), computed before the mutation so the neighbor still
           // exists. Fall back to removeNode's structural pick (next sibling /
           // parent) only when nothing is above -- the first visible row.
           const above = findVisibleNeighbor(
-            getTreeIndex(),
+            idx,
             getViewRootId(),
-            findFocusedId() ?? id,
+            activeKey,
             "up",
             getViewIsHidden(),
-            isMirrorsEnabled(),
+            mirrorsOn,
           );
-          const focusId = removeNode(getTreeIndex(), id);
+          const focusId = removeNode(idx, instanceId);
           const target = above ?? focusId;
           if (target) pendingFocus.current = target;
           else drop(); // node didn't exist; nothing was deleted

--- a/src/components/OutlineEditor.tsx
+++ b/src/components/OutlineEditor.tsx
@@ -27,13 +27,15 @@ import { ChevronRight, HomeIcon, MoreHorizontal, PlusIcon } from "lucide-react";
 import {
   getTreeIndex,
   useHasNodes,
+  useMirrorCount,
   useNode,
   useTrail,
   useTreeIndex,
   useVisibleChildIds,
   useVisibleRows,
 } from "../data/tree-store";
-import { isVirtualized } from "../data/flags";
+import { isMirrorsEnabled, isVirtualized } from "../data/flags";
+import { MirrorBadge } from "./mirror-chrome";
 import { scrollRowIntoView, setVirtualNav } from "../data/virtual-nav";
 import { OutlineRow } from "./OutlineRow";
 import { exposeHotkeyManagerForDev } from "./hotkey-devtools";
@@ -1176,6 +1178,12 @@ function ZoomedTitle({
   // registry). Mirrors OutlineNode's order: slots, then the lock, then the text.
   const beforeTextSlots = slotsAt("title:before-text");
 
+  // Mirror "appears in N places" badge on the zoomed title too (ADR 0022, slice
+  // 1d), so a mirrored node shows the chrome whether it's a list bullet or the
+  // page title. Session-fixed flag -> no reactive work when mirrors are off.
+  const mirrorsOn = isMirrorsEnabled();
+  const mirrorCount = useMirrorCount(node.id, mirrorsOn);
+
   useEffect(() => {
     const el = ref.current;
     if (!el || composingRef.current) return;
@@ -1208,6 +1216,9 @@ function ZoomedTitle({
         <Fragment key={slot.id}>{slot.render(node, getCtx)}</Fragment>
       ))}
       {protectedNode && <ProtectedLock size={16} />}
+      {mirrorsOn && mirrorCount > 0 && (
+        <MirrorBadge sourceId={node.id} count={mirrorCount} />
+      )}
       <span
         ref={(el) => {
           ref.current = el;

--- a/src/components/OutlineNode.tsx
+++ b/src/components/OutlineNode.tsx
@@ -269,6 +269,9 @@ function OutlineNodeBody({
   // menu is open so the menu owns Arrow/Enter/Tab/Esc. See use-bullet-keymap.ts.
   useBulletKeymap({
     node,
+    // Flag-off recursive path: no mirrors, so instance === content === node.
+    instanceId: node.id,
+    instanceCollapsed: node.collapsed,
     textRef,
     commands,
     pluginCtx,

--- a/src/components/OutlineNode.tsx
+++ b/src/components/OutlineNode.tsx
@@ -83,6 +83,9 @@ export interface NodeCommands {
   onSetTask: (id: string, isTask: boolean) => void;
   // Open the `/move` destination picker for this bullet.
   onRequestMove: (id: string) => void;
+  // Open the `/mirror` destination picker for this bullet (ADR 0022): same
+  // picker, but a pick creates a live mirror under the destination.
+  onRequestMirror: (id: string) => void;
   onToggleCollapsed: (id: string, collapsed: boolean) => void;
   // `x` is the caret's viewport x at the moment of the keypress, so the
   // landing node can drop the caret at the same column. Omitted when there's

--- a/src/components/OutlineRow.tsx
+++ b/src/components/OutlineRow.tsx
@@ -9,7 +9,11 @@ import {
 import { ChevronRight } from "lucide-react";
 import type { Node } from "../data/schema";
 import type { TagFilter } from "../data/tags";
-import { useMirrorCount, useNode, useVisibleChildIds } from "../data/tree-store";
+import {
+  useMirrorCount,
+  useNode,
+  useVisibleChildIds,
+} from "../data/tree-store";
 import { echoedTextFor } from "../data/collection";
 import { isMirrorsEnabled } from "../data/flags";
 import { MirrorBadge } from "./mirror-chrome";
@@ -331,7 +335,13 @@ function RowChrome({
       data-parent-id={instance.parentId ?? undefined}
       data-depth={depth}
       data-mirror={
-        isMirror ? (capped ? "capped" : "instance") : isSource ? "source" : undefined
+        isMirror
+          ? capped
+            ? "capped"
+            : "instance"
+          : isSource
+            ? "source"
+            : undefined
       }
       data-selected={selectionEdge ?? undefined}
       data-index={index}
@@ -364,7 +374,10 @@ function RowChrome({
           type="button"
           className="bullet touch-hitbox"
           aria-label="Zoom in"
-          onPointerDown={(e) => commands.onBulletPointerDown(instance.id, e)}
+          // Drag arms with the row KEY so a windowed copy inside a mirror is the
+          // exact instance grabbed, never its source copy (ADR 0022). key === id
+          // off the flag / outside a mirror.
+          onPointerDown={(e) => commands.onBulletPointerDown(rowKey, e)}
           // A mirror's bullet zooms to the SOURCE (content.id) -- you land on the
           // real node to work its subtree. For a normal row content.id ===
           // instance.id, so this is today's behavior.

--- a/src/components/OutlineRow.tsx
+++ b/src/components/OutlineRow.tsx
@@ -50,9 +50,31 @@ export const INDENT_PX = 24;
  * This intentionally duplicates OutlineNode's bullet during the flag window so
  * the recursive baseline stays untouched for e2e parity; the recursive path is
  * deleted (and this becomes the only row) when the flag flips.
+ *
+ * Mirrors (ADR 0022) split a row's identity in two: {@link nodeId} is the
+ * INSTANCE (where the row physically sits -- its `parentId`, `collapsed`, drag
+ * target, selection edge), {@link contentId} is the CONTENT (`text`, `isTask`,
+ * `completed`, children). For a normal row they're equal and the row takes the
+ * single-`useNode` fast path; only a mirror subscribes to both. The split is
+ * inert while the mirrors flag is off (every row arrives with `contentId === id`,
+ * `isMirror` false), so the 99% outline runs exactly today's code.
  */
 export interface OutlineRowProps {
+  // The INSTANCE node id (row.id) -- where this row physically sits. Drives
+  // position, collapse, drag, selection, focus/flash claiming.
   nodeId: string;
+  // The CONTENT node id (row.contentId): `mirrorOf ?? id`. Equal to nodeId for
+  // every normal row; the source's id for a mirror. Drives text/task/completed
+  // and the windowed children.
+  contentId: string;
+  // This row IS a mirror (its own `mirrorOf` is set). When false, nodeId ===
+  // contentId and the row takes the single-subscription path.
+  isMirror: boolean;
+  // A mirror whose source is an expanded ancestor on this path (a cycle): render
+  // the row but non-expandable, so the walk can't loop (ADR 0022).
+  capped: boolean;
+  // A mirror whose source resolves to no node: render a "source missing" leaf.
+  broken: boolean;
   // Depth relative to the zoom root (direct child of the root = 0). Drives the
   // left indent. Comes from the flat list, stable per id until structure shifts.
   depth: number;
@@ -80,17 +102,66 @@ export interface OutlineRowProps {
   measureRef: (el: HTMLLIElement | null) => void;
 }
 
-export const OutlineRow = memo(function OutlineRow({
-  nodeId,
-  ...rest
-}: OutlineRowProps) {
-  const node = useNode(nodeId);
-  if (!node) return null;
-  return <OutlineRowBody node={node} {...rest} />;
+export const OutlineRow = memo(function OutlineRow(props: OutlineRowProps) {
+  // Mirror split happens at the hook boundary (rules of hooks forbid a
+  // conditional `useNode`): a mirror subscribes to two nodes, a normal row to
+  // one. Both funnel into the same {@link RowChrome}.
+  return props.isMirror ? <MirrorRow {...props} /> : <NormalRow {...props} />;
 });
 
-function OutlineRowBody({
-  node,
+/** The mirror-free fast path: a single subscription, content === instance.
+ *  Byte-identical to the pre-mirror row. */
+function NormalRow({ nodeId, ...rest }: OutlineRowProps) {
+  const node = useNode(nodeId);
+  if (!node) return null;
+  return <RowChrome instance={node} content={node} {...rest} />;
+}
+
+/** A mirror: the instance (position) and the content (source) are different
+ *  nodes, so it subscribes to both. A missing source renders a leaf. */
+function MirrorRow({ nodeId, contentId, broken, ...rest }: OutlineRowProps) {
+  const instance = useNode(nodeId);
+  const content = useNode(contentId);
+  if (!instance) return null;
+  if (broken || !content) {
+    return (
+      <MirrorMissingRow
+        instance={instance}
+        depth={rest.depth}
+        index={rest.index}
+        start={rest.start}
+        scrollMargin={rest.scrollMargin}
+        measureRef={rest.measureRef}
+      />
+    );
+  }
+  return <RowChrome instance={instance} content={content} {...rest} />;
+}
+
+type RowChromeProps = Omit<
+  OutlineRowProps,
+  "nodeId" | "contentId" | "broken"
+> & {
+  /** The position node (parentId/collapsed/drag/selection live here). */
+  instance: Node;
+  /** The content node (text/isTask/completed/children live here). */
+  content: Node;
+};
+
+/**
+ * The shared row body. Reads CONTENT from `content` (`mirrorOf ?? id`) and
+ * POSITION from `instance` (the node id). For a normal row the two are the same
+ * object, so nothing about the mirror-free path changes; for a mirror the text/
+ * children/completed come from the source while collapse/drag/zoom/selection
+ * stay on the instance (ADR 0022). Editing the mirror's text writes the SOURCE
+ * (`commands.onTextChange(content.id, ...)`), which is how an edit in one place
+ * shows up everywhere. Full caret/focus/drag parity inside a mirror is Stage 2.
+ */
+function RowChrome({
+  instance,
+  content,
+  isMirror,
+  capped,
   depth,
   ancestorCompleted,
   commands,
@@ -106,43 +177,49 @@ function OutlineRowBody({
   start,
   scrollMargin,
   measureRef,
-}: Omit<OutlineRowProps, "nodeId"> & { node: Node }) {
+}: RowChromeProps) {
   const textRef = useRef<HTMLSpanElement | null>(null);
   const syncedRef = useRef<string | null>(null);
   const composingRef = useRef(false);
   const caretWatchRef = useRef<(() => void) | null>(null);
 
-  // Direct visible children only -- drives the collapse chevron + collapsed dot.
-  // No recursion: the flat list already holds the descendants as their own rows.
+  // Direct visible children of the CONTENT -- a mirror windows its source's
+  // subtree, so the chevron + collapsed dot follow the source's children. No
+  // recursion: the flat list already holds the descendants as their own rows.
   // With windowing only ~viewport rows call this, so the per-parent fan-out the
   // recursive path paid is gone.
-  const childIds = useVisibleChildIds(node.id, isHidden);
+  const childIds = useVisibleChildIds(content.id, isHidden);
   // Only the boolean is needed here (a leaf row has no children list to pass
-  // down), so test emptiness without materializing the filtered array.
-  const hasChildren = filter
-    ? childIds.some((id) => filter.visibleIds.has(id))
-    : childIds.length > 0;
-  const effectiveCollapsed = filter ? false : node.collapsed;
-  const isContext = filter ? !filter.matchIds.has(node.id) : false;
-  const isPivot = node.id === pivotId;
-  const faded = node.completed || ancestorCompleted;
+  // down), so test emptiness without materializing the filtered array. A capped
+  // mirror is never expandable (it would loop), so it shows no chevron.
+  const hasChildren = capped
+    ? false
+    : filter
+      ? childIds.some((id) => filter.visibleIds.has(id))
+      : childIds.length > 0;
+  // Collapse is LOCAL to the instance (a mirror collapsed here leaves the source
+  // open elsewhere); fade/match/pivot follow the CONTENT.
+  const effectiveCollapsed = filter ? false : instance.collapsed;
+  const isContext = filter ? !filter.matchIds.has(content.id) : false;
+  const isPivot = content.id === pivotId;
+  const faded = content.completed || ancestorCompleted;
 
   const slash = useSlashMenu({
-    node,
+    node: content,
     ctx: pluginCtx,
     getEl: () => textRef.current,
-    onTextChange: (text) => commands.onTextChange(node.id, text),
+    onTextChange: (text) => commands.onTextChange(content.id, text),
   });
 
   const beforeTextSlots = slotsAt("row:before-text");
-  const protectedNode = useIsProtected(node.id);
-  const selectionEdge = useSelectionEdge(node.id);
+  const protectedNode = useIsProtected(content.id);
+  const selectionEdge = useSelectionEdge(instance.id);
 
   const menus = useMenus({
-    node,
+    node: content,
     getEl: () => textRef.current,
     ctx: pluginCtx,
-    onTextChange: (text) => commands.onTextChange(node.id, text),
+    onTextChange: (text) => commands.onTextChange(content.id, text),
   });
 
   // Mount: seed the span's text synchronously before paint (mirrors OutlineNode;
@@ -150,8 +227,8 @@ function OutlineRowBody({
   useLayoutEffect(() => {
     const el = textRef.current;
     if (!el) return;
-    decorate(el, node.text, null, false);
-    syncedRef.current = node.text;
+    decorate(el, content.text, null, false);
+    syncedRef.current = content.text;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -159,18 +236,19 @@ function OutlineRowBody({
   // FocusPass handles rows already mounted at tree-change time; this handles a
   // row that mounts because we scrolled it into view (scrollRowIntoView), which
   // FocusPass never sees (a scroll isn't a tree change). Runs after the seed
-  // effect above, so the caret lands on populated text.
+  // effect above, so the caret lands on populated text. Keyed by the INSTANCE id
+  // (pendingFocus carries position ids, set by the commands).
   useLayoutEffect(() => {
     const el = textRef.current;
     if (!el) return;
-    if (pendingFocus.current === node.id) {
+    if (pendingFocus.current === instance.id) {
       el.focus();
       if (pendingFocusAtStart.current) placeCaretAtStart(el);
       else placeCaretAtEnd(el);
       pendingFocus.current = null;
       pendingFocusAtStart.current = false;
     }
-    if (pendingFlash.current === node.id) {
+    if (pendingFlash.current === instance.id) {
       flashRow(el.closest(".outline-row"));
       pendingFlash.current = null;
     }
@@ -179,18 +257,22 @@ function OutlineRowBody({
 
   // Push store text into the contentEditable when it changes from something
   // other than this bullet's own typing (undo, programmatic setText, a genuine
-  // echo). Identical to OutlineNode -- see there for the focused-skip rationale.
+  // echo, OR a sibling instance of the same source editing it -- the live mirror
+  // sync). Identical to OutlineNode -- see there for the focused-skip rationale.
   useEffect(() => {
     const el = textRef.current;
     if (!el || composingRef.current) return;
-    if (syncedRef.current === node.text) return;
-    if (document.activeElement === el && echoedTextFor(node.id) === node.text) {
+    if (syncedRef.current === content.text) return;
+    if (
+      document.activeElement === el &&
+      echoedTextFor(content.id) === content.text
+    ) {
       return;
     }
     const focused = document.activeElement === el;
     const revealOffset = focused ? getCaretOffset(el) : null;
-    decorate(el, node.text, revealOffset, focused);
-    syncedRef.current = node.text;
+    decorate(el, content.text, revealOffset, focused);
+    syncedRef.current = content.text;
   });
 
   // Unmount: tear down the caret-reveal watcher if it's still live. onBlur clears
@@ -205,7 +287,7 @@ function OutlineRowBody({
   }, []);
 
   useBulletKeymap({
-    node,
+    node: content,
     textRef,
     commands,
     pluginCtx,
@@ -216,9 +298,10 @@ function OutlineRowBody({
   return (
     <li
       className="outline-node"
-      data-node-id={node.id}
-      data-parent-id={node.parentId ?? undefined}
+      data-node-id={instance.id}
+      data-parent-id={instance.parentId ?? undefined}
       data-depth={depth}
+      data-mirror={isMirror ? (capped ? "capped" : "instance") : undefined}
       data-selected={selectionEdge ?? undefined}
       data-index={index}
       ref={measureRef}
@@ -239,7 +322,8 @@ function OutlineRowBody({
           data-has-children={hasChildren}
           data-collapsed={effectiveCollapsed}
           onClick={() =>
-            hasChildren && commands.onToggleCollapsed(node.id, !node.collapsed)
+            hasChildren &&
+            commands.onToggleCollapsed(instance.id, !instance.collapsed)
           }
           tabIndex={-1}
         >
@@ -249,49 +333,52 @@ function OutlineRowBody({
           type="button"
           className="bullet touch-hitbox"
           aria-label="Zoom in"
-          onPointerDown={(e) => commands.onBulletPointerDown(node.id, e)}
-          onClick={() => commands.onBulletClick(node.id)}
+          onPointerDown={(e) => commands.onBulletPointerDown(instance.id, e)}
+          // A mirror's bullet zooms to the SOURCE (content.id) -- you land on the
+          // real node to work its subtree. For a normal row content.id ===
+          // instance.id, so this is today's behavior.
+          onClick={() => commands.onBulletClick(content.id)}
           title="Zoom in"
         >
           <span
             className="bullet-dot"
-            data-completed={node.completed}
+            data-completed={content.completed}
             data-has-children={hasChildren}
             data-collapsed={effectiveCollapsed}
           />
         </button>
         {beforeTextSlots.map((slot) => (
-          <Fragment key={slot.id}>{slot.render(node, pluginCtx)}</Fragment>
+          <Fragment key={slot.id}>{slot.render(content, pluginCtx)}</Fragment>
         ))}
         {protectedNode && <ProtectedLock size={12} />}
         <span
           ref={(el) => {
             textRef.current = el;
-            registerRef(node.id, el);
+            registerRef(instance.id, el);
           }}
           className={`node-text${isPivot ? " vt-morph" : ""}`}
           style={isPivot ? { viewTransitionName: "zoom-target" } : undefined}
           contentEditable
           suppressContentEditableWarning
           spellCheck={false}
-          aria-label={node.text.trim() || "Empty bullet"}
+          aria-label={content.text.trim() || "Empty bullet"}
           aria-multiline="true"
-          data-completed={node.completed}
+          data-completed={content.completed}
           onInput={(e) => {
             const el = e.currentTarget;
             const text = readSource(el);
             if (!composingRef.current) {
-              const af = autoformat({ text, node });
+              const af = autoformat({ text, node: content });
               if (af) {
                 af.before?.(pluginCtx());
-                commands.onTextChange(node.id, af.text);
+                commands.onTextChange(content.id, af.text);
                 decorate(el, af.text, af.caret, false);
                 syncedRef.current = af.text;
                 setCaretOffset(el, af.caret);
                 return;
               }
             }
-            commands.onTextChange(node.id, text);
+            commands.onTextChange(content.id, text);
             slash.handleInput();
             menus.handleInput();
             if (!composingRef.current) {
@@ -306,14 +393,14 @@ function OutlineRowBody({
             composingRef.current = false;
             const el = e.currentTarget;
             const text = readSource(el);
-            commands.onTextChange(node.id, text);
+            commands.onTextChange(content.id, text);
             decorate(el, text, getCaretOffset(el), true);
             syncedRef.current = text;
           }}
           onPaste={(e) => {
             const el = e.currentTarget;
-            const next = pasteIntoBullet(e, el, node.id, pluginCtx, (t) =>
-              commands.onTextChange(node.id, t),
+            const next = pasteIntoBullet(e, el, content.id, pluginCtx, (t) =>
+              commands.onTextChange(content.id, t),
             );
             if (next !== null) syncedRef.current = next;
           }}
@@ -325,9 +412,9 @@ function OutlineRowBody({
               el,
               () => composingRef.current,
             );
-            if (!hasLink(node.text)) return;
-            revealLinkAtCaret(el, node.text, () => {
-              syncedRef.current = node.text;
+            if (!hasLink(content.text)) return;
+            revealLinkAtCaret(el, content.text, () => {
+              syncedRef.current = content.text;
             });
           }}
           onBlur={(e) => {
@@ -337,7 +424,7 @@ function OutlineRowBody({
             caretWatchRef.current = null;
             const el = e.currentTarget;
             const text = readSource(el);
-            const restored = healProtectedText(node.id, text, el);
+            const restored = healProtectedText(content.id, text, el);
             if (restored !== null) {
               syncedRef.current = restored;
             } else if (hasLink(text)) {
@@ -352,6 +439,58 @@ function OutlineRowBody({
         />
         {slash.menu}
         {menus.menu}
+      </div>
+    </li>
+  );
+}
+
+/**
+ * A mirror whose source resolves to no node (ADR 0022): render a non-editable
+ * "source missing" leaf in the instance's position, never recurse, never throw.
+ * Kept deliberately bare for slice 1b -- the richer broken-mirror chrome (a jump
+ * affordance, distinct styling) lands with the rest of the mirror chrome.
+ */
+function MirrorMissingRow({
+  instance,
+  depth,
+  index,
+  start,
+  scrollMargin,
+  measureRef,
+}: {
+  instance: Node;
+  depth: number;
+  index: number;
+  start: number;
+  scrollMargin: number;
+  measureRef: (el: HTMLLIElement | null) => void;
+}) {
+  return (
+    <li
+      className="outline-node"
+      data-node-id={instance.id}
+      data-parent-id={instance.parentId ?? undefined}
+      data-depth={depth}
+      data-mirror="broken"
+      data-index={index}
+      ref={measureRef}
+      style={{
+        position: "absolute",
+        top: 0,
+        left: 0,
+        width: "100%",
+        transform: `translateY(${start - scrollMargin}px)`,
+        paddingInlineStart: depth * INDENT_PX,
+      }}
+    >
+      <div className="outline-row" data-faded={true}>
+        <span className="collapse-toggle touch-hitbox" aria-hidden="true" />
+        <span className="bullet touch-hitbox" aria-hidden="true">
+          <span className="bullet-dot" data-broken="true" />
+        </span>
+        <span className="node-text" aria-label="Mirror source not found">
+          Mirror (source not found)
+        </span>
       </div>
     </li>
   );

--- a/src/components/OutlineRow.tsx
+++ b/src/components/OutlineRow.tsx
@@ -9,8 +9,10 @@ import {
 import { ChevronRight } from "lucide-react";
 import type { Node } from "../data/schema";
 import type { TagFilter } from "../data/tags";
-import { useNode, useVisibleChildIds } from "../data/tree-store";
+import { useMirrorCount, useNode, useVisibleChildIds } from "../data/tree-store";
 import { echoedTextFor } from "../data/collection";
+import { isMirrorsEnabled } from "../data/flags";
+import { MirrorBadge } from "./mirror-chrome";
 import type { PluginContext } from "../plugins/types";
 import { autoformat, slotsAt, useIsProtected } from "../plugins/registry";
 import { clearSelection, useSelectionEdge } from "../data/selection-state";
@@ -214,6 +216,13 @@ function RowChrome({
   const beforeTextSlots = slotsAt("row:before-text");
   const protectedNode = useIsProtected(content.id);
   const selectionEdge = useSelectionEdge(instance.id);
+  // Mirror chrome (ADR 0022, slice 1d). The count is the same for the source row
+  // and every instance (they share the content id), so the "appears in N places"
+  // badge shows on all of them. `mirrorsOn` is session-fixed, so the hook adds no
+  // reactive work when the flag is off (useMirrorCount short-circuits).
+  const mirrorsOn = isMirrorsEnabled();
+  const mirrorCount = useMirrorCount(content.id, mirrorsOn);
+  const isSource = !isMirror && mirrorCount > 0;
 
   const menus = useMenus({
     node: content,
@@ -301,7 +310,9 @@ function RowChrome({
       data-node-id={instance.id}
       data-parent-id={instance.parentId ?? undefined}
       data-depth={depth}
-      data-mirror={isMirror ? (capped ? "capped" : "instance") : undefined}
+      data-mirror={
+        isMirror ? (capped ? "capped" : "instance") : isSource ? "source" : undefined
+      }
       data-selected={selectionEdge ?? undefined}
       data-index={index}
       ref={measureRef}
@@ -351,6 +362,9 @@ function RowChrome({
           <Fragment key={slot.id}>{slot.render(content, pluginCtx)}</Fragment>
         ))}
         {protectedNode && <ProtectedLock size={12} />}
+        {mirrorsOn && mirrorCount > 0 && (
+          <MirrorBadge sourceId={content.id} count={mirrorCount} />
+        )}
         <span
           ref={(el) => {
             textRef.current = el;

--- a/src/components/OutlineRow.tsx
+++ b/src/components/OutlineRow.tsx
@@ -63,8 +63,13 @@ export const INDENT_PX = 24;
  */
 export interface OutlineRowProps {
   // The INSTANCE node id (row.id) -- where this row physically sits. Drives
-  // position, collapse, drag, selection, focus/flash claiming.
+  // position, collapse, drag, selection.
   nodeId: string;
+  // The render ADDRESS (row.key): the refs/focus/flash key. A bare id until the
+  // walk crosses a mirror, then a path key, so a source descendant rendered under
+  // two instances registers two distinct spans (ADR 0022). Equals nodeId for
+  // every mirror-free row, so the 99% outline keeps today's identity.
+  rowKey: string;
   // The CONTENT node id (row.contentId): `mirrorOf ?? id`. Equal to nodeId for
   // every normal row; the source's id for a mirror. Drives text/task/completed
   // and the windowed children.
@@ -162,6 +167,7 @@ type RowChromeProps = Omit<
 function RowChrome({
   instance,
   content,
+  rowKey,
   isMirror,
   capped,
   depth,
@@ -245,19 +251,20 @@ function RowChrome({
   // FocusPass handles rows already mounted at tree-change time; this handles a
   // row that mounts because we scrolled it into view (scrollRowIntoView), which
   // FocusPass never sees (a scroll isn't a tree change). Runs after the seed
-  // effect above, so the caret lands on populated text. Keyed by the INSTANCE id
-  // (pendingFocus carries position ids, set by the commands).
+  // effect above, so the caret lands on populated text. Keyed by the row KEY
+  // (the render address) so the right instance claims it when a source descendant
+  // is windowed under two mirrors; key === id for a mirror-free row (ADR 0022).
   useLayoutEffect(() => {
     const el = textRef.current;
     if (!el) return;
-    if (pendingFocus.current === instance.id) {
+    if (pendingFocus.current === rowKey) {
       el.focus();
       if (pendingFocusAtStart.current) placeCaretAtStart(el);
       else placeCaretAtEnd(el);
       pendingFocus.current = null;
       pendingFocusAtStart.current = false;
     }
-    if (pendingFlash.current === instance.id) {
+    if (pendingFlash.current === rowKey) {
       flashRow(el.closest(".outline-row"));
       pendingFlash.current = null;
     }
@@ -368,7 +375,7 @@ function RowChrome({
         <span
           ref={(el) => {
             textRef.current = el;
-            registerRef(instance.id, el);
+            registerRef(rowKey, el);
           }}
           className={`node-text${isPivot ? " vt-morph" : ""}`}
           style={isPivot ? { viewTransitionName: "zoom-target" } : undefined}

--- a/src/components/OutlineRow.tsx
+++ b/src/components/OutlineRow.tsx
@@ -206,10 +206,19 @@ function RowChrome({
       ? childIds.some((id) => filter.visibleIds.has(id))
       : childIds.length > 0;
   // Collapse is LOCAL to the instance (a mirror collapsed here leaves the source
-  // open elsewhere); fade/match/pivot follow the CONTENT.
+  // open elsewhere); fade/match follow the CONTENT.
   const effectiveCollapsed = filter ? false : instance.collapsed;
   const isContext = filter ? !filter.matchIds.has(content.id) : false;
-  const isPivot = content.id === pivotId;
+  // The zoom morph (`view-transition-name: zoom-target`) must name exactly ONE
+  // element -- the browser aborts the transition on a duplicate name. pivotId is
+  // a node id, but it addresses the row by KEY, not content: a source and every
+  // mirror of it share a content id, so `content.id === pivotId` would tag the
+  // source's own row AND each visible mirror row at once (a persistent duplicate
+  // that crashes the next zoom). rowKey is per-instance, so only the source's own
+  // canonical row (key === id) morphs; mirror rows carry path/instance keys and
+  // never collide. For a mirror-free row key === id === content.id, so the 99%
+  // path is byte-identical (ADR 0022).
+  const isPivot = rowKey === pivotId;
   const faded = content.completed || ancestorCompleted;
 
   const slash = useSlashMenu({
@@ -304,6 +313,10 @@ function RowChrome({
 
   useBulletKeymap({
     node: content,
+    // Collapse is local to the instance (mirrors the chevron, ADR 0022); the
+    // rest of the keymap re-resolves the instance from the focused key.
+    instanceId: instance.id,
+    instanceCollapsed: instance.collapsed,
     textRef,
     commands,
     pluginCtx,

--- a/src/components/OutlineRow.tsx
+++ b/src/components/OutlineRow.tsx
@@ -17,9 +17,10 @@ import {
 import { echoedTextFor } from "../data/collection";
 import { isMirrorsEnabled } from "../data/flags";
 import { MirrorBadge } from "./mirror-chrome";
-import type { PluginContext } from "../plugins/types";
+import type { PluginContext, SlotSpec } from "../plugins/types";
 import { autoformat, slotsAt, useIsProtected } from "../plugins/registry";
-import { clearSelection, useSelectionEdge } from "../data/selection-state";
+import { clearSelection } from "../data/selection-state";
+import { useSelectionFill } from "../data/selection-fill";
 import { useSlashMenu } from "./slash-menu";
 import { useMenus } from "./menu-engine";
 import { useBulletKeymap } from "./use-bullet-keymap";
@@ -232,9 +233,13 @@ function RowChrome({
     onTextChange: (text) => commands.onTextChange(content.id, text),
   });
 
-  const beforeTextSlots = slotsAt("row:before-text");
   const protectedNode = useIsProtected(content.id);
-  const selectionEdge = useSelectionEdge(instance.id);
+  // Covers this row AND its visible descendants (2e-2) -- unlike the recursive
+  // path's useSelectionEdge, the flat list has no DOM nesting for a root's tint
+  // to paint behind its children, so every covered row reads its own value.
+  // Keyed by rowKey (the render address), not instance.id, so a windowed mirror
+  // descendant and its source's canonical row are independent reads.
+  const selectionFill = useSelectionFill(rowKey);
   // Mirror chrome (ADR 0022, slice 1d). The count is the same for the source row
   // and every instance (they share the content id), so the "appears in N places"
   // badge shows on all of them. `mirrorsOn` is session-fixed, so the hook adds no
@@ -242,6 +247,27 @@ function RowChrome({
   const mirrorsOn = isMirrorsEnabled();
   const mirrorCount = useMirrorCount(content.id, mirrorsOn);
   const isSource = !isMirror && mirrorCount > 0;
+  // The plugin row slots (Seam F) plus the two core decorations (protected lock,
+  // mirror badge) in ONE list, so the row renders them uniformly instead of a
+  // standalone conditional per decoration -- core decorations aren't plugins
+  // (registering them in plugins/index.ts would misrepresent them), but they
+  // share the same {id, render} shape, so a slot-list `.map()` covers all of it.
+  const beforeTextSlots: SlotSpec[] = [
+    ...slotsAt("row:before-text"),
+    {
+      id: "core:protected-lock",
+      position: "row:before-text",
+      render: () => (protectedNode ? <ProtectedLock size={12} /> : null),
+    },
+    {
+      id: "core:mirror-badge",
+      position: "row:before-text",
+      render: () =>
+        mirrorsOn && mirrorCount > 0 ? (
+          <MirrorBadge sourceId={content.id} count={mirrorCount} />
+        ) : null,
+    },
+  ];
 
   const menus = useMenus({
     node: content,
@@ -343,7 +369,7 @@ function RowChrome({
             ? "source"
             : undefined
       }
-      data-selected={selectionEdge ?? undefined}
+      data-selected={selectionFill ?? undefined}
       data-index={index}
       ref={measureRef}
       style={{
@@ -394,10 +420,6 @@ function RowChrome({
         {beforeTextSlots.map((slot) => (
           <Fragment key={slot.id}>{slot.render(content, pluginCtx)}</Fragment>
         ))}
-        {protectedNode && <ProtectedLock size={12} />}
-        {mirrorsOn && mirrorCount > 0 && (
-          <MirrorBadge sourceId={content.id} count={mirrorCount} />
-        )}
         <span
           ref={(el) => {
             textRef.current = el;

--- a/src/components/mirror-chrome.tsx
+++ b/src/components/mirror-chrome.tsx
@@ -1,0 +1,44 @@
+import { CopyPlus } from "lucide-react";
+import { openMirrorPlaces } from "./mirror-places-opener";
+
+/**
+ * The "appears in N places" chip (ADR 0022, slice 1d). Shown on a mirror's
+ * SOURCE and on every INSTANCE / capped row -- they share the source's content
+ * id, so the count is the same everywhere -- in both the list-row and the
+ * zoomed-title paths. Clicking it opens the places list ({@link MirrorPlaces})
+ * to jump to any occurrence.
+ *
+ * `count` is the number of mirror INSTANCES; the content appears in `count + 1`
+ * places total (the source plus each mirror). The caller renders this only when
+ * `count > 0` AND the mirrors flag is on, so a mirror-free outline never mounts
+ * it.
+ */
+export function MirrorBadge({
+  sourceId,
+  count,
+}: {
+  sourceId: string;
+  count: number;
+}) {
+  const places = count + 1;
+  const label = `Appears in ${places} places`;
+  return (
+    <button
+      type="button"
+      className="mirror-badge inline-flex shrink-0 select-none items-center gap-0.5 rounded-full border border-border/60 bg-muted/60 px-1.5 text-[10px] font-medium leading-4 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+      title={label}
+      aria-label={label}
+      // Don't let a click bubble to the bullet (which would zoom) or place a
+      // caret in the contentEditable text next to it.
+      onClick={(e) => {
+        e.stopPropagation();
+        openMirrorPlaces(sourceId);
+      }}
+      onPointerDown={(e) => e.stopPropagation()}
+      tabIndex={-1}
+    >
+      <CopyPlus size={11} strokeWidth={2.5} aria-hidden="true" />
+      {places}
+    </button>
+  );
+}

--- a/src/components/mirror-places-opener.ts
+++ b/src/components/mirror-places-opener.ts
@@ -1,0 +1,14 @@
+let opener: ((sourceId: string) => void) | null = null;
+
+export function setMirrorPlacesOpener(fn: typeof opener) {
+  opener = fn;
+}
+
+/**
+ * Open the "appears in N places" list for a mirrored node, from anywhere (the
+ * mirror-count badge in a row or the zoomed title). Pass the SOURCE id (a row's
+ * content id) -- {@link MirrorPlaces} normalizes a mirror id to its source.
+ */
+export function openMirrorPlaces(sourceId: string) {
+  opener?.(sourceId);
+}

--- a/src/components/mirror-places.tsx
+++ b/src/components/mirror-places.tsx
@@ -1,0 +1,179 @@
+import { useEffect, useMemo, useState, useSyncExternalStore } from "react";
+import { useNavigate } from "@tanstack/react-router";
+import { CopyPlus } from "lucide-react";
+import { useTree } from "../data/useTree";
+import { buildTrail, trueSourceOf, type Node, type TreeIndex } from "../data/tree";
+import { stripLinks } from "../data/links";
+import { requestFlashAfterNav } from "./flash-node";
+import { setMirrorPlacesOpener } from "./mirror-places-opener";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "./ui/dialog";
+
+/**
+ * The "appears in N places" jump list (ADR 0022, slice 1d). Opened from a
+ * mirror-count badge ({@link MirrorBadge}), it lists every occurrence of a
+ * mirrored node -- the SOURCE plus each mirror INSTANCE -- and jumps to the one
+ * you pick.
+ *
+ * Jump semantics, mirroring `/move`'s "Go": the SOURCE zooms to itself (you land
+ * on the original, with its subtree). A MIRROR zooms to its parent's view and
+ * flashes the instance row, so you see the copy highlighted in its surroundings
+ * -- a mirror can't be a sane zoom ROOT (its children come from windowing the
+ * source, so `childrenOf(instance)` is empty), which is why we zoom the parent.
+ *
+ * Self-contained and mounted once in `__root.tsx`, like the quick-switcher and
+ * the move dialog; the badge reaches it via {@link openMirrorPlaces}. The data
+ * view ({@link MirrorPlacesInner}, which calls `useTree`) is client-only so its
+ * `useLiveQuery` can't hard-fail the `/` prerender (SPA mode, ADR 0004).
+ */
+
+interface Place {
+  /** The source node, or one of its mirror instances. */
+  node: Node;
+  isSource: boolean;
+}
+
+export function MirrorPlaces() {
+  const [sourceId, setSourceId] = useState<string | null>(null);
+  const mounted = useSyncExternalStore(
+    () => () => {},
+    () => true,
+    () => false,
+  );
+
+  useEffect(() => {
+    setMirrorPlacesOpener((id) => setSourceId(id));
+    return () => {
+      setMirrorPlacesOpener(null);
+    };
+  }, []);
+
+  if (!mounted) return null;
+
+  return (
+    <MirrorPlacesInner
+      sourceId={sourceId}
+      onClose={() => setSourceId(null)}
+    />
+  );
+}
+
+function MirrorPlacesInner({
+  sourceId,
+  onClose,
+}: {
+  sourceId: string | null;
+  onClose: () => void;
+}) {
+  const { index } = useTree();
+  const navigate = useNavigate();
+
+  // Normalize whatever id we were handed (a content id is already the source,
+  // but a raw mirror id flattens to it) and read the live source node.
+  const source = sourceId ? index.byId.get(trueSourceOf(index, sourceId)) : null;
+
+  const places = useMemo<Place[]>(() => {
+    if (!source) return [];
+    const list: Place[] = [{ node: source, isSource: true }];
+    for (const id of index.mirrorsBySource.get(source.id) ?? []) {
+      const n = index.byId.get(id);
+      if (n) list.push({ node: n, isSource: false });
+    }
+    return list;
+  }, [index, source]);
+
+  const open = source !== null;
+  const title = source
+    ? stripLinks(source.text).trim() || "Untitled"
+    : "";
+
+  function goToPlace(place: Place) {
+    onClose();
+    if (place.isSource) {
+      // The original: zoom it directly so you land inside its subtree.
+      navigate({ to: "/$nodeId", params: { nodeId: place.node.id } });
+      return;
+    }
+    // A mirror: zoom its parent and flash the instance once that view mounts
+    // (scrollRowIntoView brings it on screen if windowed). Home for a top-level
+    // mirror. See flash-node.ts / OutlineEditor's consumeFlashAfterNav.
+    requestFlashAfterNav(place.node.id);
+    const parent = place.node.parentId;
+    if (parent == null) navigate({ to: "/" });
+    else navigate({ to: "/$nodeId", params: { nodeId: parent } });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => !next && onClose()}>
+      <DialogContent className="max-w-md gap-0 p-0">
+        <DialogHeader className="px-4 pt-4 pb-2">
+          <DialogTitle className="flex items-center gap-1.5 text-base">
+            <CopyPlus className="size-4 shrink-0 text-muted-foreground" />
+            Appears in {places.length} places
+          </DialogTitle>
+          <DialogDescription className="truncate text-left">
+            {title}
+          </DialogDescription>
+        </DialogHeader>
+        <ul className="max-h-[60vh] overflow-y-auto px-2 pb-2">
+          {places.map((place) => (
+            <PlaceRow
+              key={place.node.id}
+              place={place}
+              crumbs={crumbsFor(index, place.node.id)}
+              onSelect={() => goToPlace(place)}
+            />
+          ))}
+        </ul>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/** Ancestors top-down, excluding the node itself -- the disambiguating
+ *  breadcrumb. "Top level" when the occurrence sits at the root. */
+function crumbsFor(index: TreeIndex, id: string): string {
+  const crumbs = buildTrail(index, id)
+    .slice(0, -1)
+    .map((n) => stripLinks(n.text).trim() || "Untitled")
+    .join(" › ");
+  return crumbs || "Top level";
+}
+
+function PlaceRow({
+  place,
+  crumbs,
+  onSelect,
+}: {
+  place: Place;
+  crumbs: string;
+  onSelect: () => void;
+}) {
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={onSelect}
+        className="flex w-full items-center gap-2 rounded-md px-2 py-2 text-left hover:bg-accent"
+      >
+        <span
+          className={
+            place.isSource
+              ? "shrink-0 rounded-full bg-primary/15 px-2 text-[10px] font-medium leading-5 text-foreground"
+              : "shrink-0 rounded-full bg-muted px-2 text-[10px] font-medium leading-5 text-muted-foreground"
+          }
+        >
+          {place.isSource ? "Source" : "Mirror"}
+        </span>
+        <span className="min-w-0 truncate text-sm text-muted-foreground">
+          {crumbs}
+        </span>
+      </button>
+    </li>
+  );
+}

--- a/src/components/move-dialog-opener.ts
+++ b/src/components/move-dialog-opener.ts
@@ -1,12 +1,20 @@
-let opener: ((nodeIds: string[]) => void) | null = null;
+/** What the destination picker DOES on pick: reparent the run (`move`) or create
+ *  a live mirror of each under the destination (`mirror`, ADR 0022). The picker
+ *  UI is shared; only the completion + candidate-exclusion root differ. */
+export type MoveMode = "move" | "mirror";
+
+let opener: ((nodeIds: string[], mode: MoveMode) => void) | null = null;
 
 export function setMoveDialogOpener(fn: typeof opener) {
   opener = fn;
 }
 
-/** Open the move picker for one node (the `/move` command) or several (node
- *  multi-selection's Move action -- ADR 0018). A single id is normalized to a
- *  one-element run. */
-export function openMoveDialog(nodeIds: string | string[]) {
-  opener?.(typeof nodeIds === "string" ? [nodeIds] : nodeIds);
+/** Open the destination picker for one node (the `/move` // `/mirror` commands)
+ *  or several (node multi-selection's Move / Mirror action -- ADR 0018). A single
+ *  id is normalized to a one-element run; `mode` defaults to a plain move. */
+export function openMoveDialog(
+  nodeIds: string | string[],
+  mode: MoveMode = "move",
+) {
+  opener?.(typeof nodeIds === "string" ? [nodeIds] : nodeIds, mode);
 }

--- a/src/components/move-dialog.tsx
+++ b/src/components/move-dialog.tsx
@@ -10,14 +10,20 @@ import Fuse, { type FuseResultMatch, type IFuseOptions } from "fuse.js";
 import { BookmarkIcon, HomeIcon } from "lucide-react";
 import { toast } from "sonner";
 import { useTree } from "../data/useTree";
-import { buildTrail, childrenOf, type Node, type TreeIndex } from "../data/tree";
-import { moveManyNodes } from "../data/mutations";
+import {
+  buildTrail,
+  childrenOf,
+  trueSourceOf,
+  type Node,
+  type TreeIndex,
+} from "../data/tree";
+import { mirrorManyNodes, moveManyNodes } from "../data/mutations";
 import { runStructural } from "../data/structural";
 import { searchAliases, searchAnnotation } from "../plugins/registry";
 import { requestFlashAfterNav } from "./flash-node";
 import { capture, drop } from "../data/history";
 import { cn } from "@/lib/utils";
-import { setMoveDialogOpener } from "./move-dialog-opener";
+import { setMoveDialogOpener, type MoveMode } from "./move-dialog-opener";
 import {
   Command,
   CommandDialog,
@@ -83,6 +89,7 @@ const BOOKMARKS_HEADING = (
  */
 export function MoveDialog() {
   const [targets, setTargets] = useState<string[] | null>(null);
+  const [mode, setMode] = useState<MoveMode>("move");
   const [query, setQuery] = useState("");
   const mounted = useSyncExternalStore(
     () => () => {},
@@ -91,8 +98,9 @@ export function MoveDialog() {
   );
 
   useEffect(() => {
-    setMoveDialogOpener((nodeIds) => {
+    setMoveDialogOpener((nodeIds, nextMode) => {
       setTargets(nodeIds);
+      setMode(nextMode);
       setQuery("");
     });
     return () => {
@@ -105,6 +113,7 @@ export function MoveDialog() {
   return (
     <MoveDialogInner
       nodeIds={targets}
+      mode={mode}
       onOpenChange={(next) => {
         if (!next) {
           setTargets(null);
@@ -119,11 +128,13 @@ export function MoveDialog() {
 
 function MoveDialogInner({
   nodeIds,
+  mode,
   onOpenChange,
   query,
   setQuery,
 }: {
   nodeIds: string[] | null;
+  mode: MoveMode;
   onOpenChange: (next: boolean) => void;
   query: string;
   setQuery: (q: string) => void;
@@ -145,12 +156,18 @@ function MoveDialogInner({
     if (!nodeIds || nodeIds.length === 0) return [];
     const excluded = new Set<string>();
     for (const id of nodeIds) {
-      for (const sub of subtreeIds(index, id)) excluded.add(sub);
+      // Move can't drop a branch into itself, so exclude the node's own subtree.
+      // Mirror can't window content that contains the mirror, so exclude the
+      // SOURCE's subtree (a mirror's source, not the mirror) -- listing either
+      // would be a dead press the mutation guards anyway (ADR 0022). For a plain
+      // node the two roots coincide.
+      const rootId = mode === "mirror" ? trueSourceOf(index, id) : id;
+      for (const sub of subtreeIds(index, rootId)) excluded.add(sub);
     }
     return Array.from(index.byId.values()).filter(
       (n) => !excluded.has(n.id) && n.text.trim() !== "",
     );
-  }, [index, nodeIds]);
+  }, [index, nodeIds, mode]);
 
   const fuse = useMemo(
     () => (open ? new Fuse(candidates, FUSE_OPTIONS) : null),
@@ -183,6 +200,41 @@ function MoveDialogInner({
   // "Home" shows on an empty query or when the text looks like the word.
   const showHome = q === "" || "home".includes(q.toLowerCase());
 
+  const destName = (targetId: string | null) =>
+    targetId === null
+      ? "Home"
+      : index.byId.get(targetId)?.text.trim() || "Untitled";
+
+  const goTo = (targetId: string | null) => {
+    if (targetId === null) navigate({ to: "/" });
+    else navigate({ to: "/$nodeId", params: { nodeId: targetId } });
+  };
+
+  // Mirror each selected source under the destination as ONE atomic batch
+  // (mirrorManyNodes appends them in order, rebuilding the index per insert).
+  // Stays put with a toast (a "Go" jumps to where the mirrors landed); no flash
+  // -- the source didn't move, and the new mirrors have fresh ids we don't hold.
+  function mirror(targetId: string | null) {
+    if (!nodeIds || nodeIds.length === 0) return;
+    const ids = nodeIds;
+    onOpenChange(false);
+    const made = runStructural(() => {
+      capture(index, ids[0]!);
+      return mirrorManyNodes(targetId, ids);
+    });
+    // Nothing created => every source would have cycled (or vanished); the
+    // captured undo point is dead, so discard it.
+    if (!made) {
+      drop();
+      toast.error("Can't mirror there.");
+      return;
+    }
+    const count = ids.length === 1 ? "" : `${made} nodes `;
+    toast.success(`Mirrored ${count}to ${destName(targetId)}`, {
+      action: { label: "Go", onClick: () => goTo(targetId) },
+    });
+  }
+
   function move(targetId: string | null) {
     if (!nodeIds || nodeIds.length === 0) return;
     const ids = nodeIds;
@@ -203,45 +255,54 @@ function MoveDialogInner({
     // Stay put -- moving shouldn't navigate you away. Confirm with a toast, and
     // offer a "Go" action to jump to the destination's zoom view on demand
     // (plain nav, no morph, since no pivot dot is involved).
-    const dest =
-      targetId === null
-        ? "Home"
-        : index.byId.get(targetId)?.text.trim() || "Untitled";
     const count = ids.length === 1 ? "" : `${moved} nodes `;
-    toast.success(`Moved ${count}to ${dest}`, {
+    toast.success(`Moved ${count}to ${destName(targetId)}`, {
       action: {
         label: "Go",
         onClick: () => {
           // Flash + focus the first moved node once the destination view mounts,
           // so it's easy to spot where the run landed. See flash-node.ts.
           requestFlashAfterNav(ids[0]!);
-          if (targetId === null) {
-            navigate({ to: "/" });
-          } else {
-            navigate({ to: "/$nodeId", params: { nodeId: targetId } });
-          }
+          goTo(targetId);
         },
       },
     });
   }
 
+  // The picker UI is identical; only the completion differs by mode.
+  const commit = mode === "mirror" ? mirror : move;
+  const copy =
+    mode === "mirror"
+      ? {
+          title: "Mirror node",
+          description: "Choose where to show a live copy of this node",
+          placeholder: "Mirror under...",
+          heading: "Mirror under",
+        }
+      : {
+          title: "Move node",
+          description: "Choose a destination to move this node under",
+          placeholder: "Move under...",
+          heading: "Move under",
+        };
+
   return (
     <CommandDialog
       open={open}
       onOpenChange={onOpenChange}
-      title="Move node"
-      description="Choose a destination to move this node under"
+      title={copy.title}
+      description={copy.description}
     >
       <Command shouldFilter={false}>
         <CommandInput
           value={query}
           onValueChange={setQuery}
-          placeholder="Move under..."
+          placeholder={copy.placeholder}
         />
         <CommandList>
           {showHome && (
             <CommandGroup heading="Top level">
-              <CommandItem value="__home__" onSelect={() => move(null)}>
+              <CommandItem value="__home__" onSelect={() => commit(null)}>
                 <HomeIcon className="size-4 shrink-0 opacity-70" />
                 <span>Home</span>
               </CommandItem>
@@ -257,7 +318,7 @@ function MoveDialogInner({
                     key={node.id}
                     index={index}
                     node={node}
-                    onSelect={move}
+                    onSelect={commit}
                   />
                 ))}
               </CommandGroup>
@@ -265,14 +326,14 @@ function MoveDialogInner({
           ) : results.length === 0 ? (
             !showHome && <Hint>No matches.</Hint>
           ) : (
-            <CommandGroup heading="Move under">
+            <CommandGroup heading={copy.heading}>
               {results.map(({ node, matches }) => (
                 <DestinationRow
                   key={node.id}
                   index={index}
                   node={node}
                   matches={matches}
-                  onSelect={move}
+                  onSelect={commit}
                 />
               ))}
             </CommandGroup>

--- a/src/components/node-switcher.tsx
+++ b/src/components/node-switcher.tsx
@@ -11,6 +11,7 @@ import { Search, BookmarkIcon } from "lucide-react";
 import { useTree } from "../data/useTree";
 import { buildTrail, type Node, type TreeIndex } from "../data/tree";
 import { stripLinks } from "../data/links";
+import { isMirrorsEnabled } from "../data/flags";
 import {
   searchAliases,
   searchActions,
@@ -74,15 +75,19 @@ const BOOKMARKS_HEADING = (
 // One pass over the nodes (skip empties, project to the searchable shape), then
 // index. Module scope: pure, and a single iteration over potentially many nodes.
 function buildFuse(nodes: Node[]): Fuse<Searchable> {
+  // With mirrors on (ADR 0022) a mirror INSTANCE shares its source's content, so
+  // indexing it too would surface the same node twice -- dedup the search corpus
+  // to the source. Flag off, a `mirrorOf` node is an ordinary node and is kept.
+  const mirrorsOn = isMirrorsEnabled();
   const searchable: Searchable[] = [];
   for (const n of nodes) {
-    if (n.text.trim() !== "") {
-      searchable.push({
-        node: n,
-        text: stripLinks(n.text),
-        aliases: searchAliases(n),
-      });
-    }
+    if (n.text.trim() === "") continue;
+    if (mirrorsOn && n.mirrorOf != null) continue;
+    searchable.push({
+      node: n,
+      text: stripLinks(n.text),
+      aliases: searchAliases(n),
+    });
   }
   return new Fuse(searchable, FUSE_OPTIONS);
 }

--- a/src/components/protection.tsx
+++ b/src/components/protection.tsx
@@ -20,6 +20,7 @@ import { Lock } from "lucide-react";
 import { toast } from "sonner";
 import { getProtection } from "../plugins/registry";
 import type { NodeProtection } from "../plugins/types";
+import { orphanedMirrorsBy, type TreeIndex } from "../data/tree";
 import { rejectRow } from "./flash-node";
 
 /** The actions a protected node forbids. The string also keys the toast id (so
@@ -81,6 +82,31 @@ export function guardProtected(
   const protection = getProtection(id);
   if (!protection) return false;
   signalRejection(rowEl, protection, kind);
+  return true;
+}
+
+/**
+ * Guard a delete of `ids` (and their subtrees): if any is a mirror SOURCE whose
+ * instances would be orphaned, shake `rowEl`, toast why, and return `true` (the
+ * caller bails). Returns `false` when nothing is orphaned (proceed). Deleting a
+ * source would strand its live mirrors -- promote-on-delete is Stage 3 (ADR
+ * 0022), so v1 blocks rather than orphans. FLAG-GATED at the call site: off the
+ * mirrors flag a `mirrorOf` node is just a normal node, so this is never called.
+ */
+export function guardMirrorSourceDelete(
+  index: TreeIndex,
+  ids: string[],
+  rowEl: Element | null,
+): boolean {
+  const n = orphanedMirrorsBy(index, ids).length;
+  if (n === 0) return false;
+  rejectRow(rowEl);
+  toast.error(
+    `Can't delete: ${n} mirror${n === 1 ? "" : "s"} point here. Delete ${
+      n === 1 ? "it" : "them"
+    } first.`,
+    { id: "mirror-source-delete" },
+  );
   return true;
 }
 

--- a/src/components/selection-mode.tsx
+++ b/src/components/selection-mode.tsx
@@ -15,6 +15,7 @@ import {
 } from "@floating-ui/react-dom";
 import {
   ClipboardCopyIcon,
+  CopyPlusIcon,
   CornerUpRightIcon,
   Trash2Icon,
 } from "lucide-react";
@@ -42,6 +43,7 @@ import {
   useSelectionRootIds,
 } from "../data/selection-state";
 import { isProtected, selectionCommandSpecs } from "../plugins/registry";
+import { isMirrorsEnabled } from "../data/flags";
 import type { PluginContext } from "../plugins/types";
 import { rejectRow } from "./flash-node";
 import { placeCaretAtEnd } from "./caret-place";
@@ -73,6 +75,7 @@ export interface SelectionOps {
   copy: () => void;
   remove: () => void;
   move: () => void;
+  mirror: () => void;
   indent: () => void;
   outdent: () => void;
   caretAbove: () => void;
@@ -154,6 +157,16 @@ function makeSelectionOps({
     clearSelection();
   };
 
+  // Mirror the whole run: the same picker in mirror mode creates a live mirror
+  // of each selected root under the destination (ADR 0022), as one batch. The
+  // dialog owns the ids now, so leave selection mode (mirrors the Move action).
+  const mirror = () => {
+    const ids = getSelectionRootIds();
+    if (ids.length === 0) return;
+    openMoveDialog([...ids], "mirror");
+    clearSelection();
+  };
+
   // Tab: indent the whole run under the first root's previous sibling, as ONE
   // atomic batch (ADR 0009). The selection PERSISTS (the moved run stays
   // selected) -- refreshSelection re-derives its new parent so the next Tab /
@@ -224,7 +237,7 @@ function makeSelectionOps({
     focusNode(id);
   };
 
-  return { copy, remove, move, indent, outdent, caretAbove, caretBelow, exitToCaret };
+  return { copy, remove, move, mirror, indent, outdent, caretAbove, caretBelow, exitToCaret };
 }
 
 /**
@@ -463,6 +476,17 @@ function buildItems(
       run: ops.move,
     },
   ];
+  // Mirror sits next to Move, but only when the feature flag is on (ADR 0022) --
+  // a mirror-free build never offers it (matches the core `/mirror` slash gate).
+  if (isMirrorsEnabled()) {
+    core.push({
+      id: "sel-mirror",
+      label: "Mirror",
+      description: "Show live copies under another node",
+      icon: CopyPlusIcon,
+      run: ops.mirror,
+    });
+  }
   // Plugin commands that opted in (To-do, Send to Today), kept only when they
   // apply to at least one selected node (To-do hides when all are already tasks).
   const pluginItems: SelItem[] = selectionCommandSpecs

--- a/src/components/selection-mode.tsx
+++ b/src/components/selection-mode.tsx
@@ -43,6 +43,7 @@ import {
   useSelectionRootIds,
 } from "../data/selection-state";
 import { isProtected, selectionCommandSpecs } from "../plugins/registry";
+import { orphanedMirrorsBy } from "../data/tree";
 import { isMirrorsEnabled } from "../data/flags";
 import type { PluginContext } from "../plugins/types";
 import { rejectRow } from "./flash-node";
@@ -129,6 +130,19 @@ function makeSelectionOps({
       );
     }
     if (deletable.length === 0) return; // nothing removed; keep the selection
+    // Deleting a SOURCE orphans its live mirrors (Stage 3 promotes; v1 blocks).
+    // Check the whole deletable set at once, so selecting a source AND its
+    // mirror together still deletes cleanly (both leave, nothing is orphaned). If
+    // anything would be stranded, keep the selection and explain. Flag-gated:
+    // off-flag a mirrorOf node is just a normal node, so this never fires.
+    if (isMirrorsEnabled() && orphanedMirrorsBy(index, deletable).length > 0) {
+      for (const id of deletable) rejectRow(rowOf(id));
+      toast.error(
+        "A selected node is mirrored elsewhere -- delete its mirrors first.",
+        { id: "mirror-source-delete" },
+      );
+      return;
+    }
     const isHidden = getViewIsHidden();
     const rootId = getViewRootId();
     // Focus relative to the rows actually being DELETED, not the full selection:

--- a/src/components/selection-mode.tsx
+++ b/src/components/selection-mode.tsx
@@ -137,9 +137,24 @@ function makeSelectionOps({
     // protected one); `below` = the row after the last deleted node's subtree.
     const firstDel = deletable[0]!;
     const lastDel = deletable[deletable.length - 1]!;
-    const above = findVisibleNeighbor(index, rootId, firstDel, "up", isHidden);
+    const mirrorsOn = isMirrorsEnabled();
+    const above = findVisibleNeighbor(
+      index,
+      rootId,
+      firstDel,
+      "up",
+      isHidden,
+      mirrorsOn,
+    );
     const bottom = lastVisibleDescendant(index, lastDel, isHidden);
-    const below = findVisibleNeighbor(index, rootId, bottom, "down", isHidden);
+    const below = findVisibleNeighbor(
+      index,
+      rootId,
+      bottom,
+      "down",
+      isHidden,
+      mirrorsOn,
+    );
     runStructural(() => {
       capture(getTreeIndex(), deletable[0]!);
       removeManyNodes(deletable);
@@ -206,8 +221,14 @@ function makeSelectionOps({
     const index = getTreeIndex();
     const top = state.rootIds[0]!;
     const target =
-      findVisibleNeighbor(index, getViewRootId(), top, "up", getViewIsHidden()) ??
-      top;
+      findVisibleNeighbor(
+        index,
+        getViewRootId(),
+        top,
+        "up",
+        getViewIsHidden(),
+        isMirrorsEnabled(),
+      ) ?? top;
     clearSelection();
     focusNode(target);
   };
@@ -222,8 +243,14 @@ function makeSelectionOps({
     const lastRoot = state.rootIds[state.rootIds.length - 1]!;
     const bottom = lastVisibleDescendant(index, lastRoot, isHidden);
     const target =
-      findVisibleNeighbor(index, getViewRootId(), bottom, "down", isHidden) ??
-      bottom;
+      findVisibleNeighbor(
+        index,
+        getViewRootId(),
+        bottom,
+        "down",
+        isHidden,
+        isMirrorsEnabled(),
+      ) ?? bottom;
     clearSelection();
     focusNode(target);
   };

--- a/src/components/slash-menu.tsx
+++ b/src/components/slash-menu.tsx
@@ -1,9 +1,10 @@
 import { useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
 import { createPortal } from "react-dom";
-import { CornerUpRightIcon } from "lucide-react";
+import { CopyPlusIcon, CornerUpRightIcon } from "lucide-react";
 import type { Node } from "../data/schema";
 import type { CommandSpec, PluginContext } from "../plugins/types";
 import { commandSpecs } from "../plugins/registry";
+import { isMirrorsEnabled } from "../data/flags";
 import { caretOffset, caretPosition, wrap } from "./caret-menu-utils";
 import {
   decorate,
@@ -28,6 +29,18 @@ const CORE_COMMANDS: CommandSpec[] = [
     keywords: ["move", "reparent", "under", "into", "relocate", "home"],
     available: () => true,
     run: (id, ctx) => ctx.mutations.onRequestMove(id),
+  },
+  // Mirror is structural like Move (it relinks the tree), so it stays core too.
+  // Hidden until the mirrors feature flag is on (ADR 0022) -- a mirror-free
+  // build never offers it. Opens the SAME destination picker, in mirror mode.
+  {
+    id: "mirror",
+    label: "Mirror to",
+    description: "Show a live copy under another node",
+    icon: CopyPlusIcon,
+    keywords: ["mirror", "synced", "instance", "alias", "reference", "clone"],
+    available: () => isMirrorsEnabled(),
+    run: (id, ctx) => ctx.mutations.onRequestMirror(id),
   },
 ];
 

--- a/src/components/use-bullet-keymap.ts
+++ b/src/components/use-bullet-keymap.ts
@@ -9,6 +9,14 @@ import type { NodeCommands } from "./OutlineNode";
 
 interface BulletKeymapArgs {
   node: Node;
+  // The INSTANCE id + its collapse state. Collapse is LOCAL to where the row
+  // sits (ADR 0022 field split), so Cmd+Up/Down toggle the INSTANCE, not the
+  // source. `node` is the CONTENT (slice 1b feeds a mirror row its source), so
+  // keying collapse off `node.id`/`node.collapsed` would expand/collapse the
+  // source instead -- exactly what the chevron (which uses `instance`) avoids.
+  // For a mirror-free row instanceId === node.id, so this is byte-identical.
+  instanceId: string;
+  instanceCollapsed: boolean;
   textRef: RefObject<HTMLSpanElement | null>;
   commands: NodeCommands;
   pluginCtx: () => PluginContext;
@@ -36,6 +44,8 @@ const EMPTY_KEYMAP: never[] = [];
 
 export function useBulletKeymap({
   node,
+  instanceId,
+  instanceCollapsed,
   textRef,
   commands,
   pluginCtx,
@@ -188,7 +198,11 @@ export function useBulletKeymap({
               if (!el || !atLineStart(el)) return;
               e.preventDefault();
               e.stopPropagation();
-              selectSingle(node.id);
+              // Select the INSTANCE, not the content (ADR 0022): selecting a
+              // mirror by its source id would make select+delete remove the
+              // source and orphan every instance. instanceId === node.id for a
+              // mirror-free row.
+              selectSingle(instanceId);
               el.blur();
               window.getSelection()?.removeAllRanges();
             },
@@ -204,7 +218,7 @@ export function useBulletKeymap({
               if (!el || !atLineEnd(el)) return;
               e.preventDefault();
               e.stopPropagation();
-              selectSingle(node.id);
+              selectSingle(instanceId); // the instance, not its source (see above)
               el.blur();
               window.getSelection()?.removeAllRanges();
             },
@@ -225,7 +239,7 @@ export function useBulletKeymap({
               if (!empty && !isAllTextSelected(el)) return; // rung 1: native select-all
               e.preventDefault();
               e.stopPropagation();
-              selectSingle(node.id);
+              selectSingle(instanceId); // the instance, not its source (see above)
               el.blur();
               window.getSelection()?.removeAllRanges();
             },
@@ -266,8 +280,10 @@ export function useBulletKeymap({
             // no-op on an already-open or childless bullet. See ADR 0007.
             hotkey: "Mod+ArrowDown",
             callback: () => {
-              if (hasChildren && node.collapsed)
-                commands.onToggleCollapsed(node.id, false);
+              // Toggle the INSTANCE (collapse is local, ADR 0022): on a mirror's
+              // own row this opens that mirror, leaving the source untouched.
+              if (hasChildren && instanceCollapsed)
+                commands.onToggleCollapsed(instanceId, false);
             },
           },
           {
@@ -275,8 +291,8 @@ export function useBulletKeymap({
             // Mirror of Mod+ArrowDown -- Up only ever closes; otherwise a no-op.
             hotkey: "Mod+ArrowUp",
             callback: () => {
-              if (hasChildren && !node.collapsed)
-                commands.onToggleCollapsed(node.id, true);
+              if (hasChildren && !instanceCollapsed)
+                commands.onToggleCollapsed(instanceId, true);
             },
           },
           {

--- a/src/components/use-drag-reorder.ts
+++ b/src/components/use-drag-reorder.ts
@@ -1,5 +1,11 @@
 import { useCallback, useRef, type PointerEvent as ReactPointerEvent } from "react";
-import { childrenOf, type Node, type TreeIndex } from "../data/tree";
+import { type Node, type TreeIndex } from "../data/tree";
+import {
+  buildVisibleRows,
+  instanceIdForKey,
+  parentKeyOf,
+} from "../data/visible-order";
+import { isMirrorsEnabled } from "../data/flags";
 import { isVirtualNavActive, virtualRowRect } from "../data/virtual-nav";
 import { INDENT_PX } from "./OutlineRow";
 
@@ -35,7 +41,23 @@ const EDGE = 72;
 const SCROLL_MAX = 18;
 
 interface Row {
+  // The render ADDRESS (row.key) -- the drag's identity, so a windowed source
+  // descendant inside a mirror is the exact on-screen row, not its source copy
+  // (ADR 0022). Equals `id` for every mirror-free row, so the 99% path is
+  // unchanged. Geometry (virtualRowRect) and the refs lookup both key off this.
+  key: string;
+  // The INSTANCE (position) node id -- what `moveNode` repositions. Inside a
+  // mirror's window this is the real node (instance === content), so reordering
+  // it restructures the source and shows in every instance.
   id: string;
+  // The CONTENT node id (`mirrorOf ?? id`). Used when this row is the drop
+  // PARENT: dropping under a mirror targets its SOURCE, so the new child windows
+  // into every instance (the ADR 0022 field split, applied in onMove).
+  contentId: string;
+  // The RENDER parent's instance id (`instanceIdForKey(parentKeyOf(key))`), not
+  // the tree parent: inside a mirror a windowed child's render parent is the
+  // mirror instance, so the sibling/ancestor projection stays within the window.
+  // Field-split back to a content id in onMove. Equals the tree parent off-flag.
   parentId: string | null;
   depth: number; // relative to the zoom root: its direct children are depth 0
   el: HTMLElement | null;
@@ -57,18 +79,28 @@ interface DragDeps {
   /** The composed Seam-G visibility prune (hide-completed today). Drag mirrors
    *  the render: a hidden node is not a droppable row. See ADR 0001. */
   getIsHidden: () => (node: Node) => boolean;
-  /** The `.outline-row` element for a node id (via the editor's refs registry). */
-  getRowEl: (id: string) => HTMLElement | null;
+  /** The `.outline-row` element for a row KEY (via the editor's refs registry,
+   *  keyed by row.key since ADR 0022; key === id off the flag). */
+  getRowEl: (key: string) => HTMLElement | null;
   /** The `ul.outline-list` element, for the indicator's right edge. */
   getListEl: () => HTMLElement | null;
+  /**
+   * Commit the drop. `grabbedKey` is the dragged row's render address; the parent
+   * + predecessor are INSTANCE ids from the render hierarchy. The editor resolves
+   * the field split (a drop under a mirror targets its source) and re-derives the
+   * landing focus key from the post-move render walk. Off the flag these are bare
+   * ids and the resolution is a no-op.
+   */
   onMove: (
-    id: string,
-    newParentId: string | null,
-    afterSiblingId: string | null,
+    grabbedKey: string,
+    newParentInstanceId: string | null,
+    afterSiblingInstanceId: string | null,
   ) => void;
 }
 
 interface DragState {
+  /** The grabbed row's KEY (render address) -- buildRows/getRowEl/onMove all key
+   *  off it. Equals the node id for every mirror-free drag. */
   id: string;
   startX: number;
   startY: number;
@@ -112,41 +144,59 @@ export function useDragReorder(deps: DragDeps) {
   }, []);
 
   // Build the visible, ordered rows (matching what's rendered), with depth,
-  // excluding the grabbed node and everything under it (can't drop into self).
-  const buildRows = useCallback((grabbedId: string): Row[] => {
+  // excluding the grabbed row and everything under it (can't drop into self).
+  //
+  // Reuses `buildVisibleRows` -- the SAME flat walk the editor renders and the
+  // virtualizer indexes -- so the drag's rows can't drift from what's on screen
+  // (inside a mirror the ad-hoc tree walk produced the wrong rows: it never
+  // resolved the windowed source descendants, so their geometry was missing and
+  // the drop line projected off only the non-mirror rows). The grabbed subtree
+  // is the CONTIGUOUS run of deeper rows right after the grabbed one -- the flat
+  // list's standard subtree property, uniform across mirror-free and crossed
+  // paths. Filter is null to match today's drag (it ignores the tag filter).
+  const buildRows = useCallback((grabbedKey: string): Row[] => {
     const { getIndex, getRootId, getIsHidden, getRowEl } = depsRef.current;
     const index = getIndex();
     const rootId = getRootId();
     const isHidden = getIsHidden();
+    const visible = buildVisibleRows(
+      index,
+      rootId,
+      isHidden,
+      null,
+      isMirrorsEnabled(),
+    );
 
-    const skip = new Set<string>([grabbedId]);
-    const stack = [grabbedId];
-    while (stack.length) {
-      const id = stack.pop()!;
-      for (const c of childrenOf(index, id)) {
-        skip.add(c.id);
-        stack.push(c.id);
+    // The grabbed row, then skip it + its rendered subtree (rows deeper than it,
+    // up to the next row at or above its depth).
+    const gi = visible.findIndex((r) => r.key === grabbedKey);
+    let skipEnd = gi;
+    if (gi !== -1) {
+      const grabbedDepth = visible[gi]!.depth;
+      skipEnd = gi + 1;
+      while (skipEnd < visible.length && visible[skipEnd]!.depth > grabbedDepth) {
+        skipEnd++;
       }
     }
 
     const rows: Row[] = [];
-    const walk = (parentId: string | null, depth: number) => {
-      for (const child of childrenOf(index, parentId)) {
-        if (isHidden(child)) continue;
-        if (!skip.has(child.id)) {
-          rows.push({
-            id: child.id,
-            parentId: child.parentId,
-            depth,
-            el: getRowEl(child.id),
-          });
-        }
-        // Descend regardless of skip: a non-skipped node can't live under a
-        // skipped (grabbed) one, so this only walks real visible structure.
-        if (!child.collapsed && !skip.has(child.id)) walk(child.id, depth + 1);
-      }
-    };
-    walk(rootId, 0);
+    for (let i = 0; i < visible.length; i++) {
+      if (gi !== -1 && i >= gi && i < skipEnd) continue;
+      const vr = visible[i]!;
+      const parentKey = parentKeyOf(vr.key);
+      rows.push({
+        key: vr.key,
+        id: vr.id,
+        contentId: vr.contentId,
+        // Render parent: the mirror/ancestor instance the row sits under, or the
+        // node's tree parent at the top level (key === id, parentKey === null).
+        parentId: parentKey
+          ? instanceIdForKey(parentKey)
+          : (index.byId.get(vr.id)?.parentId ?? null),
+        depth: vr.depth,
+        el: getRowEl(vr.key),
+      });
+    }
     return rows;
   }, []);
 
@@ -173,7 +223,8 @@ export function useDragReorder(deps: DragDeps) {
     sourceRow?.closest(".outline-node")?.classList.add("drag-collapsed");
 
     const index = depsRef.current.getIndex();
-    const text = index.byId.get(s.id)?.text?.trim() || "Untitled";
+    const text =
+      index.byId.get(instanceIdForKey(s.id))?.text?.trim() || "Untitled";
 
     const pill = document.createElement("div");
     pill.className = "drag-pill";
@@ -205,7 +256,7 @@ export function useDragReorder(deps: DragDeps) {
     const pairs: { row: Row; rect: RowRect }[] = [];
     for (const r of s.rows) {
       if (virtualized) {
-        const vr = virtualRowRect(r.id, scrollY);
+        const vr = virtualRowRect(r.key, scrollY);
         if (!vr) continue;
         // Uniform indent: depth-0 left is the container left; deeper rows add
         // depth * indent (OutlineRow's paddingInlineStart). project() backs
@@ -358,10 +409,14 @@ export function useDragReorder(deps: DragDeps) {
     if (s.dragging) {
       consumed.current = true;
       const pending = s.pending;
-      const id = s.id;
+      const grabbedKey = s.id;
       cleanup();
       if (pending) {
-        depsRef.current.onMove(id, pending.parentId, pending.afterSiblingId);
+        depsRef.current.onMove(
+          grabbedKey,
+          pending.parentId,
+          pending.afterSiblingId,
+        );
       }
       return;
     }
@@ -369,13 +424,13 @@ export function useDragReorder(deps: DragDeps) {
   }
 
   const startDrag = useCallback(
-    (id: string, e: ReactPointerEvent) => {
+    (grabbedKey: string, e: ReactPointerEvent) => {
       // A fresh press: clear any stale click-suppression.
       consumed.current = false;
       // Ignore secondary buttons.
       if (e.button !== 0 && e.pointerType === "mouse") return;
       state.current = {
-        id,
+        id: grabbedKey,
         startX: e.clientX,
         startY: e.clientY,
         dragging: false,

--- a/src/data/collection.ts
+++ b/src/data/collection.ts
@@ -261,6 +261,23 @@ function healSiblingChains(nodes: Node[]): void {
   })
 }
 
+/**
+ * Backfill `mirrorOf` for rows persisted before the field existed (ADR 0022,
+ * mirrors Stage 0). The per-user DO adds the column with a NULL default in its
+ * constructor, so a healthy DO always sends it; this guards the brief
+ * pre-migration window and any mock/snapshot that predates the field (e.g. the
+ * e2e Worker mock). Done inline rather than via the post-commit sibling-chain
+ * heal because the value must be present BEFORE the schema-typed collection
+ * write (`mirrorOf` is required, no default — ADR 0003), and it allocates a new
+ * object only when the field is actually absent (the never-taken branch once
+ * every DO has migrated). */
+function withMirrorDefault(n: Node): Node {
+  // The wire/DO type says mirrorOf is always present, so read it through a cast:
+  // a row persisted before the field existed (or the e2e mock) may omit it at
+  // runtime even though the type can't express that.
+  return (n as { mirrorOf?: unknown }).mirrorOf === undefined ? { ...n, mirrorOf: null } : n
+}
+
 export const nodesCollection = createCollection({
   id: 'nodes',
   getKey: (node: Node) => node.id,
@@ -293,7 +310,7 @@ export const nodesCollection = createCollection({
             write({ type: 'delete', key: op.key })
             echoedText.delete(op.key)
           } else {
-            write({ type: op.op, value: op.value })
+            write({ type: op.op, value: withMirrorDefault(op.value) })
             echoedText.set(op.value.id, op.value.text)
           }
         }
@@ -312,7 +329,7 @@ export const nodesCollection = createCollection({
           // changelog window. The cursor survives truncate (separate store).
           begin()
           truncate()
-          for (const n of msg.nodes) write({ type: 'insert', value: n })
+          for (const n of msg.nodes) write({ type: 'insert', value: withMirrorDefault(n) })
           metadata?.collection.set('cursor', msg.seq)
           commit()
           // A fresh snapshot supersedes every earlier seq (and may be the

--- a/src/data/flags.ts
+++ b/src/data/flags.ts
@@ -17,10 +17,9 @@ const VIRTUALIZED_DEFAULT = true;
 
 const MIRRORS_KEY = "dotflowy:flag:mirrors";
 
-// Compiled default OFF. Mirrors (ADR 0022) are mid-build: the render walk reads
-// the flag, but the mirror-free outline must run today's exact code, so the
-// feature is opt-in (localStorage "on") until it's complete and dogfooded.
-const MIRRORS_DEFAULT = false;
+// Compiled default ON. Mirrors (ADR 0022) shipped to all users; localStorage
+// "off" is the escape hatch if a regression turns up.
+const MIRRORS_DEFAULT = true;
 
 /**
  * Whether the editor renders the flat, windowed outline (Phase B) instead of the
@@ -43,9 +42,8 @@ export function isVirtualized(): boolean {
 /**
  * Whether node mirrors (ADR 0022) are active. Read at render time by the visible-
  * order walk (mirror resolution + path keys) and the mirror create/chrome paths.
- * OFF by default: a mirror-free outline must behave byte-identically to today, so
- * the whole feature is opt-in until complete. Same localStorage escape-hatch shape
- * as {@link isVirtualized}.
+ * ON by default for all users; localStorage "off" is the rollback escape hatch.
+ * Same localStorage escape-hatch shape as {@link isVirtualized}.
  */
 export function isMirrorsEnabled(): boolean {
   if (typeof window === "undefined") return MIRRORS_DEFAULT;

--- a/src/data/flags.ts
+++ b/src/data/flags.ts
@@ -15,6 +15,13 @@ const VIRTUALIZED_KEY = "dotflowy:flag:virtualized";
 // so it's on; localStorage "off" is the escape hatch (and the e2e parity lever).
 const VIRTUALIZED_DEFAULT = true;
 
+const MIRRORS_KEY = "dotflowy:flag:mirrors";
+
+// Compiled default OFF. Mirrors (ADR 0022) are mid-build: the render walk reads
+// the flag, but the mirror-free outline must run today's exact code, so the
+// feature is opt-in (localStorage "on") until it's complete and dogfooded.
+const MIRRORS_DEFAULT = false;
+
 /**
  * Whether the editor renders the flat, windowed outline (Phase B) instead of the
  * recursive DOM tree. Read at render time. SSR/prerender has no window and never
@@ -31,4 +38,23 @@ export function isVirtualized(): boolean {
     // localStorage can throw (private mode / disabled); fall back to the default.
   }
   return VIRTUALIZED_DEFAULT;
+}
+
+/**
+ * Whether node mirrors (ADR 0022) are active. Read at render time by the visible-
+ * order walk (mirror resolution + path keys) and the mirror create/chrome paths.
+ * OFF by default: a mirror-free outline must behave byte-identically to today, so
+ * the whole feature is opt-in until complete. Same localStorage escape-hatch shape
+ * as {@link isVirtualized}.
+ */
+export function isMirrorsEnabled(): boolean {
+  if (typeof window === "undefined") return MIRRORS_DEFAULT;
+  try {
+    const v = window.localStorage.getItem(MIRRORS_KEY);
+    if (v === "on") return true;
+    if (v === "off") return false;
+  } catch {
+    // localStorage can throw (private mode / disabled); fall back to the default.
+  }
+  return MIRRORS_DEFAULT;
 }

--- a/src/data/history.ts
+++ b/src/data/history.ts
@@ -1,6 +1,7 @@
 import { nodesCollection } from './collection'
 import type { Node } from './schema'
 import type { TreeIndex } from './tree'
+import { instanceIdForKey } from './visible-order'
 
 /**
  * Undo/redo history for the outline.
@@ -105,8 +106,14 @@ function restore(index: TreeIndex, entry: Entry): string | null {
     }
   }
 
-  // Only focus if the node still exists in the restored state.
-  return entry.focusId && target.has(entry.focusId) ? entry.focusId : null
+  // Only focus if the focused node still exists in the restored state. The focus
+  // identity may be a row KEY (a path address inside a mirror, ADR 0022); gate on
+  // the node it points at (the key's last segment) but return the full key, so
+  // focus lands back in the same instance the user was editing. For a mirror-free
+  // row key === id, so this is identical to a bare-id check.
+  return entry.focusId && target.has(instanceIdForKey(entry.focusId))
+    ? entry.focusId
+    : null
 }
 
 /**

--- a/src/data/mutations.ts
+++ b/src/data/mutations.ts
@@ -205,22 +205,28 @@ export function indent(index: TreeIndex, nodeId: string): boolean {
     ? oldSiblings[i + 1]!
     : null
 
+  // The node becomes the LAST child of newParent, so read newParent's current
+  // last child BEFORE moving it. The shared tree index is maintained IN PLACE
+  // (tree-store applyChanges), and an update can notify synchronously, so a read
+  // AFTER the move can already include the node itself -- it would then point its
+  // own prevSiblingId at itself (a self-referencing chain). node is a sibling of
+  // newParent here, never already its child, so the pre-move read excludes it.
+  const newSiblings = childrenOf(index, newParent.id)
+  const lastExisting = newSiblings.length > 0
+    ? newSiblings[newSiblings.length - 1]!
+    : null
+
   // Node becomes last child of newParent. If that parent was collapsed, the
   // node would be indented out of sight, so expand it to keep the node visible.
-  update(nodeId, { parentId: newParent.id, prevSiblingId: null })
+  update(nodeId, {
+    parentId: newParent.id,
+    prevSiblingId: lastExisting ? lastExisting.id : null,
+  })
   if (newParent.collapsed) update(newParent.id, { collapsed: false })
 
   // Old next sibling links back to node's old prev.
   if (oldNext) {
     update(oldNext.id, { prevSiblingId: node.prevSiblingId })
-  }
-
-  // Node is now the last child of newParent; repoint whatever was last.
-  const newSiblings = childrenOf(index, newParent.id)
-  // newSiblings is from the pre-mutation index, so it doesn't include node yet.
-  if (newSiblings.length > 0) {
-    const lastExisting = newSiblings[newSiblings.length - 1]!
-    update(nodeId, { prevSiblingId: lastExisting.id })
   }
 
   return true

--- a/src/data/mutations.ts
+++ b/src/data/mutations.ts
@@ -7,6 +7,8 @@ import {
   createId,
   makeNode,
   now,
+  trueSourceOf,
+  wouldMirrorCycle,
 } from './tree'
 
 /**
@@ -117,6 +119,66 @@ export function appendChild(
     makeNode({ id, parentId, prevSiblingId, text }),
   )
   return id
+}
+
+/**
+ * Create a MIRROR of `sourceId` as the last child of `targetId` (or the last
+ * top-level node when targetId is null/Home) -- a node carrying `mirrorOf` ->
+ * the TRUE source (ADR 0022). Two invariants:
+ *
+ *  - **Flatten:** if `sourceId` is itself a mirror, the new node points at its
+ *    source (`trueSourceOf`), never at another mirror, so every instance shares
+ *    ONE canonical content node and there's no chain to resolve.
+ *  - **No cycle:** refuses (returns null) when the true source is the
+ *    destination or one of its ancestors -- expanding such a mirror would window
+ *    content that contains the mirror itself.
+ *
+ * The stored `text` snapshots the source so a mirror still reads sensibly with
+ * the feature flag OFF; with mirrors ON the field split reads the live source,
+ * so the snapshot is never shown. Returns the new node's id, or null when
+ * blocked / the source is gone. Wrap in `runStructural` (ADR 0009).
+ */
+export function mirrorNode(
+  index: TreeIndex,
+  sourceId: string,
+  targetId: string | null,
+): string | null {
+  if (!index.byId.has(sourceId)) return null
+  const trueSourceId = trueSourceOf(index, sourceId)
+  if (wouldMirrorCycle(index, trueSourceId, targetId)) return null
+
+  const siblings = childrenOf(index, targetId)
+  const after = siblings.length ? siblings[siblings.length - 1]!.id : null
+  const id = createId()
+  nodesCollection.insert(
+    makeNode({
+      id,
+      parentId: targetId,
+      prevSiblingId: after,
+      text: index.byId.get(trueSourceId)?.text ?? '',
+      mirrorOf: trueSourceId,
+    }),
+  )
+  return id
+}
+
+/**
+ * Mirror several sources under `targetId`, appended in order (node multi-
+ * selection's Mirror action + daily "Mirror to Today" -- ADR 0018). Rebuilds the
+ * index between inserts so each append reads the freshly grown sibling list;
+ * sources that would cycle (or are gone) are skipped. Returns the count actually
+ * mirrored. Wrap in `runStructural` (ADR 0009).
+ */
+export function mirrorManyNodes(
+  targetId: string | null,
+  ids: string[],
+): number {
+  let made = 0
+  for (const id of ids) {
+    const index = buildTreeIndex(nodesCollection.toArray)
+    if (mirrorNode(index, id, targetId)) made++
+  }
+  return made
 }
 
 /**

--- a/src/data/schema.ts
+++ b/src/data/schema.ts
@@ -38,6 +38,12 @@ export const nodeSchema = Schema.Struct({
   // timestamp beats a boolean: it carries both "is it pinned?" and "in what
   // order?" in one field. See ADR 0011.
   bookmarkedAt: Schema.NullOr(Schema.Number),
+  // Mirror pointer (ADR 0022). `null` = this node is its own source (the normal
+  // case); a node id = this node is a *mirror* that windows that source's content
+  // and children. The content id is `mirrorOf ?? id`. Required + nullable, no
+  // default (ADR 0003) -- makeNode() sets it to null. Stage 0 ships this field
+  // dark: nothing reads it yet.
+  mirrorOf: Schema.NullOr(Schema.String),
   createdAt: Schema.Number,
   updatedAt: Schema.Number,
 })

--- a/src/data/selection-fill.ts
+++ b/src/data/selection-fill.ts
@@ -1,0 +1,123 @@
+import { useCallback, useEffect, useSyncExternalStore } from "react";
+import {
+  getSelectionState,
+  subscribeSelection,
+  type SelectionData,
+  type SelectionEdge,
+} from "./selection-state";
+import type { VisibleRow } from "./visible-order";
+
+/**
+ * Per-row selection FILL for the windowed list (2e-2, ADR 0019/0022). The
+ * recursive path's `useSelectionEdge` only marks a selected ROOT, because its
+ * descendants are DOM-nested inside the root's `<li>` and inherit the tint for
+ * free. The flat list has no such nesting -- every row is its own absolutely
+ * positioned sibling -- so a selected root's descendants need their OWN
+ * `data-selected` value or they render untinted (the windowed-subtree-tint bug;
+ * affects any node, not just mirrors).
+ *
+ * `SelectionFill` reuses {@link SelectionEdge}'s vocabulary (same four values,
+ * same CSS) -- only what counts as "covered" changes: every visible row inside
+ * the selection's span, not just its roots.
+ */
+export type SelectionFill = SelectionEdge;
+
+/**
+ * One walk of the current flat row list, marking the contiguous covered span:
+ * each selected root, plus every visible descendant beneath it (by `depth`,
+ * mirroring how `buildVisibleRows` already flattens collapse/hide/filter), as
+ * ONE slab from the first covered row to the last. Corner rounding lands on the
+ * span's actual first/last ROW -- which for a root with children is a
+ * descendant, not the root -- not on `rootIds[0]`/`rootIds[last]` (the old
+ * root-only edge map's anchors).
+ *
+ * Coverage is matched by row id against `rootIds`, the same identity the old
+ * `edgeMapFor` used -- so it inherits the same known limitation: a node
+ * rendered at two row keys at once (a windowed mirror descendant whose source
+ * is ALSO visible elsewhere) covers both occurrences. Killing that fully needs
+ * the selection itself to carry a row key, not just a node id -- out of scope
+ * here (issue 03's 2e bullet tracks it separately); this only fixes the named
+ * bug, that a covered descendant gets no tint at all.
+ */
+function computeFillMap(
+  rows: VisibleRow[],
+  data: SelectionData | null,
+): Map<string, SelectionFill> {
+  const map = new Map<string, SelectionFill>();
+  const rootIds = data?.rootIds as readonly string[] | undefined;
+  if (!rootIds || rootIds.length === 0) return map;
+  const rootSet = new Set(rootIds);
+  const covered: string[] = [];
+  let openDepth: number | null = null;
+  for (const row of rows) {
+    if (openDepth !== null && row.depth > openDepth) {
+      covered.push(row.key);
+      continue;
+    }
+    openDepth = null;
+    if (rootSet.has(row.id)) {
+      covered.push(row.key);
+      openDepth = row.depth;
+    }
+  }
+  if (covered.length === 0) return map;
+  if (covered.length === 1) {
+    map.set(covered[0]!, "single");
+    return map;
+  }
+  map.set(covered[0]!, "top");
+  map.set(covered[covered.length - 1]!, "bottom");
+  for (let i = 1; i < covered.length - 1; i++) map.set(covered[i]!, "middle");
+  return map;
+}
+
+const EMPTY_ROWS: VisibleRow[] = [];
+let rows: VisibleRow[] = EMPTY_ROWS;
+let fillMap: Map<string, SelectionFill> = new Map();
+const listeners = new Set<() => void>();
+let started = false;
+
+function recompute() {
+  fillMap = computeFillMap(rows, getSelectionState());
+  for (const l of listeners) l();
+}
+
+function ensureStarted() {
+  if (started || typeof window === "undefined") return;
+  started = true;
+  subscribeSelection(recompute);
+}
+
+/**
+ * Mirror the editor's current flat row list into the fill computation (mirrors
+ * `useSyncViewState`'s pattern). Call once in OutlineEditor, right after
+ * `useVisibleRows`. The write runs in an effect, so nothing here trips the
+ * React Compiler's ref-during-render bailout; `rows` only changes identity on a
+ * structural edit (collapse, insert, move, filter), never on a keystroke.
+ */
+export function useSyncSelectionFillRows(nextRows: VisibleRow[]): void {
+  useEffect(() => {
+    rows = nextRows;
+    recompute();
+  }, [nextRows]);
+}
+
+function subscribe(cb: () => void): () => void {
+  ensureStarted();
+  listeners.add(cb);
+  return () => {
+    listeners.delete(cb);
+  };
+}
+
+/**
+ * Per-row subscription to this row's fill: a row re-renders only when ITS OWN
+ * value changes (ADR 0014), exactly `useSelectionEdge`'s contract -- the
+ * windowed-list counterpart, keyed by `row.key` (not the bare node id, so a
+ * windowed mirror descendant and its source's canonical row -- different keys,
+ * same id -- are independent reads). Returns null when this row isn't covered.
+ */
+export function useSelectionFill(key: string): SelectionFill | null {
+  const getSnapshot = useCallback(() => fillMap.get(key) ?? null, [key]);
+  return useSyncExternalStore(subscribe, getSnapshot, () => null);
+}

--- a/src/data/selection-state.ts
+++ b/src/data/selection-state.ts
@@ -63,7 +63,9 @@ const SelectionDataSchema = Schema.Struct({
   /** The selected sibling roots, in visible display order. */
   rootIds: Schema.Array(Schema.String),
 });
-type SelectionData = Schema.Schema.Type<typeof SelectionDataSchema>;
+/** Exported for {@link "./selection-fill"}'s coverage walk -- a type-only need,
+ *  not a widening of the frozen function API (ADR 0020). */
+export type SelectionData = Schema.Schema.Type<typeof SelectionDataSchema>;
 
 /** Machine context: the current selection, or null while idle. One field, so a
  *  transition just replaces it; a no-op transition returns nothing and the
@@ -374,4 +376,16 @@ export function useSelectionRootIds(): string[] {
  *  flip, not on every selection change within `selecting`. */
 export function useIsSelectionActive(): boolean {
   return useSelector(selectionActor, (snap) => snap.value === "selecting");
+}
+
+/** Raw subscribe to any selection change, outside React. The one consumer is
+ *  {@link "./selection-fill"}'s module-singleton mirror (ADR 0019's windowed
+ *  list has no DOM nesting for a root's tint to paint behind its descendants,
+ *  so the fill map needs its own walk -- this is how it learns a selection
+ *  changed without itself being a React subscriber). Not part of the frozen
+ *  consumer-facing API (selectSingle/extendSelection/useSelectionEdge/...) --
+ *  an internal seam for the one other module in this slice. */
+export function subscribeSelection(cb: () => void): () => void {
+  const sub = selectionActor.subscribe(cb);
+  return () => sub.unsubscribe();
 }

--- a/src/data/tree-store.ts
+++ b/src/data/tree-store.ts
@@ -290,6 +290,36 @@ export function useNode(id: string): Node | undefined {
   return useSyncExternalStore(subscribeTree, getSnapshot, () => undefined)
 }
 
+/** A no-op store subscription, for hooks switched off by a session-fixed flag:
+ *  no listener is registered and it never notifies, so the snapshot stays at its
+ *  disabled value for the session. */
+const NOOP_SUBSCRIBE = () => () => {}
+
+/**
+ * Subscribe to how many mirror INSTANCES point at `id` as their source (ADR
+ * 0022) -- the number behind the "appears in N places" chrome. A primitive
+ * snapshot, so a row re-renders only when its source's mirror count actually
+ * changes (create / promote / delete), never on a keystroke -- the same per-node
+ * budget as {@link useNode} / `useIsProtected`.
+ *
+ * `enabled` is the session-fixed mirrors flag, read once by the caller. When off
+ * the hook subscribes to nothing and reports 0, so a mirror-free outline adds
+ * zero reactive work to the hot path -- the "don't regress" rule (ADR 0019/0022).
+ * Always called (rules of hooks); only the subscribe target varies by the stable
+ * flag.
+ */
+export function useMirrorCount(id: string, enabled = true): number {
+  const getSnapshot = useCallback(
+    () => (enabled ? (getTreeIndex().mirrorsBySource.get(id)?.length ?? 0) : 0),
+    [id, enabled],
+  )
+  return useSyncExternalStore(
+    enabled ? subscribeTree : NOOP_SUBSCRIBE,
+    getSnapshot,
+    () => 0,
+  )
+}
+
 /**
  * Subscribe to a node's ordered, visibility-filtered child ids. `isHidden` is
  * the composed Seam-G prune predicate (ADR 0001): the store no longer hardcodes

--- a/src/data/tree-store.ts
+++ b/src/data/tree-store.ts
@@ -11,6 +11,7 @@ import {
   type TreeIndex,
 } from './tree'
 import { buildVisibleRows, type VisibleRow } from './visible-order'
+import { isMirrorsEnabled } from './flags'
 import type { TagFilter } from './tags'
 
 /**
@@ -376,6 +377,11 @@ const EMPTY_ROWS: VisibleRow[] = []
  * rebuild -- correct, and not the 100k hot path). They must be referentially
  * stable across unrelated keystrokes (the caller memoizes them), or the cache
  * resets every render.
+ *
+ * Mirror resolution (ADR 0022) is gated on {@link isMirrorsEnabled}, read here
+ * rather than threaded as a dep: the flag is fixed for a session (set before the
+ * first render, like {@link isVirtualized}), so a flip is picked up on the next
+ * structural rebuild -- it never needs to invalidate the keystroke-hot cache.
  */
 export function useVisibleRows(
   rootId: string | null,
@@ -404,7 +410,7 @@ export function useVisibleRows(
     ) {
       return c.rows
     }
-    const rows = buildVisibleRows(getTreeIndex(), rootId, isHidden, filter)
+    const rows = buildVisibleRows(getTreeIndex(), rootId, isHidden, filter, isMirrorsEnabled())
     cache.current = { rev, rootId, isHidden, filter, rows }
     return rows
   }, [rootId, isHidden, filter])

--- a/src/data/tree-store.ts
+++ b/src/data/tree-store.ts
@@ -42,7 +42,11 @@ const EMPTY_TRAIL: Node[] = []
 // The store owns ONE mutable index, maintained in place by applyChanges. It must
 // be its own instance -- never the shared EMPTY_INDEX, which has to stay pristine
 // as the server/initial snapshot for the hooks below.
-let index: TreeIndex = { byId: new Map(), childrenByParent: new Map() }
+let index: TreeIndex = {
+  byId: new Map(),
+  childrenByParent: new Map(),
+  mirrorsBySource: new Map(),
+}
 const listeners = new Set<() => void>()
 let started = false
 
@@ -99,6 +103,10 @@ function applyChanges(changes: ReadonlyArray<ChangeMessage<Node>>) {
   // (hide-completed Seam-G + collapse). If a future Seam-G transform hides a node
   // by another field, add it here or useVisibleRows will show stale rows.
   let visibilityChanged = false
+  // mirrorOf transitions (create/promote — ADR 0022) are rare and ride structural
+  // batches today, but tracked independently so the reverse index stays correct
+  // (and its Map identity is refreshed) even on a bare field edit that flips it.
+  let mirrorsChanged = false
   for (const change of changes) {
     if (change.type === 'delete') {
       const prev = index.byId.get(change.key as string)
@@ -107,6 +115,10 @@ function applyChanges(changes: ReadonlyArray<ChangeMessage<Node>>) {
       const key = parentKeyOf(prev)
       removeChildId(key, prev.id)
       dirty.add(key)
+      if (prev.mirrorOf) {
+        removeMirror(prev.mirrorOf, prev.id)
+        mirrorsChanged = true
+      }
       continue
     }
     const next = change.value
@@ -114,6 +126,12 @@ function applyChanges(changes: ReadonlyArray<ChangeMessage<Node>>) {
     index.byId.set(next.id, next)
     if (prev && (prev.collapsed !== next.collapsed || prev.completed !== next.completed)) {
       visibilityChanged = true
+    }
+    if ((prev?.mirrorOf ?? null) !== (next.mirrorOf ?? null)) {
+      // null<->id or id<->id: leave the old source's bucket, join the new one.
+      if (prev?.mirrorOf) removeMirror(prev.mirrorOf, next.id)
+      if (next.mirrorOf) addMirror(next.mirrorOf, next.id)
+      mirrorsChanged = true
     }
     if (!prev) {
       // Insert (also the safe fallback for an update to a row we haven't seen).
@@ -156,13 +174,16 @@ function applyChanges(changes: ReadonlyArray<ChangeMessage<Node>>) {
   // Field-only edits (the hot path) keep the SAME Map refs -- O(1). Per-node
   // reactivity flows through `useNode` (node-object identity), not Map identity,
   // and whole-collection readers are inert while a bullet is being edited.
-  index =
-    dirty.size > 0
-      ? {
-          byId: new Map(index.byId),
-          childrenByParent: new Map(index.childrenByParent),
-        }
-      : { byId: index.byId, childrenByParent: index.childrenByParent }
+  const structural = dirty.size > 0
+  index = {
+    byId: structural ? new Map(index.byId) : index.byId,
+    childrenByParent: structural ? new Map(index.childrenByParent) : index.childrenByParent,
+    // Copy the reverse-index Map on a structural change (it rides the same fresh-
+    // Maps discipline as the others) OR whenever a mirrorOf flipped, so readers
+    // memoized on its reference can't go stale. Untouched on the keystroke path.
+    mirrorsBySource:
+      structural || mirrorsChanged ? new Map(index.mirrorsBySource) : index.mirrorsBySource,
+  }
   // Bump the flat-list signal on a structural change OR a visibility flip; a
   // pure text/isTask edit leaves it untouched (the typing hot path). See
   // useVisibleRows.
@@ -190,6 +211,26 @@ function removeChildId(key: string, id: string) {
   const i = ids.indexOf(id)
   if (i !== -1) ids.splice(i, 1)
   if (ids.length === 0) index.childrenByParent.delete(key)
+}
+
+/** Register a mirror id under its source in the reverse index (ADR 0022).
+ *  Guards against a duplicate from a redelivered change. */
+function addMirror(sourceId: string, id: string) {
+  const ids = index.mirrorsBySource.get(sourceId)
+  if (ids) {
+    if (!ids.includes(id)) ids.push(id)
+  } else {
+    index.mirrorsBySource.set(sourceId, [id])
+  }
+}
+
+/** Drop a mirror id from its source's bucket; prune the entry when it empties. */
+function removeMirror(sourceId: string, id: string) {
+  const ids = index.mirrorsBySource.get(sourceId)
+  if (!ids) return
+  const i = ids.indexOf(id)
+  if (i !== -1) ids.splice(i, 1)
+  if (ids.length === 0) index.mirrorsBySource.delete(sourceId)
 }
 
 /**

--- a/src/data/tree.test.ts
+++ b/src/data/tree.test.ts
@@ -4,6 +4,7 @@ import {
   buildTreeIndex,
   childrenOf,
   makeNode,
+  orphanedMirrorsBy,
   trueSourceOf,
   wouldMirrorCycle,
 } from './tree'
@@ -68,6 +69,58 @@ describe('buildTreeIndex mirrorsBySource (ADR 0022)', () => {
     const m = makeNode({ id: 'm', mirrorOf: 'ghost' })
     const index = buildTreeIndex([m])
     expect(index.mirrorsBySource.get('ghost')).toEqual(['m'])
+  })
+})
+
+describe('orphanedMirrorsBy (delete-source guard, ADR 0022)', () => {
+  // src has two children; M (under p) mirrors src.
+  const tree = () => [
+    makeNode({ id: 'src' }),
+    makeNode({ id: 'k1', parentId: 'src', prevSiblingId: null }),
+    makeNode({ id: 'k2', parentId: 'src', prevSiblingId: 'k1' }),
+    makeNode({ id: 'p', prevSiblingId: 'src' }),
+    makeNode({ id: 'M', parentId: 'p', prevSiblingId: null, mirrorOf: 'src' }),
+  ]
+
+  test('deleting a source with a live mirror reports the orphan', () => {
+    const index = buildTreeIndex(tree())
+    expect(orphanedMirrorsBy(index, ['src'])).toEqual(['M'])
+  })
+
+  test('deleting a plain mirror is always safe', () => {
+    const index = buildTreeIndex(tree())
+    expect(orphanedMirrorsBy(index, ['M'])).toEqual([])
+  })
+
+  test('a source is found even when it sits inside the deleted subtree', () => {
+    // Delete p's parent; src is a deep descendant whose mirror lives elsewhere.
+    const nested = [
+      makeNode({ id: 'top' }),
+      makeNode({ id: 'src', parentId: 'top', prevSiblingId: null }),
+      makeNode({ id: 'p', prevSiblingId: 'top' }),
+      makeNode({ id: 'M', parentId: 'p', prevSiblingId: null, mirrorOf: 'src' }),
+    ]
+    const index = buildTreeIndex(nested)
+    expect(orphanedMirrorsBy(index, ['top'])).toEqual(['M'])
+  })
+
+  test('deleting a source together with all its mirrors is safe', () => {
+    // Both src and its only mirror M sit under `top`, so deleting top takes both.
+    const together = [
+      makeNode({ id: 'top' }),
+      makeNode({ id: 'src', parentId: 'top', prevSiblingId: null }),
+      makeNode({ id: 'M', parentId: 'top', prevSiblingId: 'src', mirrorOf: 'src' }),
+    ]
+    const index = buildTreeIndex(together)
+    expect(orphanedMirrorsBy(index, ['top'])).toEqual([])
+  })
+
+  test('a mirror-free deletion is always safe', () => {
+    const index = buildTreeIndex([
+      makeNode({ id: 'a' }),
+      makeNode({ id: 'b', parentId: 'a', prevSiblingId: null }),
+    ])
+    expect(orphanedMirrorsBy(index, ['a'])).toEqual([])
   })
 })
 

--- a/src/data/tree.test.ts
+++ b/src/data/tree.test.ts
@@ -36,6 +36,34 @@ describe('buildTreeIndex + childrenOf', () => {
   })
 })
 
+describe('buildTreeIndex mirrorsBySource (ADR 0022)', () => {
+  test('is empty for a mirror-free outline', () => {
+    const a = makeNode({ id: 'a' })
+    const b = makeNode({ id: 'b', prevSiblingId: 'a' })
+    const index = buildTreeIndex([a, b])
+    expect(index.mirrorsBySource.size).toBe(0)
+  })
+
+  test('buckets every mirror under its source id', () => {
+    const src = makeNode({ id: 'src' })
+    const m1 = makeNode({ id: 'm1', mirrorOf: 'src' })
+    const m2 = makeNode({ id: 'm2', mirrorOf: 'src' })
+    const other = makeNode({ id: 'other' })
+    const index = buildTreeIndex([src, m1, m2, other])
+
+    expect(index.mirrorsBySource.get('src')).toEqual(['m1', 'm2'])
+    // A source is not its own mirror; an un-mirrored node has no bucket.
+    expect(index.mirrorsBySource.has('other')).toBe(false)
+    expect(index.mirrorsBySource.has('m1')).toBe(false)
+  })
+
+  test('a mirror whose source is absent still indexes (broken-mirror tolerant)', () => {
+    const m = makeNode({ id: 'm', mirrorOf: 'ghost' })
+    const index = buildTreeIndex([m])
+    expect(index.mirrorsBySource.get('ghost')).toEqual(['m'])
+  })
+})
+
 describe('buildTrail', () => {
   // a -> b -> c (parent chain)
   const a = makeNode({ id: 'a', parentId: null })

--- a/src/data/tree.test.ts
+++ b/src/data/tree.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, test } from 'bun:test'
-import { buildTrail, buildTreeIndex, childrenOf, makeNode } from './tree'
+import {
+  buildTrail,
+  buildTreeIndex,
+  childrenOf,
+  makeNode,
+  trueSourceOf,
+  wouldMirrorCycle,
+} from './tree'
 
 describe('buildTreeIndex + childrenOf', () => {
   test('orders siblings by the prevSiblingId chain, not input order', () => {
@@ -61,6 +68,60 @@ describe('buildTreeIndex mirrorsBySource (ADR 0022)', () => {
     const m = makeNode({ id: 'm', mirrorOf: 'ghost' })
     const index = buildTreeIndex([m])
     expect(index.mirrorsBySource.get('ghost')).toEqual(['m'])
+  })
+})
+
+describe('trueSourceOf (mirror flatten, ADR 0022)', () => {
+  const src = makeNode({ id: 'src' })
+  const m = makeNode({ id: 'm', mirrorOf: 'src' })
+  const plain = makeNode({ id: 'plain' })
+  const index = buildTreeIndex([src, m, plain])
+
+  test('a non-mirror node is its own source', () => {
+    expect(trueSourceOf(index, 'plain')).toBe('plain')
+    expect(trueSourceOf(index, 'src')).toBe('src')
+  })
+
+  test('a mirror resolves to its source (one hop -- the create invariant)', () => {
+    // mirrorOf always points at a TRUE source, so mirroring a mirror flattens to
+    // that same source rather than chaining through the mirror.
+    expect(trueSourceOf(index, 'm')).toBe('src')
+  })
+
+  test('an unknown id resolves to itself (tolerant)', () => {
+    expect(trueSourceOf(index, 'ghost')).toBe('ghost')
+  })
+})
+
+describe('wouldMirrorCycle (ADR 0022)', () => {
+  // src > c > gc ; `other` is an unrelated top-level node.
+  const src = makeNode({ id: 'src', parentId: null })
+  const c = makeNode({ id: 'c', parentId: 'src' })
+  const gc = makeNode({ id: 'gc', parentId: 'c' })
+  const other = makeNode({ id: 'other', parentId: null, prevSiblingId: 'src' })
+  const index = buildTreeIndex([src, c, gc, other])
+
+  test('mirroring into an unrelated branch is fine', () => {
+    expect(wouldMirrorCycle(index, 'src', 'other')).toBe(false)
+  })
+
+  test('mirroring into the source itself cycles', () => {
+    expect(wouldMirrorCycle(index, 'src', 'src')).toBe(true)
+  })
+
+  test('mirroring into a descendant of the source cycles (direct + deep)', () => {
+    expect(wouldMirrorCycle(index, 'src', 'c')).toBe(true)
+    expect(wouldMirrorCycle(index, 'src', 'gc')).toBe(true)
+  })
+
+  test('mirroring a descendant under the source does NOT cycle', () => {
+    // A mirror of `c` placed under `src` windows c's subtree, which never
+    // contains the mirror -- only `src` being an ancestor would close a loop.
+    expect(wouldMirrorCycle(index, 'c', 'src')).toBe(false)
+  })
+
+  test('Home (null parent) never cycles', () => {
+    expect(wouldMirrorCycle(index, 'src', null)).toBe(false)
   })
 })
 

--- a/src/data/tree.ts
+++ b/src/data/tree.ts
@@ -19,6 +19,15 @@ export interface TreeIndex {
   /** parentId -> ordered child *ids*, plus the synthetic ROOT_PARENT for top-level */
   childrenByParent: Map<string, string[]>
   byId: Map<string, Node>
+  /**
+   * Reverse mirror index (ADR 0022): a source node's id -> ids of the *mirror*
+   * nodes pointing at it (`mirrorOf === sourceId`). Built here and maintained
+   * incrementally in tree-store.ts alongside `childrenByParent`. Stage 0 fills
+   * it but nothing reads it yet; Stage 1 uses it for the "mirrored xN" badge,
+   * Stage 3 for promote-on-delete. Empty for any mirror-free outline (every
+   * `mirrorOf` is null), so it costs nothing today.
+   */
+  mirrorsBySource: Map<string, string[]>
 }
 
 /** Synthetic parent id for top-level nodes (those with parentId === null). */
@@ -50,7 +59,17 @@ export function buildTreeIndex(nodes: Node[]): TreeIndex {
     childrenByParent.set(parentKey, orderSiblings(list).map((n) => n.id))
   }
 
-  return { childrenByParent, byId }
+  // Reverse mirror index (ADR 0022): bucket each mirror's id under its source.
+  // Source order within a bucket is arbitrary (callers sort if they care).
+  const mirrorsBySource = new Map<string, string[]>()
+  for (const node of nodes) {
+    if (!node.mirrorOf) continue
+    const list = mirrorsBySource.get(node.mirrorOf)
+    if (list) list.push(node.id)
+    else mirrorsBySource.set(node.mirrorOf, [node.id])
+  }
+
+  return { childrenByParent, byId, mirrorsBySource }
 }
 
 export function childrenOf(index: TreeIndex, parentId: string | null): Node[] {
@@ -126,6 +145,7 @@ export function makeNode(partial: Partial<Node> & Pick<Node, 'id'>): Node {
     completed: false,
     collapsed: false,
     bookmarkedAt: null,
+    mirrorOf: null,
     createdAt: now(),
     updatedAt: now(),
     ...partial,

--- a/src/data/tree.ts
+++ b/src/data/tree.ts
@@ -84,6 +84,36 @@ export function childrenOf(index: TreeIndex, parentId: string | null): Node[] {
 }
 
 /**
+ * The mirror instances that deleting `ids` (and their subtrees) would ORPHAN: a
+ * source in the deletion set whose mirror lives OUTSIDE it. Empty = safe.
+ *
+ * `removeNode` cascades, so the whole subtree of each id is collected, then any
+ * mirror whose source is being deleted but which itself survives is an orphan.
+ * Deleting a source-and-all-its-mirrors together (both in the set) is safe;
+ * deleting a plain mirror is always safe (a mirror is never a source). The
+ * caller blocks the delete when this is non-empty (ADR 0022: promote-on-delete
+ * is Stage 3, so v1 protects rather than orphans). Mirror-free outline -> the
+ * `mirrorsBySource` lookups all miss, so this is O(subtree) and returns [].
+ */
+export function orphanedMirrorsBy(index: TreeIndex, ids: string[]): string[] {
+  const deleting = new Set<string>()
+  const stack = [...ids]
+  while (stack.length) {
+    const id = stack.pop()!
+    if (deleting.has(id)) continue
+    deleting.add(id)
+    for (const k of childrenOf(index, id)) stack.push(k.id)
+  }
+  const orphans: string[] = []
+  for (const sourceId of deleting) {
+    const mirrors = index.mirrorsBySource.get(sourceId)
+    if (!mirrors) continue
+    for (const m of mirrors) if (!deleting.has(m)) orphans.push(m)
+  }
+  return orphans
+}
+
+/**
  * Re-derive one parent's ordered child ids from the live `byId`: map ids ->
  * nodes, run the canonical sibling-chain order, map back to ids. Used by the
  * incremental tree-store to re-sort a parent whose membership or sibling order

--- a/src/data/tree.ts
+++ b/src/data/tree.ts
@@ -120,6 +120,37 @@ export function buildTrail(index: TreeIndex, rootId: string | null): Node[] {
   return trail
 }
 
+/**
+ * The canonical content node for a mirror source: a mirror's own source, or the
+ * node itself when it isn't a mirror. Flattens mirror-of-mirror so every created
+ * mirror points at ONE true source -- there's never a chain to resolve (ADR
+ * 0022). Pure -- reads `index` only.
+ */
+export function trueSourceOf(index: TreeIndex, sourceId: string): string {
+  return index.byId.get(sourceId)?.mirrorOf ?? sourceId
+}
+
+/**
+ * Whether mirroring the content node `trueSourceId` under `destParentId` would
+ * form a cycle: the source is the destination itself, or an ancestor of it, so
+ * the mirror would window a subtree that contains the mirror (ADR 0022). Home
+ * (a null parent) never cycles. The render walk caps such a cycle if one forms
+ * later (a move), but creation refuses it outright. Pure -- reads `index` only.
+ */
+export function wouldMirrorCycle(
+  index: TreeIndex,
+  trueSourceId: string,
+  destParentId: string | null,
+): boolean {
+  let cursor: string | null = destParentId
+  let guard = index.byId.size + 1
+  while (cursor && guard-- > 0) {
+    if (cursor === trueSourceId) return true
+    cursor = index.byId.get(cursor)?.parentId ?? null
+  }
+  return false
+}
+
 /** Stable-ish id. crypto.randomUUID is ubiquitous in modern browsers. */
 export function createId(): string {
   if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {

--- a/src/data/visible-order.test.ts
+++ b/src/data/visible-order.test.ts
@@ -3,7 +3,9 @@ import { buildTreeIndex, makeNode } from './tree'
 import {
   buildVisibleRows,
   contentIdForKey,
+  focusKeyAfterEdit,
   instanceIdForKey,
+  parentKeyOf,
   parseRowKey,
   rowKeyFor,
 } from './visible-order'
@@ -251,5 +253,77 @@ describe('row-key helpers (the Stage 2 identity keystone, ADR 0022)', () => {
       expect(instanceIdForKey(r.key)).toBe(r.id)
       expect(contentIdForKey(plain, r.key)).toBe(r.id)
     }
+  })
+})
+
+describe('parentKeyOf (Stage 2c focus composition)', () => {
+  test('a bare key has no parent (top level / pre-mirror)', () => {
+    expect(parentKeyOf('a1')).toBeNull()
+  })
+
+  test('drops the last segment of a compound key', () => {
+    expect(parentKeyOf(rowKeyFor('M', 'a1'))).toBe('M')
+    expect(parentKeyOf(rowKeyFor(rowKeyFor('M', 'a1'), 'leaf'))).toBe(
+      rowKeyFor('M', 'a1'),
+    )
+  })
+
+  test('inverse of rowKeyFor: recompose a sibling under the same parent', () => {
+    const child = rowKeyFor('M', 'a1')
+    // A sibling of `child` shares its parent prefix.
+    expect(rowKeyFor(parentKeyOf(child), 'a2')).toBe(rowKeyFor('M', 'a2'))
+    // For a bare key the sibling stays bare (today's identity).
+    expect(rowKeyFor(parentKeyOf('a1'), 'a2')).toBe('a2')
+  })
+})
+
+describe('focusKeyAfterEdit (land focus in the editing instance, ADR 0022 2c)', () => {
+  // A          (source)
+  //   a1
+  //   a2
+  // P
+  //   M -> A   (windows a1, a2)
+  const tree = [
+    makeNode({ id: 'A', prevSiblingId: null }),
+    makeNode({ id: 'P', prevSiblingId: 'A' }),
+    makeNode({ id: 'a1', parentId: 'A', prevSiblingId: null }),
+    makeNode({ id: 'a2', parentId: 'A', prevSiblingId: 'a1' }),
+    makeNode({ id: 'M', parentId: 'P', prevSiblingId: null, mirrorOf: 'A' }),
+  ]
+  const rows = buildVisibleRows(buildTreeIndex(tree), null, show, null, true)
+
+  test('a unique (mirror-free) id resolves to its own bare key', () => {
+    // P appears once; the active key is irrelevant.
+    expect(focusKeyAfterEdit(rows, 'P', 'anything')).toBe('P')
+  })
+
+  test('a duplicated id resolves to the copy under the active mirror anchor', () => {
+    // a1 appears under the real source (key 'a1') AND under the mirror M
+    // (key M·a1). Editing under M must keep focus under M, not teleport to A.
+    expect(focusKeyAfterEdit(rows, 'a1', rowKeyFor('M', 'a2'))).toBe(
+      rowKeyFor('M', 'a1'),
+    )
+    // Conversely, editing under the real source (bare active key) keeps the bare
+    // copy.
+    expect(focusKeyAfterEdit(rows, 'a1', 'a2')).toBe('a1')
+  })
+
+  test('a newly inserted source child lands under the editing mirror', () => {
+    // Simulate inserting a child `n` under source A: it windows under M too.
+    const withChild = buildVisibleRows(
+      buildTreeIndex([...tree, makeNode({ id: 'n', parentId: 'A', prevSiblingId: 'a2' })]),
+      null,
+      show,
+      null,
+      true,
+    )
+    // Editing on the mirror row M (active key 'M'): focus the windowed copy.
+    expect(focusKeyAfterEdit(withChild, 'n', 'M')).toBe(rowKeyFor('M', 'n'))
+    // Editing on the real source A (active key 'A'): focus the bare copy.
+    expect(focusKeyAfterEdit(withChild, 'n', 'A')).toBe('n')
+  })
+
+  test('returns null when the id is no longer visible (moved out of the view)', () => {
+    expect(focusKeyAfterEdit(rows, 'ghost', 'M')).toBeNull()
   })
 })

--- a/src/data/visible-order.test.ts
+++ b/src/data/visible-order.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from 'bun:test'
 import { buildTreeIndex, makeNode } from './tree'
-import { buildVisibleRows } from './visible-order'
+import {
+  buildVisibleRows,
+  contentIdForKey,
+  instanceIdForKey,
+  parseRowKey,
+  rowKeyFor,
+} from './visible-order'
 
 const show = () => false // nothing hidden
 const hideCompleted = (n: { completed: boolean }) => n.completed
@@ -170,5 +176,80 @@ describe('buildVisibleRows — cycle + broken guards', () => {
     expect(m.broken).toBe(true)
     expect(m.contentId).toBe('ghost')
     expect(rows).toHaveLength(1) // no children expanded
+  })
+})
+
+describe('row-key helpers (the Stage 2 identity keystone, ADR 0022)', () => {
+  // A          (source)
+  //   a1
+  // P
+  //   M -> A   (windows a1)
+  const tree = [
+    makeNode({ id: 'A', prevSiblingId: null }),
+    makeNode({ id: 'P', prevSiblingId: 'A' }),
+    makeNode({ id: 'a1', parentId: 'A', prevSiblingId: null }),
+    makeNode({ id: 'M', parentId: 'P', prevSiblingId: null, mirrorOf: 'A' }),
+  ]
+  const index = buildTreeIndex(tree)
+
+  test('parseRowKey / instanceIdForKey: a bare id is a single segment', () => {
+    expect(parseRowKey('a1')).toEqual(['a1'])
+    expect(instanceIdForKey('a1')).toBe('a1')
+  })
+
+  test('rowKeyFor composes, and parseRowKey is its inverse', () => {
+    const childKey = rowKeyFor('M', 'a1')
+    expect(parseRowKey(childKey)).toEqual(['M', 'a1'])
+    expect(instanceIdForKey(childKey)).toBe('a1')
+    // Top level (no prefix) is the bare id — today's identity.
+    expect(rowKeyFor(null, 'x')).toBe('x')
+    // Nesting composes left-to-right.
+    expect(parseRowKey(rowKeyFor(rowKeyFor('M', 'a1'), 'leaf'))).toEqual([
+      'M',
+      'a1',
+      'leaf',
+    ])
+  })
+
+  test('rowKeyFor matches the address buildVisibleRows actually emits', () => {
+    const rows = buildVisibleRows(index, null, show, null, true)
+    // a1 appears under the real source (bare id) and under the mirror (path key).
+    const windowed = rows.find((r) => r.id === 'a1' && r.key !== 'a1')!
+    expect(windowed.key).toBe(rowKeyFor('M', 'a1'))
+  })
+
+  test('contentIdForKey resolves a mirror to its source, a real node to itself', () => {
+    // The mirror row's key resolves to the SOURCE's content id.
+    expect(contentIdForKey(index, 'M')).toBe('A')
+    // A windowed real descendant reads its own content (it is not itself a mirror).
+    expect(contentIdForKey(index, rowKeyFor('M', 'a1'))).toBe('a1')
+    // A bare real node is its own content.
+    expect(contentIdForKey(index, 'a1')).toBe('a1')
+    // Unknown node falls back to the raw instance id, never throws.
+    expect(contentIdForKey(index, 'ghost')).toBe('ghost')
+  })
+
+  test('INVARIANT: helpers agree with every row buildVisibleRows emits', () => {
+    const rows = buildVisibleRows(index, null, show, null, true)
+    for (const r of rows) {
+      // The key always points back at the row's own instance id...
+      expect(instanceIdForKey(r.key)).toBe(r.id)
+      // ...and resolves to the same content id the walk computed.
+      expect(contentIdForKey(index, r.key)).toBe(r.contentId)
+    }
+  })
+
+  test('INVARIANT: key === id for a mirror-free tree (flag-off parity budget)', () => {
+    const plain = buildTreeIndex([
+      makeNode({ id: 'A', prevSiblingId: null }),
+      makeNode({ id: 'a1', parentId: 'A', prevSiblingId: null }),
+      makeNode({ id: 'a2', parentId: 'A', prevSiblingId: 'a1' }),
+    ])
+    const rows = buildVisibleRows(plain, null, show, null, true)
+    for (const r of rows) {
+      expect(r.key).toBe(r.id)
+      expect(instanceIdForKey(r.key)).toBe(r.id)
+      expect(contentIdForKey(plain, r.key)).toBe(r.id)
+    }
   })
 })

--- a/src/data/visible-order.test.ts
+++ b/src/data/visible-order.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, test } from 'bun:test'
+import { buildTreeIndex, makeNode } from './tree'
+import { buildVisibleRows } from './visible-order'
+
+const show = () => false // nothing hidden
+const hideCompleted = (n: { completed: boolean }) => n.completed
+
+describe('buildVisibleRows — mirror-free parity (the default path)', () => {
+  // A
+  //   a1
+  //   a2
+  // B
+  const tree = [
+    makeNode({ id: 'A', prevSiblingId: null }),
+    makeNode({ id: 'B', prevSiblingId: 'A' }),
+    makeNode({ id: 'a1', parentId: 'A', prevSiblingId: null }),
+    makeNode({ id: 'a2', parentId: 'A', prevSiblingId: 'a1' }),
+  ]
+  const index = buildTreeIndex(tree)
+
+  test('every row is its own content, keyed by bare id, never a mirror', () => {
+    const rows = buildVisibleRows(index, null, show)
+    expect(rows.map((r) => r.id)).toEqual(['A', 'a1', 'a2', 'B'])
+    for (const r of rows) {
+      expect(r.contentId).toBe(r.id)
+      expect(r.key).toBe(r.id)
+      expect(r.isMirror).toBe(false)
+      expect(r.capped).toBe(false)
+      expect(r.broken).toBe(false)
+    }
+  })
+
+  test('depth + fade inheritance unchanged', () => {
+    const rows = buildVisibleRows(index, null, show)
+    expect(rows.find((r) => r.id === 'a1')?.depth).toBe(1)
+    expect(rows.find((r) => r.id === 'A')?.depth).toBe(0)
+  })
+
+  test('a node carrying mirrorOf is treated as normal while the flag is OFF', () => {
+    // Same node set, but B mirrors A. With mirrors disabled (default arg) B is an
+    // ordinary leaf — no source windowing, no resolution. Byte-identical to today.
+    const withMirror = [
+      makeNode({ id: 'A', prevSiblingId: null }),
+      makeNode({ id: 'B', prevSiblingId: 'A', mirrorOf: 'A' }),
+      makeNode({ id: 'a1', parentId: 'A', prevSiblingId: null }),
+    ]
+    const i2 = buildTreeIndex(withMirror)
+    const rows = buildVisibleRows(i2, null, show) // mirrorsEnabled defaults false
+    const b = rows.find((r) => r.id === 'B')!
+    expect(b.contentId).toBe('B')
+    expect(b.isMirror).toBe(false)
+    // B's "children" are not A's — A's children don't appear under B.
+    expect(rows.map((r) => r.id)).toEqual(['A', 'a1', 'B'])
+  })
+})
+
+describe('buildVisibleRows — mirrors enabled (ADR 0022)', () => {
+  // A          (source)
+  //   a1
+  //   a2
+  // P
+  //   M -> A   (a mirror of A, windowing a1/a2)
+  const tree = [
+    makeNode({ id: 'A', prevSiblingId: null }),
+    makeNode({ id: 'P', prevSiblingId: 'A' }),
+    makeNode({ id: 'a1', parentId: 'A', prevSiblingId: null }),
+    makeNode({ id: 'a2', parentId: 'A', prevSiblingId: 'a1' }),
+    makeNode({ id: 'M', parentId: 'P', prevSiblingId: null, mirrorOf: 'A' }),
+  ]
+  const index = buildTreeIndex(tree)
+
+  test("a mirror windows the source's children", () => {
+    const rows = buildVisibleRows(index, null, show, null, true)
+    expect(rows.map((r) => r.id)).toEqual(['A', 'a1', 'a2', 'P', 'M', 'a1', 'a2'])
+
+    const m = rows.find((r) => r.id === 'M')!
+    expect(m.isMirror).toBe(true)
+    expect(m.contentId).toBe('A') // reads the source's content
+    expect(m.key).toBe('M') // top-level mirror: bare id (no mirror crossed yet)
+    expect(m.capped).toBe(false)
+    expect(m.broken).toBe(false)
+  })
+
+  test('source descendants get unique path keys under the mirror, bare ids under the source', () => {
+    const rows = buildVisibleRows(index, null, show, null, true)
+    // Two rows share id 'a1' (real + mirrored) but their keys are distinct.
+    const a1Rows = rows.filter((r) => r.id === 'a1')
+    expect(a1Rows).toHaveLength(2)
+    const keys = a1Rows.map((r) => r.key)
+    expect(keys[0]).toBe('a1') // under the real source: bare id (today's identity)
+    expect(keys[1]).not.toBe('a1') // under the mirror: a compound path key
+    expect(new Set(rows.map((r) => r.key)).size).toBe(rows.length) // all keys unique
+    // The mirrored copies still read their own (real) content.
+    for (const r of a1Rows) expect(r.contentId).toBe('a1')
+  })
+
+  test('two mirrors of the same source keep distinct keys', () => {
+    // P holds two mirrors of A back to back.
+    const t2 = [
+      makeNode({ id: 'A', prevSiblingId: null }),
+      makeNode({ id: 'P', prevSiblingId: 'A' }),
+      makeNode({ id: 'a1', parentId: 'A', prevSiblingId: null }),
+      makeNode({ id: 'M1', parentId: 'P', prevSiblingId: null, mirrorOf: 'A' }),
+      makeNode({ id: 'M2', parentId: 'P', prevSiblingId: 'M1', mirrorOf: 'A' }),
+    ]
+    const rows = buildVisibleRows(buildTreeIndex(t2), null, show, null, true)
+    expect(new Set(rows.map((r) => r.key)).size).toBe(rows.length)
+  })
+
+  test('collapse is LOCAL to the instance — a collapsed mirror hides the source subtree', () => {
+    const t2 = [
+      makeNode({ id: 'A', prevSiblingId: null }),
+      makeNode({ id: 'P', prevSiblingId: 'A' }),
+      makeNode({ id: 'a1', parentId: 'A', prevSiblingId: null }),
+      // The mirror itself is collapsed; the source A is NOT.
+      makeNode({ id: 'M', parentId: 'P', prevSiblingId: null, mirrorOf: 'A', collapsed: true }),
+    ]
+    const rows = buildVisibleRows(buildTreeIndex(t2), null, show, null, true)
+    // a1 appears once (under the real, expanded A) — not under the collapsed mirror.
+    expect(rows.filter((r) => r.id === 'a1')).toHaveLength(1)
+    expect(rows.map((r) => r.id)).toEqual(['A', 'a1', 'P', 'M'])
+  })
+
+  test("visibility prunes follow the SOURCE's completed (content), not the instance", () => {
+    // Source A is completed; the mirror node M itself is not.
+    const t2 = [
+      makeNode({ id: 'A', prevSiblingId: null, completed: true }),
+      makeNode({ id: 'P', prevSiblingId: 'A' }),
+      makeNode({ id: 'M', parentId: 'P', prevSiblingId: null, mirrorOf: 'A', completed: false }),
+    ]
+    const rows = buildVisibleRows(buildTreeIndex(t2), null, hideCompleted, null, true)
+    // Hide-completed reads the resolved content (A is completed), so the mirror is
+    // pruned — checking the source off hides every instance.
+    expect(rows.some((r) => r.id === 'M')).toBe(false)
+    expect(rows.some((r) => r.id === 'A')).toBe(false)
+  })
+})
+
+describe('buildVisibleRows — cycle + broken guards', () => {
+  test('a mirror whose source is an ancestor caps instead of looping', () => {
+    // A contains a mirror of A — an immediate cycle.
+    const t = [
+      makeNode({ id: 'A', prevSiblingId: null }),
+      makeNode({ id: 'M', parentId: 'A', prevSiblingId: null, mirrorOf: 'A' }),
+    ]
+    const rows = buildVisibleRows(buildTreeIndex(t), null, show, null, true)
+    const m = rows.find((r) => r.id === 'M')!
+    expect(m.isMirror).toBe(true)
+    expect(m.capped).toBe(true)
+    // Capped => not expanded: no second copy of M (or A) underneath it.
+    expect(rows.map((r) => r.id)).toEqual(['A', 'M'])
+  })
+
+  test('a deep cycle (mirror of an ancestor several levels up) still caps', () => {
+    // A > b > M(->A): M's source A is an expanded ancestor.
+    const t = [
+      makeNode({ id: 'A', prevSiblingId: null }),
+      makeNode({ id: 'b', parentId: 'A', prevSiblingId: null }),
+      makeNode({ id: 'M', parentId: 'b', prevSiblingId: null, mirrorOf: 'A' }),
+    ]
+    const rows = buildVisibleRows(buildTreeIndex(t), null, show, null, true)
+    expect(rows.find((r) => r.id === 'M')?.capped).toBe(true)
+    expect(rows.map((r) => r.id)).toEqual(['A', 'b', 'M'])
+  })
+
+  test('a mirror whose source is missing renders a broken leaf, never throws', () => {
+    const t = [makeNode({ id: 'M', prevSiblingId: null, mirrorOf: 'ghost' })]
+    const rows = buildVisibleRows(buildTreeIndex(t), null, show, null, true)
+    const m = rows.find((r) => r.id === 'M')!
+    expect(m.broken).toBe(true)
+    expect(m.contentId).toBe('ghost')
+    expect(rows).toHaveLength(1) // no children expanded
+  })
+})

--- a/src/data/visible-order.ts
+++ b/src/data/visible-order.ts
@@ -51,6 +51,49 @@ export interface VisibleRow {
 const PATH_SEP = String.fromCharCode(1)
 
 /**
+ * Split a {@link VisibleRow.key} back into its segment node ids. A mirror-free
+ * key is a single bare id, so this returns `[id]`; a key inside a mirrored
+ * subtree is the `PATH_SEP`-joined instance-id chain, so this returns each hop
+ * in display order. The LAST segment is always the row's own instance id
+ * (ADR 0022).
+ */
+export function parseRowKey(key: string): string[] {
+  return key.split(PATH_SEP)
+}
+
+/**
+ * The row's own instance (position) node id — the last path segment. For a
+ * mirror-free key this is the key itself, so `instanceIdForKey(id) === id`.
+ */
+export function instanceIdForKey(key: string): string {
+  const i = key.lastIndexOf(PATH_SEP)
+  return i === -1 ? key : key.slice(i + 1)
+}
+
+/**
+ * The CONTENT node id a row key reads from: its instance id resolved through
+ * `mirrorOf` (a mirror windows its source). Equals {@link VisibleRow.contentId},
+ * but recomputed from a bare key for the callers that hold a key without the row
+ * object (focus restore, caret nav). Falls back to the raw instance id when the
+ * node is unknown. For a mirror-free row, content === instance === the key.
+ */
+export function contentIdForKey(index: TreeIndex, key: string): string {
+  const instanceId = instanceIdForKey(key)
+  return index.byId.get(instanceId)?.mirrorOf ?? instanceId
+}
+
+/**
+ * Compose a child row key from its parent's path prefix and the child's instance
+ * id — the inverse of {@link parseRowKey}. `prefix` is the parent row's key when
+ * the child sits inside a crossed mirror; `null`/empty at the top level (the
+ * child key is then its bare id, matching today's identity). Used by the
+ * structural-redirect and caret-nav slices to land focus on the right instance.
+ */
+export function rowKeyFor(prefix: string | null, instanceId: string): string {
+  return prefix ? prefix + PATH_SEP + instanceId : instanceId
+}
+
+/**
  * The visible (non-collapsed, non-hidden) descendants of `rootId` in display
  * order, flattened to a depth-tagged list. EXCLUDES the root itself: when zoomed
  * the root renders as the page title (not a list row), and at the top level
@@ -89,9 +132,12 @@ export function buildVisibleRows(
     contentParentId: string | null,
     depth: number,
     ancestorCompleted: boolean,
-    // The instance-id chain of ancestors below the root. Only consulted (and only
-    // grown) once a mirror has been crossed, so it stays `[]` in the mirror-free
-    // path.
+    // The instance-id chain ANCHORED AT THE CROSSING MIRROR: empty until a mirror
+    // is crossed, then the mirror's own id followed by each instance id down to
+    // (not including) the current child. So a crossed row's key is
+    // `mirrorId[·childId]*` and composes cleanly — `childKey === rowKeyFor(
+    // parentKey, childId)` (see {@link rowKeyFor}), which the Stage 2 caret/
+    // structural slices rely on. Stays `[]` in the mirror-free path.
     path: string[],
     // Has the walk descended through a mirror to reach here? Once true, rows take
     // a compound path key (their bare id is duplicated across instances).
@@ -167,7 +213,11 @@ export function buildVisibleRows(
           contentId,
           depth + 1,
           childFade,
-          mirrorsEnabled ? path.concat(child.id) : path,
+          // Grow the path only from the crossing mirror down (mirror-free /
+          // pre-crossing levels keep it `[]`, so the key stays the bare id and
+          // the 99% outline is unchanged). `crossed || mirrored` is exactly the
+          // next level's `crossed`, so the path and the key grow in lockstep.
+          crossed || mirrored ? path.concat(child.id) : path,
           crossed || mirrored,
           mirrorsEnabled ? new Set(expandedContent).add(contentId) : expandedContent,
         )

--- a/src/data/visible-order.ts
+++ b/src/data/visible-order.ts
@@ -94,6 +94,17 @@ export function rowKeyFor(prefix: string | null, instanceId: string): string {
 }
 
 /**
+ * The parent row's key — drop the last path segment. `null` for a bare key (top
+ * level / pre-mirror), matching {@link rowKeyFor}'s null prefix, so the round trip
+ * holds: `rowKeyFor(parentKeyOf(childKey), instanceIdForKey(childKey)) === childKey`.
+ * Used by the structural slice to compose a new sibling's key from the active row.
+ */
+export function parentKeyOf(key: string): string | null {
+  const i = key.lastIndexOf(PATH_SEP)
+  return i === -1 ? null : key.slice(0, i)
+}
+
+/**
  * The visible (non-collapsed, non-hidden) descendants of `rootId` in display
  * order, flattened to a depth-tagged list. EXCLUDES the root itself: when zoomed
  * the root renders as the page title (not a list row), and at the top level
@@ -262,6 +273,48 @@ export function findVisibleNeighbor(
   if (i === -1) return null
   const neighbor = direction === 'up' ? seq[i - 1] : seq[i + 1]
   return neighbor ?? null
+}
+
+/**
+ * The render key to focus after a structural edit (insert / move) inside a mirror
+ * (ADR 0022, Stage 2c). A source descendant windows into EVERY instance, so a node
+ * id can address several rows; focus must land in the instance the user was
+ * editing. Rather than compose the key by hand (fragile across reparent moves),
+ * re-derive it from the freshly-built visible rows — the SAME render walk the UI
+ * uses, so the focus key can never drift from what's on screen.
+ *
+ * Picks the row with `id === instanceId` whose key shares the longest leading-
+ * segment prefix with `activeKey` (the pre-edit focused row): that's the copy
+ * under the same crossed-mirror anchor. Ties resolve to the SHALLOWEST key (fewest
+ * segments) — the copy nearest the source. Returns `null` when no visible row has
+ * that id (e.g. an outdent pushed the node out of the current view). For a
+ * mirror-free outline a node id is unique, so the single match is its bare key.
+ * Pure.
+ */
+export function focusKeyAfterEdit(
+  rows: readonly VisibleRow[],
+  instanceId: string,
+  activeKey: string,
+): string | null {
+  const active = parseRowKey(activeKey)
+  let best: VisibleRow | null = null
+  let bestShared = -1
+  for (const r of rows) {
+    if (r.id !== instanceId) continue
+    const segs = parseRowKey(r.key)
+    let shared = 0
+    while (shared < segs.length && shared < active.length && segs[shared] === active[shared]) {
+      shared++
+    }
+    if (
+      shared > bestShared ||
+      (shared === bestShared && best !== null && segs.length < parseRowKey(best.key).length)
+    ) {
+      bestShared = shared
+      best = r
+    }
+  }
+  return best?.key ?? null
 }
 
 /**

--- a/src/data/visible-order.ts
+++ b/src/data/visible-order.ts
@@ -233,24 +233,32 @@ export function buildVisibleRows(
 const EMPTY_EXPANDED: ReadonlySet<string> = new Set<string>()
 
 /**
- * The id immediately before/after `id` in visible display order within the zoom
- * root, or null if none. Used for caret motion across bullets and for landing
- * the caret above/below a node multi-selection.
+ * The row KEY immediately before/after `key` in visible display order within the
+ * zoom root, or null if none. Used for caret motion across bullets and for
+ * landing the caret above/below a node multi-selection. Takes and returns row
+ * keys (the render address), so it crosses mirror boundaries correctly — a
+ * windowed source descendant has a path key, not a bare id (ADR 0022). For a
+ * mirror-free row key === id, so this is unchanged from before.
+ *
+ * `mirrorsEnabled` MUST match how the editor renders (callers pass
+ * `isMirrorsEnabled()`): the neighbor sequence has to be the rendered sequence,
+ * or a mirror elsewhere in the view shifts the rows and the neighbor is wrong.
  *
  * The root is prepended so ArrowUp from the first child lands on the title (the
- * root registers a contentEditable span under its own id). Filter is not applied
- * here -- caret nav walks the unfiltered visible tree, unchanged from before.
+ * root registers a contentEditable span under its own id, which is its key).
+ * Filter is not applied here -- caret nav walks the unfiltered visible tree.
  */
 export function findVisibleNeighbor(
   index: TreeIndex,
   rootId: string | null,
-  id: string,
+  key: string,
   direction: 'up' | 'down',
   isHidden: (n: Node) => boolean,
+  mirrorsEnabled = false,
 ): string | null {
-  const rows = buildVisibleRows(index, rootId, isHidden)
-  const seq = rootId ? [rootId, ...rows.map((r) => r.id)] : rows.map((r) => r.id)
-  const i = seq.indexOf(id)
+  const rows = buildVisibleRows(index, rootId, isHidden, null, mirrorsEnabled)
+  const seq = rootId ? [rootId, ...rows.map((r) => r.key)] : rows.map((r) => r.key)
+  const i = seq.indexOf(key)
   if (i === -1) return null
   const neighbor = direction === 'up' ? seq[i - 1] : seq[i + 1]
   return neighbor ?? null

--- a/src/data/visible-order.ts
+++ b/src/data/visible-order.ts
@@ -11,10 +11,44 @@ import type { TagFilter } from './tags'
  * without a parent passing it a prop (ADR 0002).
  */
 export interface VisibleRow {
+  /**
+   * The instance/position node id — where this row physically sits. Its
+   * `parentId`/`prevSiblingId`, `collapsed`, and drag target are read from here.
+   * Equals {@link contentId} for every normal (non-mirror) row.
+   */
   id: string
+  /**
+   * The node to read CONTENT from — `text`, `isTask`, `completed`, and children:
+   * `mirrorOf ?? id` (ADR 0022). Differs from {@link id} only on a mirror's own
+   * row; everything inside a mirrored subtree is real nodes (content === id).
+   */
+  contentId: string
+  /**
+   * Unique render address: the React key, and (Stage 2) the refs/focus/flash/drag
+   * key. A bare `id` until the walk crosses a mirror, then a compound path key —
+   * because a source's descendant appears under every instance, so its bare id is
+   * no longer unique. Equal to `id` for every mirror-free row, so the 99% outline
+   * keeps today's exact identity (ADR 0022 "don't regress").
+   */
+  key: string
   depth: number
   ancestorCompleted: boolean
+  /** This row IS a mirror (its own `mirrorOf` is set). */
+  isMirror: boolean
+  /**
+   * A mirror whose source is already an expanded ancestor on this path: rendered
+   * as a non-expandable capped row so the walk can't recurse forever (the cycle
+   * net for a loop formed after creation — ADR 0022).
+   */
+  capped: boolean
+  /** A mirror whose `mirrorOf` resolves to no node (sync race / bug): rendered as
+   *  a "source not found" leaf, never expanded. */
+  broken: boolean
 }
+
+/** Path-key separator: a control char that can't appear in a node id, so a joined
+ *  path can't collide with another path or a bare id. */
+const PATH_SEP = String.fromCharCode(1)
 
 /**
  * The visible (non-collapsed, non-hidden) descendants of `rootId` in display
@@ -32,6 +66,13 @@ export interface VisibleRow {
  * recursive render's per-node filter. Omitted by the caret walk (nav doesn't
  * prune to the filter), so render and nav share one builder, parameterized.
  *
+ * `mirrorsEnabled` (ADR 0022) turns on mirror resolution: a node with `mirrorOf`
+ * windows its source's content + children, rows gain a content id + a path-based
+ * key, and cycles cap / broken sources render a leaf. Default OFF, and when off
+ * every branch collapses back to the original mirror-free walk (no resolution, no
+ * path keys, no per-level allocation) -- the "don't regress" rule. The caret walk
+ * omits it for now (mirror caret nav is Stage 2).
+ *
  * Pure; no DOM, no React.
  */
 export function buildVisibleRows(
@@ -39,26 +80,107 @@ export function buildVisibleRows(
   rootId: string | null,
   isHidden: (n: Node) => boolean,
   filter?: TagFilter | null,
+  mirrorsEnabled = false,
 ): VisibleRow[] {
   const out: VisibleRow[] = []
   const walk = (
-    parentId: string | null,
+    // The node whose children we iterate. For a normal parent this is its own id;
+    // for a mirror it is the SOURCE id (so a mirror windows the source's subtree).
+    contentParentId: string | null,
     depth: number,
     ancestorCompleted: boolean,
+    // The instance-id chain of ancestors below the root. Only consulted (and only
+    // grown) once a mirror has been crossed, so it stays `[]` in the mirror-free
+    // path.
+    path: string[],
+    // Has the walk descended through a mirror to reach here? Once true, rows take
+    // a compound path key (their bare id is duplicated across instances).
+    crossed: boolean,
+    // Content ids already expanded on this path (ancestor sources). A mirror whose
+    // source is in here would loop, so it caps. Only tracked under the flag.
+    expandedContent: ReadonlySet<string>,
   ) => {
-    for (const child of childrenOf(index, parentId)) {
-      if (isHidden(child)) continue
-      if (filter && !filter.visibleIds.has(child.id)) continue
-      out.push({ id: child.id, depth, ancestorCompleted })
-      // Faded children inherit the fade; filter-mode descends regardless of
-      // collapse so a deep match is still reached.
-      const childFade = ancestorCompleted || child.completed
-      if (filter || !child.collapsed) walk(child.id, depth + 1, childFade)
+    for (const child of childrenOf(index, contentParentId)) {
+      const mirrored = mirrorsEnabled && child.mirrorOf != null
+      const contentId = mirrored ? (child.mirrorOf as string) : child.id
+      const key = crossed ? path.concat(child.id).join(PATH_SEP) : child.id
+      // Content node: the mirror's source, or the node itself. A non-mirror reads
+      // its own row exactly as before (content === child).
+      const content = mirrored ? index.byId.get(contentId) : child
+
+      // Broken mirror: the source id resolves to nothing (sync race / bug). Render
+      // a "source not found" leaf, never recurse, never throw.
+      if (mirrored && !content) {
+        out.push({
+          id: child.id,
+          contentId,
+          key,
+          depth,
+          ancestorCompleted,
+          isMirror: true,
+          capped: false,
+          broken: true,
+        })
+        continue
+      }
+      // content is defined here (non-mirror → child; mirror → resolved source).
+      const c = content as Node
+      // Visibility prunes read CONTENT (a mirror of a completed task hides under
+      // hide-completed; a tag filter matches the source's text). Identical to the
+      // old `isHidden(child)` / `filter.has(child.id)` when content === child.
+      if (isHidden(c)) continue
+      if (filter && !filter.visibleIds.has(contentId)) continue
+
+      // Cycle net: this mirror's source is already an expanded ancestor. Cap it
+      // (non-expandable; the UI shows a badge + jump-to-source) instead of looping.
+      if (mirrored && expandedContent.has(contentId)) {
+        out.push({
+          id: child.id,
+          contentId,
+          key,
+          depth,
+          ancestorCompleted,
+          isMirror: true,
+          capped: true,
+          broken: false,
+        })
+        continue
+      }
+
+      out.push({
+        id: child.id,
+        contentId,
+        key,
+        depth,
+        ancestorCompleted,
+        isMirror: mirrored,
+        capped: false,
+        broken: false,
+      })
+
+      // Faded children inherit the fade (from CONTENT's completed); filter-mode
+      // descends regardless of collapse so a deep match is still reached. Collapse
+      // is LOCAL -- read from the instance node (`child`), not the content.
+      const childFade = ancestorCompleted || c.completed
+      if (filter || !child.collapsed) {
+        walk(
+          contentId,
+          depth + 1,
+          childFade,
+          mirrorsEnabled ? path.concat(child.id) : path,
+          crossed || mirrored,
+          mirrorsEnabled ? new Set(expandedContent).add(contentId) : expandedContent,
+        )
+      }
     }
   }
-  walk(rootId, 0, false)
+  walk(rootId, 0, false, [], false, mirrorsEnabled && rootId ? new Set([rootId]) : EMPTY_EXPANDED)
   return out
 }
+
+/** Shared empty set for the mirror-free recursion (never mutated — the walk only
+ *  ever copies it via `new Set(...)` under the flag). */
+const EMPTY_EXPANDED: ReadonlySet<string> = new Set<string>()
 
 /**
  * The id immediately before/after `id` in visible display order within the zoom

--- a/src/plugins/daily/index.tsx
+++ b/src/plugins/daily/index.tsx
@@ -16,6 +16,7 @@
 import {
   CalendarArrowDownIcon,
   CalendarDaysIcon,
+  CalendarPlusIcon,
   Loader2Icon,
   SunIcon,
 } from "lucide-react";
@@ -24,9 +25,12 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { definePlugin, type PluginContext } from "../types";
 import { capture, drop } from "../../data/history";
+import { isMirrorsEnabled } from "../../data/flags";
 import {
   appendChild,
   insertChildAtStart,
+  mirrorManyNodes,
+  mirrorNode,
   moveManyNodes,
   moveNode,
   setText,
@@ -325,6 +329,64 @@ export default definePlugin({
           return;
         }
         toast.success(`Moved ${moved} to Today`, {
+          action: { label: "Go", onClick: () => ctx.nav.zoom(todayId) },
+        });
+      },
+    },
+
+    // Seam C: the mirror sibling of "Send to Today" -- create a LIVE copy of the
+    // node under today's note (ADR 0022) instead of moving it, so the same node
+    // stays where it is AND appears in Today, editable from both. Hidden until
+    // the mirrors flag is on. No picker: the destination is always today.
+    {
+      id: "mirror-to-today",
+      label: "Mirror to Today",
+      description: "Show a live copy under today's daily note",
+      icon: CalendarPlusIcon,
+      keywords: ["today", "daily", "mirror", "synced"],
+      available: () => isMirrorsEnabled(),
+      run: async (nodeId, ctx) => {
+        const todayId = await getOrCreateDay(localDateKey(), ctx.tree);
+        if (!todayId) {
+          toast.error("Couldn't open today's daily note");
+          return;
+        }
+        // Rebuild fresh: today may have just been created, so ctx.tree is stale
+        // (no `after`, no cycle context). Capture AFTER, so undo removes the
+        // mirror but keeps the new day note (mirrors the runMany path below).
+        const index = buildTreeIndex(nodesCollection.toArray);
+        const newId = runStructural(() => {
+          capture(index, nodeId);
+          return mirrorNode(index, nodeId, todayId);
+        });
+        if (!newId) {
+          drop();
+          toast.error("Can't mirror that into Today.");
+          return;
+        }
+        toast.success("Mirrored to Today", {
+          action: { label: "Go", onClick: () => ctx.nav.zoom(todayId) },
+        });
+      },
+      // Node multi-selection (ADR 0018): mirror every selected root under today
+      // in ONE batch. Captured against the LIVE tree AFTER the day exists, so
+      // undo removes the mirrors without deleting the freshly created day note.
+      runMany: async (ids, ctx) => {
+        const todayId = await getOrCreateDay(localDateKey(), ctx.tree);
+        if (!todayId) {
+          toast.error("Couldn't open today's daily note");
+          return;
+        }
+        const made = runStructural(() => {
+          capture(buildTreeIndex(nodesCollection.toArray), ids[0]!);
+          return mirrorManyNodes(todayId, ids);
+        });
+        if (!made) {
+          drop();
+          toast.error("Couldn't mirror those into Today.");
+          return;
+        }
+        toast.success(`Mirrored ${made} to Today`, {
           action: { label: "Go", onClick: () => ctx.nav.zoom(todayId) },
         });
       },

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -9,6 +9,7 @@ import { ThemeProvider } from '../components/theme-provider'
 import { ShowCompletedProvider } from '../components/show-completed-provider'
 import { NodeSwitcher } from '../components/node-switcher'
 import { MoveDialog } from '../components/move-dialog'
+import { MirrorPlaces } from '../components/mirror-places'
 import { TagColorStyles } from '../plugins/tags/tag-color-menu'
 import { PluginStyles } from '../components/plugin-styles'
 import { Toaster } from '../components/ui/sonner'
@@ -63,6 +64,7 @@ function RootComponent() {
             <Outlet />
             <NodeSwitcher />
             <MoveDialog />
+            <MirrorPlaces />
             <TagColorStyles />
             <PluginStyles />
           </ShowCompletedProvider>

--- a/src/styles.css
+++ b/src/styles.css
@@ -372,8 +372,8 @@ h2 > span.protected-lock {
  * `.outline-row` (the flex line), so depth indentation already offsets it.
  */
 .outline-node[data-mirror] > .outline-row {
-  box-shadow: inset 3px 0 0 0 transparent;
-  transition: box-shadow 0.12s ease;
+  outline: 2px solid transparent;
+  transition: outline-color 0.12s ease;
 }
 /*.outline-node[data-mirror="source"]:hover > .outline-row,*/
 .outline-node[data-mirror="source"]:focus-within > .outline-row {

--- a/src/styles.css
+++ b/src/styles.css
@@ -508,6 +508,18 @@ h2 > span.protected-lock {
   margin-top: 6px;
 }
 
+/* The mirror badge is a bordered pill in the same flex-start row; left at the
+   top it reads as jammed into the row's top edge, and a fixed margin would need
+   per-height tuning (cf. the checkbox's 6px and the daily badge's `mt-1`, each
+   tuned to its own height). `align-self: center` drops its middle onto the row's
+   cross-axis center -- which is the text line's center (the `.node-text` line
+   box fills the row's 28px content area) -- and self-adjusts if the badge height
+   changes. Scoped to the row for the same reason as the checkbox: the zoomed
+   title is already flex-centered, so the badge needs no nudge there. */
+.outline-row .mirror-badge {
+  align-self: center;
+}
+
 .node-text {
   flex: 1 1 auto;
   min-height: 24px;

--- a/src/styles.css
+++ b/src/styles.css
@@ -81,6 +81,11 @@
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
+  /* Node mirrors (ADR 0022): a source hue and a distinct instance hue, the only
+   * chromatic accents in an otherwise grayscale theme, so a colored edge reads at
+   * a glance. Tuned for light surfaces. */
+  --mirror-source: oklch(0.58 0.13 250);
+  --mirror-instance: oklch(0.6 0.16 300);
 }
 
 .dark {
@@ -115,6 +120,9 @@
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.556 0 0);
+  /* Brighter on dark surfaces (see :root). */
+  --mirror-source: oklch(0.72 0.13 250);
+  --mirror-instance: oklch(0.74 0.16 300);
 }
 
 @layer base {
@@ -352,6 +360,30 @@ h2 > span.protected-lock {
 .outline-node[data-selected="single"] {
   border-bottom-left-radius: 6px;
   border-bottom-right-radius: 6px;
+}
+
+/*
+ * Node mirrors (ADR 0022, slice 1d). A mirror INSTANCE and its SOURCE each wear a
+ * thin colored left edge, revealed only on row hover or while the caret is within
+ * (:focus-within) -- so a mirror-free outline, and an idle mirror, look exactly as
+ * before. Source hue vs instance hue tells the original apart from its live
+ * copies; a capped row (a cycle) reuses the instance hue. Pure CSS keyed off the
+ * row's `data-mirror`, zero JS -- the tag-color ethos (ADR 0007). The edge sits on
+ * `.outline-row` (the flex line), so depth indentation already offsets it.
+ */
+.outline-node[data-mirror] > .outline-row {
+  box-shadow: inset 3px 0 0 0 transparent;
+  transition: box-shadow 0.12s ease;
+}
+.outline-node[data-mirror="source"]:hover > .outline-row,
+.outline-node[data-mirror="source"]:focus-within > .outline-row {
+  box-shadow: inset 3px 0 0 0 var(--mirror-source);
+}
+.outline-node[data-mirror="instance"]:hover > .outline-row,
+.outline-node[data-mirror="instance"]:focus-within > .outline-row,
+.outline-node[data-mirror="capped"]:hover > .outline-row,
+.outline-node[data-mirror="capped"]:focus-within > .outline-row {
+  box-shadow: inset 3px 0 0 0 var(--mirror-instance);
 }
 
 /*

--- a/src/styles.css
+++ b/src/styles.css
@@ -375,15 +375,16 @@ h2 > span.protected-lock {
   box-shadow: inset 3px 0 0 0 transparent;
   transition: box-shadow 0.12s ease;
 }
-.outline-node[data-mirror="source"]:hover > .outline-row,
+/*.outline-node[data-mirror="source"]:hover > .outline-row,*/
 .outline-node[data-mirror="source"]:focus-within > .outline-row {
-  box-shadow: inset 3px 0 0 0 var(--mirror-source);
+  /*box-shadow: inset 3px 0 0 0 var(--mirror-source);*/
+  outline: 2px solid var(--mirror-source);
 }
-.outline-node[data-mirror="instance"]:hover > .outline-row,
+/*.outline-node[data-mirror="instance"]:hover > .outline-row,*/
 .outline-node[data-mirror="instance"]:focus-within > .outline-row,
-.outline-node[data-mirror="capped"]:hover > .outline-row,
+/*.outline-node[data-mirror="capped"]:hover > .outline-row,*/
 .outline-node[data-mirror="capped"]:focus-within > .outline-row {
-  box-shadow: inset 3px 0 0 0 var(--mirror-instance);
+  outline: 2px solid var(--mirror-instance);
 }
 
 /*

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -107,6 +107,9 @@ function rowToNode(r: NodeRow): Node {
     completed: !!r.completed,
     collapsed: !!r.collapsed,
     bookmarkedAt: r.bookmarkedAt,
+    // Legacy D1 data predates mirrors (ADR 0022); the import source has no such
+    // column, so every imported node is its own source.
+    mirrorOf: null,
     createdAt: r.createdAt,
     updatedAt: r.updatedAt,
   }

--- a/worker/outline-do.ts
+++ b/worker/outline-do.ts
@@ -20,6 +20,7 @@ interface NodeRow {
   completed: number
   collapsed: number
   bookmarkedAt: number | null
+  mirrorOf: string | null
   createdAt: number
   updatedAt: number
 }
@@ -45,6 +46,7 @@ const WRITABLE_COLUMNS = new Set([
   'completed',
   'collapsed',
   'bookmarkedAt',
+  'mirrorOf',
   'createdAt',
   'updatedAt',
 ])
@@ -91,6 +93,7 @@ function rowToNode(r: NodeRow): Node {
     completed: !!r.completed,
     collapsed: !!r.collapsed,
     bookmarkedAt: r.bookmarkedAt,
+    mirrorOf: r.mirrorOf,
     createdAt: r.createdAt,
     updatedAt: r.updatedAt,
   }
@@ -135,6 +138,7 @@ export class UserOutlineDO extends DurableObject<Env> {
           completed     INTEGER NOT NULL DEFAULT 0,
           collapsed     INTEGER NOT NULL DEFAULT 0,
           bookmarkedAt  INTEGER,
+          mirrorOf      TEXT,
           createdAt     INTEGER NOT NULL,
           updatedAt     INTEGER NOT NULL
         );
@@ -155,6 +159,16 @@ export class UserOutlineDO extends DurableObject<Env> {
           ops TEXT NOT NULL
         );
       `)
+      // Migrate already-deployed DOs (ADR 0022): a pre-mirror `nodes` table was
+      // created without `mirrorOf`, and `CREATE TABLE IF NOT EXISTS` above no-ops
+      // for it. Add the column once (NULL default), guarded by a column-existence
+      // check since SQLite has no `ADD COLUMN IF NOT EXISTS`. Fresh DOs already
+      // have it from the CREATE above, so this skips. Runs before any request is
+      // served (blockConcurrencyWhile), so getNodes never reads a missing column.
+      const hasMirrorOf = (this.sql.exec(`PRAGMA table_info(nodes)`).toArray() as Array<{
+        name: string
+      }>).some((c) => c.name === 'mirrorOf')
+      if (!hasMirrorOf) this.sql.exec(`ALTER TABLE nodes ADD COLUMN mirrorOf TEXT`)
     })
   }
 
@@ -163,7 +177,7 @@ export class UserOutlineDO extends DurableObject<Env> {
   getNodes(): Node[] {
     const rows = this.sql
       .exec(
-        'SELECT id, parentId, prevSiblingId, text, isTask, completed, collapsed, bookmarkedAt, createdAt, updatedAt FROM nodes',
+        'SELECT id, parentId, prevSiblingId, text, isTask, completed, collapsed, bookmarkedAt, mirrorOf, createdAt, updatedAt FROM nodes',
       )
       .toArray() as unknown as NodeRow[]
     return rows.map(rowToNode)
@@ -178,12 +192,12 @@ export class UserOutlineDO extends DurableObject<Env> {
     const existed =
       this.sql.exec('SELECT 1 FROM nodes WHERE id = ?', n.id).toArray().length > 0
     this.sql.exec(
-      `INSERT INTO nodes (id, parentId, prevSiblingId, text, isTask, completed, collapsed, bookmarkedAt, createdAt, updatedAt)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `INSERT INTO nodes (id, parentId, prevSiblingId, text, isTask, completed, collapsed, bookmarkedAt, mirrorOf, createdAt, updatedAt)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON CONFLICT(id) DO UPDATE SET
          parentId=excluded.parentId, prevSiblingId=excluded.prevSiblingId, text=excluded.text,
          isTask=excluded.isTask, completed=excluded.completed, collapsed=excluded.collapsed,
-         bookmarkedAt=excluded.bookmarkedAt, updatedAt=excluded.updatedAt`,
+         bookmarkedAt=excluded.bookmarkedAt, mirrorOf=excluded.mirrorOf, updatedAt=excluded.updatedAt`,
       n.id,
       n.parentId,
       n.prevSiblingId,
@@ -192,6 +206,7 @@ export class UserOutlineDO extends DurableObject<Env> {
       n.completed ? 1 : 0,
       n.collapsed ? 1 : 0,
       n.bookmarkedAt,
+      n.mirrorOf,
       n.createdAt,
       n.updatedAt,
     )
@@ -261,7 +276,7 @@ export class UserOutlineDO extends DurableObject<Env> {
           // a remote client applies an unambiguous update regardless of rowUpdateMode.
           const row = this.sql
             .exec(
-              'SELECT id, parentId, prevSiblingId, text, isTask, completed, collapsed, bookmarkedAt, createdAt, updatedAt FROM nodes WHERE id = ?',
+              'SELECT id, parentId, prevSiblingId, text, isTask, completed, collapsed, bookmarkedAt, mirrorOf, createdAt, updatedAt FROM nodes WHERE id = ?',
               u.id,
             )
             .toArray()[0] as unknown as NodeRow | undefined

--- a/worker/wire.test.ts
+++ b/worker/wire.test.ts
@@ -31,6 +31,7 @@ const node = (id: string): Node => ({
   completed: false,
   collapsed: false,
   bookmarkedAt: null,
+  mirrorOf: null,
   createdAt: 1,
   updatedAt: 1,
 })
@@ -81,6 +82,11 @@ describe('NodesPostBody (POST /api/nodes)', () => {
   it('rejects a node missing a required field', () => {
     const { text: _omit, ...missingText } = node('a')
     rejects(NodesPostBody, { ops: [{ op: 'insert', value: missingText }] })
+  })
+
+  it('rejects a node missing mirrorOf (required + nullable at the boundary — ADR 0022)', () => {
+    const { mirrorOf: _omit, ...missingMirrorOf } = node('a')
+    rejects(NodesPostBody, { ops: [{ op: 'insert', value: missingMirrorOf }] })
   })
 })
 

--- a/worker/wire.ts
+++ b/worker/wire.ts
@@ -36,6 +36,10 @@ export const NodeSchema = Schema.Struct({
   completed: Schema.Boolean,
   collapsed: Schema.Boolean,
   bookmarkedAt: Schema.NullOr(Schema.Number),
+  // Mirror pointer (ADR 0022): null = own source, an id = a mirror of that node.
+  // Required + nullable at the boundary, same as every other field — the client
+  // always sends it (makeNode), so a body without it is malformed (→ 400).
+  mirrorOf: Schema.NullOr(Schema.String),
   createdAt: Schema.Number,
   updatedAt: Schema.Number,
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mirrored nodes that can show the same content in multiple places.
  * Added a new “Mirror” action and a “Mirror to Today” option for creating mirrored copies.
  * Added a places view and badge to jump between all locations where content appears.

* **Bug Fixes**
  * Improved editing, selection, drag-and-drop, and keyboard navigation for mirrored content.
  * Prevented invalid mirror loops and handled missing sources more gracefully.
  * Updated delete behavior so mirrored content stays consistent across views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->