### PR TITLE
[codex] Fix outline arrow and link shortcuts

### DIFF
--- a/e2e/keyboard-nav.spec.ts
+++ b/e2e/keyboard-nav.spec.ts
@@ -7,6 +7,18 @@ import { seedOutline, STANDARD_TREE, type SeedNode } from "./fixtures";
 const text = (page: Page, id: string) =>
   page.locator(`li[data-node-id="${id}"] > .outline-row > .node-text`);
 
+async function caretAtEdge(page: Page, id: string, edge: "start" | "end") {
+  await text(page, id).evaluate((el: HTMLElement, atEnd) => {
+    el.focus();
+    const range = document.createRange();
+    range.selectNodeContents(el);
+    range.collapse(!atEnd);
+    const sel = window.getSelection();
+    sel?.removeAllRanges();
+    sel?.addRange(range);
+  }, edge === "end");
+}
+
 async function load(
   page: Page,
   tree: SeedNode[] = STANDARD_TREE,
@@ -156,6 +168,24 @@ test.describe("keyboard arrow navigation", () => {
 
     await page.keyboard.press("ArrowUp");
     await expect(text(page, "alpha")).toBeFocused();
+  });
+
+  test("ArrowLeft/ArrowRight snake between adjacent visible bullets", async ({
+    page,
+  }) => {
+    await load(page);
+
+    await caretAtEdge(page, "alpha", "end");
+    await page.keyboard.press("ArrowRight");
+    await expect(text(page, "alpha-1")).toBeFocused();
+    await page.keyboard.type("!");
+    await expect(text(page, "alpha-1")).toHaveText("!Alpha one");
+
+    await caretAtEdge(page, "bravo", "start");
+    await page.keyboard.press("ArrowLeft");
+    await expect(text(page, "alpha-2")).toBeFocused();
+    await page.keyboard.type("!");
+    await expect(text(page, "alpha-2")).toHaveText("Alpha two!");
   });
 
   test("backspacing an empty bullet away focuses the row ABOVE, not below", async ({

--- a/e2e/rich-links.spec.ts
+++ b/e2e/rich-links.spec.ts
@@ -59,6 +59,7 @@ const opened = (page: Page) =>
   page.evaluate(() => (window as unknown as { __opened: string[] }).__opened);
 
 const LINK = "[Anthropic](https://anthropic.com)";
+const MOD = process.platform === "darwin" ? "Meta" : "Control";
 
 test.describe("Rich links fold and reveal", () => {
   test("a blurred bullet folds the link to a clean <a>; focusing bracket-reveals it", async ({
@@ -119,6 +120,31 @@ test.describe("Rich links fold and reveal", () => {
     expect(await opened(page)).toEqual(["https://anthropic.com/"]);
     // Still folded -- the click opened, it didn't focus into edit mode.
     await expect(text(page, "n").locator("a[data-link]")).toBeVisible();
+  });
+
+  test("Mod+Enter inside a markdown link opens it instead of completing the node", async ({
+    page,
+  }) => {
+    await load(page, [
+      { id: "n", parentId: null, prevSiblingId: null, text: LINK },
+    ]);
+
+    await focusBullet(page, "n");
+    await text(page, "n").evaluate((el: HTMLElement) => {
+      const label = el.querySelector(".link-label")?.firstChild;
+      if (!label) throw new Error("missing revealed link label");
+      const range = document.createRange();
+      range.setStart(label, 1);
+      range.collapse(true);
+      const sel = window.getSelection();
+      sel?.removeAllRanges();
+      sel?.addRange(range);
+    });
+
+    await page.keyboard.press(`${MOD}+Enter`);
+
+    expect(await opened(page)).toEqual(["https://anthropic.com"]);
+    await expect(text(page, "n")).toHaveAttribute("data-completed", "false");
   });
 });
 

--- a/src/components/OutlineEditor.tsx
+++ b/src/components/OutlineEditor.tsx
@@ -108,6 +108,7 @@ import { DailyNavigationProgress } from "../plugins/daily/navigation-progress";
 import { useShowCompleted } from "./show-completed-provider";
 import { openMoveDialog } from "./move-dialog-opener";
 import { Button } from "./ui/button";
+import { openLinkAtCaret } from "./link-keymap";
 
 // Carry the zoom "pivot" (the node morphing between title and list-item) in
 // history state, so the incoming view knows which element to name -- and so it
@@ -1281,7 +1282,8 @@ function useNodeCommands({
         if (el) {
           el.focus();
           if (x != null) placeCaretAtColumn(el, direction, x);
-          else placeCaretAtStart(el);
+          else if (direction === "down") placeCaretAtStart(el);
+          else placeCaretAtEnd(el);
         } else if (scrollRowIntoView(target)) {
           // Crossed the window edge: the neighbor row isn't mounted. Scroll it
           // in and let its mount effect claim focus (column intent is lost on
@@ -1398,7 +1400,11 @@ function ZoomedTitle({
       { hotkey: "ArrowDown", callback: () => onArrowDown() },
       ...keymapSpecs.map((k) => ({
         hotkey: k.hotkey as UseHotkeyDefinition["hotkey"],
-        callback: () => k.run(node.id, getCtx()),
+        callback: () => {
+          const el = ref.current;
+          if (k.hotkey === "Mod+Enter" && el && openLinkAtCaret(el)) return;
+          k.run(node.id, getCtx());
+        },
       })),
     ],
     { target: ref },

--- a/src/components/OutlineNode.tsx
+++ b/src/components/OutlineNode.tsx
@@ -92,8 +92,8 @@ export interface NodeCommands {
   onRequestMirror: (id: string) => void;
   onToggleCollapsed: (id: string, collapsed: boolean) => void;
   // `x` is the caret's viewport x at the moment of the keypress, so the
-  // landing node can drop the caret at the same column. Omitted when there's
-  // no caret to preserve (e.g. the zoom title), which lands at the start.
+  // landing node can drop the caret at the same column. Omitted for horizontal
+  // snaking: up lands at the previous row's end, down at the next row's start.
   onMoveFocus: (id: string, direction: "up" | "down", x?: number) => void;
   // Zoom the outline so this node becomes the temporary root.
   onZoom: (id: string) => void;

--- a/src/components/link-keymap.ts
+++ b/src/components/link-keymap.ts
@@ -1,0 +1,9 @@
+import { linkUrlAtOffset } from "../data/links";
+import { getCaretOffset, readSource } from "./inline-code";
+
+export function openLinkAtCaret(el: HTMLElement): boolean {
+  const url = linkUrlAtOffset(readSource(el), getCaretOffset(el));
+  if (!url) return false;
+  window.open(url, "_blank", "noopener,noreferrer");
+  return true;
+}

--- a/src/components/use-bullet-keymap.ts
+++ b/src/components/use-bullet-keymap.ts
@@ -4,7 +4,8 @@ import type { Node } from "../data/schema";
 import { keymapSpecs } from "../plugins/registry";
 import type { PluginContext } from "../plugins/types";
 import { selectSingle } from "../data/selection-state";
-import { getCaretOffset } from "./inline-code";
+import { getCaretOffset, readSource } from "./inline-code";
+import { openLinkAtCaret } from "./link-keymap";
 import type { NodeCommands } from "./OutlineNode";
 
 interface BulletKeymapArgs {
@@ -98,7 +99,11 @@ export function useBulletKeymap({
             // KeymapSpec.hotkey is a plain string (plugin contract stays library-
             // agnostic); the manager wants its RegisterableHotkey union here.
             hotkey: k.hotkey as UseHotkeyDefinition["hotkey"],
-            callback: () => k.run(node.id, pluginCtx()),
+            callback: () => {
+              const el = textRef.current;
+              if (k.hotkey === "Mod+Enter" && el && openLinkAtCaret(el)) return;
+              k.run(node.id, pluginCtx());
+            },
           })),
           {
             // Enter: split the bullet at the caret -- text left of the caret stays,
@@ -273,6 +278,31 @@ export function useBulletKeymap({
             options: { preventDefault: false, stopPropagation: false },
           },
           {
+            // Left at the start snakes to the previous visible node's end,
+            // matching the existing visible-order walk used by Up/Down.
+            hotkey: "ArrowLeft",
+            callback: (e) => {
+              const el = textRef.current;
+              if (!el || !isCollapsedCaretAtStart(el)) return;
+              e.preventDefault();
+              e.stopPropagation();
+              commands.onMoveFocus(node.id, "up");
+            },
+            options: { preventDefault: false, stopPropagation: false },
+          },
+          {
+            // Right at the end snakes to the next visible node's start.
+            hotkey: "ArrowRight",
+            callback: (e) => {
+              const el = textRef.current;
+              if (!el || !isCaretAtEnd(el)) return;
+              e.preventDefault();
+              e.stopPropagation();
+              commands.onMoveFocus(node.id, "down");
+            },
+            options: { preventDefault: false, stopPropagation: false },
+          },
+          {
             // Cmd/Ctrl+Down: open (reveal the children of) a closed bullet that
             // has children. Direction encodes intent -- Down only ever opens.
             // Default options preventDefault, so the caret never jumps to the end
@@ -327,6 +357,17 @@ function isCaretAtStart(el: HTMLElement): boolean {
   const sel = window.getSelection();
   if (!sel || sel.rangeCount === 0) return true;
   return getCaretOffset(el) === 0;
+}
+
+function isCaretAtEnd(el: HTMLElement): boolean {
+  const sel = window.getSelection();
+  if (!sel || !sel.isCollapsed || sel.rangeCount === 0) return false;
+  return getCaretOffset(el) === readSource(el).length;
+}
+
+function isCollapsedCaretAtStart(el: HTMLElement): boolean {
+  const sel = window.getSelection();
+  return !!sel && sel.isCollapsed && isCaretAtStart(el);
 }
 
 // Caret-to-neighbor navigation is about VISUAL lines, not text offset: on a

--- a/src/data/links.test.ts
+++ b/src/data/links.test.ts
@@ -4,6 +4,7 @@ import {
   encodeUrlForMarkdown,
   hasLink,
   isHttpUrl,
+  linkUrlAtOffset,
   replaceLinkToken,
   sanitizeLinkLabel,
   stripLinks,
@@ -35,6 +36,30 @@ describe('stripLinks', () => {
 
   test('leaves link-free text untouched', () => {
     expect(stripLinks('no links here')).toBe('no links here')
+  })
+})
+
+describe('linkUrlAtOffset', () => {
+  const text = 'see [Example](https://example.com) now'
+
+  test('returns the url when the caret is in the link label', () => {
+    expect(linkUrlAtOffset(text, text.indexOf('Example'))).toBe(
+      'https://example.com',
+    )
+    expect(linkUrlAtOffset(text, text.indexOf(']'))).toBe(
+      'https://example.com',
+    )
+  })
+
+  test('returns the url when the caret is in the url segment', () => {
+    expect(linkUrlAtOffset(text, text.indexOf('example.com'))).toBe(
+      'https://example.com',
+    )
+  })
+
+  test('returns null outside a complete link token', () => {
+    expect(linkUrlAtOffset(text, 0)).toBeNull()
+    expect(linkUrlAtOffset('[partial]', 3)).toBeNull()
   })
 })
 

--- a/src/data/links.ts
+++ b/src/data/links.ts
@@ -17,6 +17,13 @@ export const LINK_PATTERN = "\\[[^\\]]*\\]\\([^)]*\\)";
 
 const LINK_RE = () => new RegExp(`\\[([^\\]]*)\\]\\(([^)]*)\\)`, "g");
 
+export interface LinkAtOffset {
+  label: string;
+  url: string;
+  start: number;
+  end: number;
+}
+
 /** True iff the text contains at least one complete link token. */
 export function hasLink(text: string): boolean {
   return new RegExp(LINK_PATTERN).test(text);
@@ -26,6 +33,31 @@ export function hasLink(text: string): boolean {
  *  and for clean display in result rows (ADR 0005). */
 export function stripLinks(text: string): string {
   return text.replace(LINK_RE(), (_full, label: string) => label);
+}
+
+/** Return the markdown link whose editable label/url contains `offset`.
+ *  The offset is in SOURCE space, matching contentEditable caret helpers. */
+export function linkAtOffset(text: string, offset: number): LinkAtOffset | null {
+  for (const m of text.matchAll(LINK_RE())) {
+    const start = m.index ?? 0;
+    const token = m[0] ?? "";
+    const label = m[1] ?? "";
+    const url = m[2] ?? "";
+    const labelStart = start + 1;
+    const labelEnd = labelStart + label.length;
+    const urlStart = labelEnd + 2; // `](`
+    const urlEnd = urlStart + url.length;
+    const inLabel = offset >= labelStart && offset <= labelEnd;
+    const inUrl = offset >= urlStart && offset <= urlEnd;
+    if (inLabel || inUrl) {
+      return { label, url, start, end: start + token.length };
+    }
+  }
+  return null;
+}
+
+export function linkUrlAtOffset(text: string, offset: number): string | null {
+  return linkAtOffset(text, offset)?.url ?? null;
 }
 
 /** http(s) only -- the single URL shape v1 auto-detects (ADR 0005). */


### PR DESCRIPTION
## Summary

Fixes #51 and #52.

- Add Workflowy-style horizontal snaking: Left at the start of a bullet moves to the previous visible row at its end, and Right at the end moves to the next visible row at its start.
- Make Mod+Enter link-aware: when the caret is inside a markdown link label or URL, it opens the link instead of toggling completion.
- Add focused unit/e2e coverage for link offset detection, arrow snaking, and Mod+Enter link activation.

## Validation

- `bun test src/data/links.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run test:e2e -- e2e/keyboard-nav.spec.ts e2e/rich-links.spec.ts`

## Notes

Direct push to `cameronapak/dotflowy` was denied for `dpshde`, so this PR is opened from the `dpshde/dotflowy` fork.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * You can now use **Cmd/Ctrl+Enter** on a link to open it in a new tab.
  * Left/Right arrow navigation now moves between nearby visible bullets when the cursor is at the text edge.

* **Bug Fixes**
  * Improved keyboard navigation between rows so the cursor lands more naturally at the start or end of the next item.
  * Link opening now works reliably without completing the current outline item.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->