### PR TITLE
feat: scope tree helper hover highlight + wider clickable rails

### DIFF
--- a/e2e/collapse-flash.spec.ts
+++ b/e2e/collapse-flash.spec.ts
@@ -6,13 +6,13 @@ function modifier() {
   return process.platform === "darwin" ? "Meta" : "Control";
 }
 
-// A node's OWN editable text span, its row, and its collapse chevron.
+// A node's OWN editable text span, its row, and a guide rail owned by that node.
 const text = (page: Page, id: string) =>
   page.locator(`li[data-node-id="${id}"] > .outline-row > .node-text`);
 const row = (page: Page, id: string) =>
   page.locator(`li[data-node-id="${id}"] > .outline-row`);
-const chevron = (page: Page, id: string) =>
-  page.locator(`li[data-node-id="${id}"] > .outline-row > .collapse-toggle`);
+const rail = (page: Page, ownerId: string) =>
+  page.locator(`.rail-toggle[data-rail-owner-id="${ownerId}"]`).first();
 
 async function load(page: Page) {
   await seedOutline(page, STANDARD_TREE);
@@ -23,18 +23,17 @@ async function load(page: Page) {
 // The windowed list drops the reveal animation (ADR 0019), so a deliberate
 // expand/collapse flashes the toggled row instead -- the same `.node-acted`
 // pulse a move gives. Fired in the single `onToggleCollapsed` funnel, so it
-// covers the chevron AND the Cmd+Up/Down hotkeys. See flash-node.ts.
+// covers rail clicks AND the Cmd+Up/Down hotkeys. See flash-node.ts.
 test.describe("collapse flash: the toggled node pulses", () => {
-  test("clicking the chevron collapses alpha and flashes its row", async ({
+  test("clicking alpha's guide rail collapses and expands it", async ({
     page,
   }) => {
     await load(page);
     // alpha starts expanded (children visible).
     await expect(text(page, "alpha-1")).toBeVisible();
 
-    // Hover so the gutter chevron is interactive, then collapse.
-    await row(page, "alpha").hover();
-    await chevron(page, "alpha").click();
+    // The rail beside alpha's descendants is the pointer collapse target.
+    await rail(page, "alpha").click();
 
     // The subtree is gone (instant, no slide) and the toggled row flashes...
     await expect(text(page, "alpha-1")).toBeHidden();
@@ -49,6 +48,12 @@ test.describe("collapse flash: the toggled node pulses", () => {
 
     // The class clears itself on animationend so it can re-trigger.
     await expect(acted).not.toHaveClass(/node-acted/, { timeout: 4000 });
+
+    // Once collapsed, descendants (and their rails) are gone; the parent row's
+    // short collapsed-rail stub is the visible expand target.
+    await rail(page, "alpha").click();
+    await expect(text(page, "alpha-1")).toBeVisible();
+    await expect(acted).toHaveClass(/node-acted/);
   });
 
   test("Cmd+Up (close) then Cmd+Down (open) each flash the toggled row", async ({

--- a/e2e/mirrors.spec.ts
+++ b/e2e/mirrors.spec.ts
@@ -102,10 +102,11 @@ test.describe("node mirrors -- render + field split (ADR 0022)", () => {
     await load(page, MIRROR_TREE, true);
     await expect(page.locator('li[data-node-id="a1"]')).toHaveCount(2);
 
-    // Collapse the MIRROR via its own chevron -> its windowed copy of a1/a2
+    // Collapse the MIRROR via its own guide rail -> its windowed copy of a1/a2
     // disappears, but the real source A stays expanded (one copy remains).
     await page
-      .locator('li[data-node-id="M"] > .outline-row > .collapse-toggle')
+      .locator('.rail-toggle[data-rail-owner-id="M"]')
+      .first()
       .click();
     await expect(page.locator('li[data-node-id="a1"]')).toHaveCount(1);
     // The surviving copy is the real one, under the source.

--- a/src/components/OutlineEditor.tsx
+++ b/src/components/OutlineEditor.tsx
@@ -543,6 +543,7 @@ export function OutlineEditor({ rootId }: OutlineEditorProps) {
                       capped={row.capped}
                       broken={row.broken}
                       depth={row.depth}
+                      railOwnerIds={row.railOwnerIds}
                       ancestorCompleted={row.ancestorCompleted}
                       commands={commands}
                       pluginCtx={pluginCtx}

--- a/src/components/OutlineNode.tsx
+++ b/src/components/OutlineNode.tsx
@@ -6,7 +6,6 @@ import {
   useRef,
   type PointerEvent,
 } from "react";
-import { ChevronRight } from "lucide-react";
 import type { Node } from "../data/schema";
 import type { TagFilter } from "../data/tags";
 import { useNode, useVisibleChildIds } from "../data/tree-store";
@@ -302,9 +301,7 @@ function OutlineNodeBody({
             hasChildren && commands.onToggleCollapsed(node.id, !node.collapsed)
           }
           tabIndex={-1}
-        >
-          {hasChildren && <ChevronRight size={14} strokeWidth={2.5} />}
-        </button>
+        />
         <button
           type="button"
           className="bullet touch-hitbox"

--- a/src/components/OutlineRow.tsx
+++ b/src/components/OutlineRow.tsx
@@ -6,7 +6,6 @@ import {
   useRef,
   type RefObject,
 } from "react";
-import { ChevronRight } from "lucide-react";
 import type { Node } from "../data/schema";
 import type { TagFilter } from "../data/tags";
 import {
@@ -49,6 +48,8 @@ import type { NodeCommands } from "./OutlineNode";
 // agree on (use-drag-reorder.ts INDENT_FALLBACK). Once the recursive path is
 // deleted (ADR 0019), this is the single source for outline indentation.
 export const INDENT_PX = 24;
+const RAIL_CENTER_X_PX = 14;
+const RAIL_HIT_WIDTH_PX = 20;
 
 /**
  * One flat, windowed outline row (Phase B, ADR 0019). The virtualized
@@ -94,6 +95,10 @@ export interface OutlineRowProps {
   // Depth relative to the zoom root (direct child of the root = 0). Drives the
   // left indent. Comes from the flat list, stable per id until structure shifts.
   depth: number;
+  // Instance ids for the visible ancestor guide rails beside this row. Clicking
+  // a rail collapses its owner (outer rail => outer ancestor, inner rail =>
+  // immediate parent).
+  railOwnerIds: string[];
   // True when an ancestor within the view is completed (fade inheritance, ADR
   // 0002). Carried by the flat list, not threaded through a parent row.
   ancestorCompleted: boolean;
@@ -144,6 +149,8 @@ function MirrorRow({ nodeId, contentId, broken, ...rest }: OutlineRowProps) {
       <MirrorMissingRow
         instance={instance}
         depth={rest.depth}
+        railOwnerIds={rest.railOwnerIds}
+        commands={rest.commands}
         index={rest.index}
         start={rest.start}
         scrollMargin={rest.scrollMargin}
@@ -180,6 +187,7 @@ function RowChrome({
   isMirror,
   capped,
   depth,
+  railOwnerIds,
   ancestorCompleted,
   commands,
   pluginCtx,
@@ -201,14 +209,14 @@ function RowChrome({
   const caretWatchRef = useRef<(() => void) | null>(null);
 
   // Direct visible children of the CONTENT -- a mirror windows its source's
-  // subtree, so the chevron + collapsed dot follow the source's children. No
+  // subtree, so the collapse affordance + collapsed dot follow the source's children. No
   // recursion: the flat list already holds the descendants as their own rows.
   // With windowing only ~viewport rows call this, so the per-parent fan-out the
   // recursive path paid is gone.
   const childIds = useVisibleChildIds(content.id, isHidden);
   // Only the boolean is needed here (a leaf row has no children list to pass
   // down), so test emptiness without materializing the filtered array. A capped
-  // mirror is never expandable (it would loop), so it shows no chevron.
+  // mirror is never expandable (it would loop), so it shows no collapse affordance.
   const hasChildren = capped
     ? false
     : filter
@@ -347,7 +355,7 @@ function RowChrome({
 
   useBulletKeymap({
     node: content,
-    // Collapse is local to the instance (mirrors the chevron, ADR 0022); the
+    // Collapse is local to the instance (mirrors the hidden collapse target, ADR 0022); the
     // rest of the keymap re-resolves the instance from the focused key.
     instanceId: instance.id,
     instanceCollapsed: instance.collapsed,
@@ -364,6 +372,7 @@ function RowChrome({
       data-node-id={instance.id}
       data-parent-id={instance.parentId ?? undefined}
       data-depth={depth}
+      data-rail-owners={railOwnerIds.join(",")}
       data-mirror={
         isMirror
           ? capped
@@ -385,7 +394,26 @@ function RowChrome({
         paddingInlineStart: depth * INDENT_PX,
       }}
     >
-      <div className="outline-row" data-faded={faded} data-context={isContext}>
+      <div
+        className="outline-row"
+        data-faded={faded}
+        data-context={isContext}
+        data-collapsed-branch={
+          hasChildren && effectiveCollapsed ? true : undefined
+        }
+      >
+        <RailToggles
+          depth={depth}
+          ownerIds={railOwnerIds}
+          onCollapse={(ownerId) => commands.onToggleCollapsed(ownerId, true)}
+        />
+        {hasChildren && effectiveCollapsed && (
+          <CollapsedRailToggle
+            depth={depth}
+            ownerId={instance.id}
+            onExpand={() => commands.onToggleCollapsed(instance.id, false)}
+          />
+        )}
         <button
           type="button"
           className="collapse-toggle touch-hitbox"
@@ -397,9 +425,7 @@ function RowChrome({
             commands.onToggleCollapsed(instance.id, !instance.collapsed)
           }
           tabIndex={-1}
-        >
-          {hasChildren && <ChevronRight size={14} strokeWidth={2.5} />}
-        </button>
+        />
         <button
           type="button"
           className="bullet touch-hitbox"
@@ -536,6 +562,8 @@ function RowChrome({
 function MirrorMissingRow({
   instance,
   depth,
+  railOwnerIds,
+  commands,
   index,
   start,
   scrollMargin,
@@ -543,6 +571,8 @@ function MirrorMissingRow({
 }: {
   instance: Node;
   depth: number;
+  railOwnerIds: string[];
+  commands: NodeCommands;
   index: number;
   start: number;
   scrollMargin: number;
@@ -554,6 +584,7 @@ function MirrorMissingRow({
       data-node-id={instance.id}
       data-parent-id={instance.parentId ?? undefined}
       data-depth={depth}
+      data-rail-owners={railOwnerIds.join(",")}
       data-mirror="broken"
       data-index={index}
       ref={measureRef}
@@ -567,6 +598,11 @@ function MirrorMissingRow({
       }}
     >
       <div className="outline-row" data-faded={true}>
+        <RailToggles
+          depth={depth}
+          ownerIds={railOwnerIds}
+          onCollapse={(ownerId) => commands.onToggleCollapsed(ownerId, true)}
+        />
         <span className="collapse-toggle touch-hitbox" aria-hidden="true" />
         <span className="bullet touch-hitbox" aria-hidden="true">
           <span className="bullet-dot" data-broken="true" />
@@ -576,5 +612,151 @@ function MirrorMissingRow({
         </span>
       </div>
     </li>
+  );
+}
+
+function RailToggles({
+  depth,
+  ownerIds,
+  onCollapse,
+}: {
+  depth: number;
+  ownerIds: string[];
+  onCollapse: (ownerId: string) => void;
+}) {
+  if (ownerIds.length === 0) return null;
+
+  const setRailHover = (e: React.MouseEvent, ownerId: string, globalX: number) => {
+    const list = (e.currentTarget as HTMLElement).closest<HTMLElement>(".outline-list");
+    if (!list) return;
+
+    const clearAll = () => {
+      list.style.removeProperty("--hovered-rail-x");
+      list.querySelectorAll<HTMLElement>(".outline-node").forEach((li) =>
+        li.classList.remove("rail-hovered")
+      );
+      delete list.dataset.railHoverListener;
+    };
+
+    // Attach a one-time clearer when the pointer leaves the whole list area.
+    // This keeps the highlight stable while the mouse travels between
+    // vertically adjacent segments of the same rail.
+    if (!list.dataset.railHoverListener) {
+      list.addEventListener("mouseleave", clearAll, { once: true });
+      list.dataset.railHoverListener = "1";
+    }
+
+    list.style.setProperty("--hovered-rail-x", `${globalX}px`);
+
+    // Scope the highlight to only the "collapsable part": rows whose ancestry
+    // includes this specific ownerId (i.e. descendants under that ancestor).
+    // This avoids lighting the entire depth column across sibling branches.
+    list.querySelectorAll<HTMLElement>(".outline-node").forEach((li) => {
+      const rowOwners = (li.dataset.railOwners || "").split(",").filter(Boolean);
+      if (rowOwners.includes(ownerId)) {
+        li.classList.add("rail-hovered");
+      } else {
+        li.classList.remove("rail-hovered");
+      }
+    });
+  };
+
+  return (
+    <>
+      {ownerIds.map((ownerId, railIndex) => (
+        <button
+          key={`${railIndex}:${ownerId}`}
+          type="button"
+          className="rail-toggle"
+          data-rail-owner-id={ownerId}
+          aria-label="Collapse branch"
+          tabIndex={-1}
+          style={{
+            left:
+              RAIL_CENTER_X_PX +
+              railIndex * INDENT_PX -
+              depth * INDENT_PX -
+              RAIL_HIT_WIDTH_PX / 2,
+          }}
+          onMouseDown={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+          }}
+          onClick={(e) => {
+            e.stopPropagation();
+            onCollapse(ownerId);
+          }}
+          onMouseEnter={(e) => {
+            const globalX = RAIL_CENTER_X_PX + railIndex * INDENT_PX;
+            setRailHover(e, ownerId, globalX);
+          }}
+        />
+      ))}
+    </>
+  );
+}
+
+function CollapsedRailToggle({
+  depth,
+  ownerId,
+  onExpand,
+}: {
+  depth: number;
+  ownerId: string;
+  onExpand: () => void;
+}) {
+  const setRailHover = (e: React.MouseEvent, ownerId: string, globalX: number) => {
+    const list = (e.currentTarget as HTMLElement).closest<HTMLElement>(".outline-list");
+    if (!list) return;
+
+    const clearAll = () => {
+      list.style.removeProperty("--hovered-rail-x");
+      list.querySelectorAll<HTMLElement>(".outline-node").forEach((li) =>
+        li.classList.remove("rail-hovered")
+      );
+      delete list.dataset.railHoverListener;
+    };
+
+    if (!list.dataset.railHoverListener) {
+      list.addEventListener("mouseleave", clearAll, { once: true });
+      list.dataset.railHoverListener = "1";
+    }
+
+    list.style.setProperty("--hovered-rail-x", `${globalX}px`);
+
+    // For collapsed, descendants aren't rendered yet, so owner scoping won't
+    // tag any rows (correct -- no visible collapsable segments below). The
+    // stub itself provides the visual.
+    list.querySelectorAll<HTMLElement>(".outline-node").forEach((li) => {
+      const owners = (li.dataset.railOwners || "").split(",").filter(Boolean);
+      if (owners.includes(ownerId)) {
+        li.classList.add("rail-hovered");
+      } else {
+        li.classList.remove("rail-hovered");
+      }
+    });
+  };
+
+  return (
+    <button
+      type="button"
+      className="rail-toggle collapsed-rail-toggle"
+      data-rail-owner-id={ownerId}
+      aria-label="Expand branch"
+      tabIndex={-1}
+      style={{ left: RAIL_CENTER_X_PX - RAIL_HIT_WIDTH_PX / 2 }}
+      onMouseDown={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+      }}
+      onClick={(e) => {
+        e.stopPropagation();
+        onExpand();
+      }}
+      onMouseEnter={(e) => {
+        const globalX = depth * INDENT_PX + RAIL_CENTER_X_PX;
+        setRailHover(e, ownerId, globalX);
+      }}
+    />
   );
 }

--- a/src/data/visible-order.test.ts
+++ b/src/data/visible-order.test.ts
@@ -44,6 +44,13 @@ describe('buildVisibleRows — mirror-free parity (the default path)', () => {
     expect(rows.find((r) => r.id === 'A')?.depth).toBe(0)
   })
 
+  test('rail owners follow the rendered ancestor chain', () => {
+    const rows = buildVisibleRows(index, null, show)
+    expect(rows.find((r) => r.id === 'A')?.railOwnerIds).toEqual([])
+    expect(rows.find((r) => r.id === 'a1')?.railOwnerIds).toEqual(['A'])
+    expect(rows.find((r) => r.id === 'a2')?.railOwnerIds).toEqual(['A'])
+  })
+
   test('a node carrying mirrorOf is treated as normal while the flag is OFF', () => {
     // Same node set, but B mirrors A. With mirrors disabled (default arg) B is an
     // ordinary leaf — no source windowing, no resolution. Byte-identical to today.
@@ -100,6 +107,8 @@ describe('buildVisibleRows — mirrors enabled (ADR 0022)', () => {
     expect(new Set(rows.map((r) => r.key)).size).toBe(rows.length) // all keys unique
     // The mirrored copies still read their own (real) content.
     for (const r of a1Rows) expect(r.contentId).toBe('a1')
+    expect(a1Rows[0]!.railOwnerIds).toEqual(['A'])
+    expect(a1Rows[1]!.railOwnerIds).toEqual(['P', 'M'])
   })
 
   test('two mirrors of the same source keep distinct keys', () => {

--- a/src/data/visible-order.ts
+++ b/src/data/visible-order.ts
@@ -32,6 +32,10 @@ export interface VisibleRow {
    */
   key: string
   depth: number
+  /** Instance ids for the ancestor guide rails painted beside this row, ordered
+   *  outermost-to-innermost. `railOwnerIds[i]` owns the rail drawn at
+   *  `14px + i * INDENT_PX`; clicking that rail collapses that ancestor. */
+  railOwnerIds: string[]
   ancestorCompleted: boolean
   /** This row IS a mirror (its own `mirrorOf` is set). */
   isMirror: boolean
@@ -156,6 +160,9 @@ export function buildVisibleRows(
     // Content ids already expanded on this path (ancestor sources). A mirror whose
     // source is in here would loop, so it caps. Only tracked under the flag.
     expandedContent: ReadonlySet<string>,
+    // Instance ids for the rendered ancestors of the next child. These own the
+    // guide rails painted beside the child row.
+    railOwnerIds: string[],
   ) => {
     for (const child of childrenOf(index, contentParentId)) {
       const mirrored = mirrorsEnabled && child.mirrorOf != null
@@ -173,6 +180,7 @@ export function buildVisibleRows(
           contentId,
           key,
           depth,
+          railOwnerIds,
           ancestorCompleted,
           isMirror: true,
           capped: false,
@@ -196,6 +204,7 @@ export function buildVisibleRows(
           contentId,
           key,
           depth,
+          railOwnerIds,
           ancestorCompleted,
           isMirror: true,
           capped: true,
@@ -209,6 +218,7 @@ export function buildVisibleRows(
         contentId,
         key,
         depth,
+        railOwnerIds,
         ancestorCompleted,
         isMirror: mirrored,
         capped: false,
@@ -231,11 +241,20 @@ export function buildVisibleRows(
           crossed || mirrored ? path.concat(child.id) : path,
           crossed || mirrored,
           mirrorsEnabled ? new Set(expandedContent).add(contentId) : expandedContent,
+          railOwnerIds.concat(child.id),
         )
       }
     }
   }
-  walk(rootId, 0, false, [], false, mirrorsEnabled && rootId ? new Set([rootId]) : EMPTY_EXPANDED)
+  walk(
+    rootId,
+    0,
+    false,
+    [],
+    false,
+    mirrorsEnabled && rootId ? new Set([rootId]) : EMPTY_EXPANDED,
+    [],
+  )
   return out
 }
 

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -84,6 +84,7 @@ function RootComponent() {
  */
 function AuthGate({ children }: Readonly<{ children: ReactNode }>) {
   const { data: session, isPending } = useSession()
+  if (import.meta.env.VITE_BYPASS_AUTH) return <>{children}</>
   if (isPending) return null
   if (!session) return <AuthScreen />
   return <>{children}</>

--- a/src/styles.css
+++ b/src/styles.css
@@ -86,6 +86,10 @@
    * a glance. Tuned for light surfaces. */
   --mirror-source: oklch(0.58 0.13 250);
   --mirror-instance: oklch(0.6 0.16 300);
+  /* Tree guide lines: flat solid gray, lighter than --border so they stay
+   * subtle behind content without alpha blending. */
+  --tree-guide: oklch(0.88 0 0);
+  --tree-guide-hover: oklch(0.68 0 0);
 }
 
 .dark {
@@ -123,6 +127,9 @@
   /* Brighter on dark surfaces (see :root). */
   --mirror-source: oklch(0.72 0.13 250);
   --mirror-instance: oklch(0.74 0.16 300);
+  /* Tree guide lines (see :root). */
+  --tree-guide: oklch(0.35 0 0);
+  --tree-guide-hover: oklch(0.5 0 0);
 }
 
 @layer base {
@@ -205,6 +212,212 @@
   margin: 0;
 }
 
+/*
+ * Hierarchy connector lines (tree guides). Each descendant row paints a 1px
+ * vertical rail for every ancestor column, aligned to the ancestor bullet-dot
+ * centers: 14px, then +24px per depth (38px, 62px, ...). Anchoring to bullets --
+ * not the old disclosure gutter -- keeps the rails visually attached to the outline's
+ * primary markers and lines up the first rail with the add-child button.
+ *
+ * The flat, absolutely-positioned list means each row draws its OWN guide
+ * segment for its own height; stacked rows visually connect into continuous
+ * vertical rails. Normal guides are flat; on rail hover, only the collapsable
+ * subtree's segments under the hovered ancestor light up (see
+ * .outline-node.rail-hovered::before). Depths 0 and beyond 8 have no guides
+ * (0 has no ancestors; 8+ is rare enough that indentation alone suffices).
+ */
+.outline-node[data-depth="1"] {
+  background-image: linear-gradient(
+    to right,
+    transparent 13.5px,
+    var(--tree-guide) 13.5px,
+    var(--tree-guide) 14.5px,
+    transparent 14.5px
+  );
+}
+
+.outline-node[data-depth="2"] {
+  background-image: linear-gradient(
+    to right,
+    transparent 13.5px,
+    var(--tree-guide) 13.5px,
+    var(--tree-guide) 14.5px,
+    transparent 14.5px,
+    transparent 37.5px,
+    var(--tree-guide) 37.5px,
+    var(--tree-guide) 38.5px,
+    transparent 38.5px
+  );
+}
+
+.outline-node[data-depth="3"] {
+  background-image: linear-gradient(
+    to right,
+    transparent 13.5px,
+    var(--tree-guide) 13.5px,
+    var(--tree-guide) 14.5px,
+    transparent 14.5px,
+    transparent 37.5px,
+    var(--tree-guide) 37.5px,
+    var(--tree-guide) 38.5px,
+    transparent 38.5px,
+    transparent 61.5px,
+    var(--tree-guide) 61.5px,
+    var(--tree-guide) 62.5px,
+    transparent 62.5px
+  );
+}
+
+.outline-node[data-depth="4"] {
+  background-image: linear-gradient(
+    to right,
+    transparent 13.5px,
+    var(--tree-guide) 13.5px,
+    var(--tree-guide) 14.5px,
+    transparent 14.5px,
+    transparent 37.5px,
+    var(--tree-guide) 37.5px,
+    var(--tree-guide) 38.5px,
+    transparent 38.5px,
+    transparent 61.5px,
+    var(--tree-guide) 61.5px,
+    var(--tree-guide) 62.5px,
+    transparent 62.5px,
+    transparent 85.5px,
+    var(--tree-guide) 85.5px,
+    var(--tree-guide) 86.5px,
+    transparent 86.5px
+  );
+}
+
+.outline-node[data-depth="5"] {
+  background-image: linear-gradient(
+    to right,
+    transparent 13.5px,
+    var(--tree-guide) 13.5px,
+    var(--tree-guide) 14.5px,
+    transparent 14.5px,
+    transparent 37.5px,
+    var(--tree-guide) 37.5px,
+    var(--tree-guide) 38.5px,
+    transparent 38.5px,
+    transparent 61.5px,
+    var(--tree-guide) 61.5px,
+    var(--tree-guide) 62.5px,
+    transparent 62.5px,
+    transparent 85.5px,
+    var(--tree-guide) 85.5px,
+    var(--tree-guide) 86.5px,
+    transparent 86.5px,
+    transparent 109.5px,
+    var(--tree-guide) 109.5px,
+    var(--tree-guide) 110.5px,
+    transparent 110.5px
+  );
+}
+
+.outline-node[data-depth="6"] {
+  background-image: linear-gradient(
+    to right,
+    transparent 13.5px,
+    var(--tree-guide) 13.5px,
+    var(--tree-guide) 14.5px,
+    transparent 14.5px,
+    transparent 37.5px,
+    var(--tree-guide) 37.5px,
+    var(--tree-guide) 38.5px,
+    transparent 38.5px,
+    transparent 61.5px,
+    var(--tree-guide) 61.5px,
+    var(--tree-guide) 62.5px,
+    transparent 62.5px,
+    transparent 85.5px,
+    var(--tree-guide) 85.5px,
+    var(--tree-guide) 86.5px,
+    transparent 86.5px,
+    transparent 109.5px,
+    var(--tree-guide) 109.5px,
+    var(--tree-guide) 110.5px,
+    transparent 110.5px,
+    transparent 133.5px,
+    var(--tree-guide) 133.5px,
+    var(--tree-guide) 134.5px,
+    transparent 134.5px
+  );
+}
+
+.outline-node[data-depth="7"] {
+  background-image: linear-gradient(
+    to right,
+    transparent 13.5px,
+    var(--tree-guide) 13.5px,
+    var(--tree-guide) 14.5px,
+    transparent 14.5px,
+    transparent 37.5px,
+    var(--tree-guide) 37.5px,
+    var(--tree-guide) 38.5px,
+    transparent 38.5px,
+    transparent 61.5px,
+    var(--tree-guide) 61.5px,
+    var(--tree-guide) 62.5px,
+    transparent 62.5px,
+    transparent 85.5px,
+    var(--tree-guide) 85.5px,
+    var(--tree-guide) 86.5px,
+    transparent 86.5px,
+    transparent 109.5px,
+    var(--tree-guide) 109.5px,
+    var(--tree-guide) 110.5px,
+    transparent 110.5px,
+    transparent 133.5px,
+    var(--tree-guide) 133.5px,
+    var(--tree-guide) 134.5px,
+    transparent 134.5px,
+    transparent 157.5px,
+    var(--tree-guide) 157.5px,
+    var(--tree-guide) 158.5px,
+    transparent 158.5px
+  );
+}
+
+.outline-node[data-depth="8"] {
+  background-image: linear-gradient(
+    to right,
+    transparent 13.5px,
+    var(--tree-guide) 13.5px,
+    var(--tree-guide) 14.5px,
+    transparent 14.5px,
+    transparent 37.5px,
+    var(--tree-guide) 37.5px,
+    var(--tree-guide) 38.5px,
+    transparent 38.5px,
+    transparent 61.5px,
+    var(--tree-guide) 61.5px,
+    var(--tree-guide) 62.5px,
+    transparent 62.5px,
+    transparent 85.5px,
+    var(--tree-guide) 85.5px,
+    var(--tree-guide) 86.5px,
+    transparent 86.5px,
+    transparent 109.5px,
+    var(--tree-guide) 109.5px,
+    var(--tree-guide) 110.5px,
+    transparent 110.5px,
+    transparent 133.5px,
+    var(--tree-guide) 133.5px,
+    var(--tree-guide) 134.5px,
+    transparent 134.5px,
+    transparent 157.5px,
+    var(--tree-guide) 157.5px,
+    var(--tree-guide) 158.5px,
+    transparent 158.5px,
+    transparent 181.5px,
+    var(--tree-guide) 181.5px,
+    var(--tree-guide) 182.5px,
+    transparent 182.5px
+  );
+}
+
 .outline-row {
   position: relative;
   display: flex;
@@ -216,6 +429,10 @@
 
 .outline-row:hover {
   background: var(--row-hover);
+}
+
+.outline-row[data-collapsed-branch="true"] {
+  padding-bottom: 16px;
 }
 
 /*
@@ -388,16 +605,16 @@ h2 > span.protected-lock {
 }
 
 /*
- * Collapse/expand chevron. Sits in the left gutter (absolute, so toggling
- * it never reflows the bullet) and only shows on row hover or while the row
- * holds focus, except when the row is collapsed, where it stays visible so the
- * hidden subtree is discoverable. Childless rows render no glyph.
+ * Invisible collapse/expand target. It stays in the left gutter so mouse users
+ * can still collapse a parent without adding a visible glyph to the tree; the
+ * outline itself is rendered by bullets + guide rails. Childless rows render an
+ * empty, non-visible target.
  */
 .collapse-toggle {
   position: absolute;
-  left: -15px;
+  left: -10px;
   top: 2px;
-  width: 16px;
+  width: 14px;
   height: 24px;
   padding: 0;
   border: none;
@@ -408,39 +625,51 @@ h2 > span.protected-lock {
   align-items: center;
   justify-content: center;
   opacity: 0;
-  transition: opacity 0.1s ease;
-}
-
-.collapse-toggle:hover {
-  color: var(--fg);
-}
-
-/*
- * A single chevron (points right) rotates to point down when expanded, so
- * open/close reads as one continuous motion instead of an icon swap.
- */
-.collapse-toggle svg {
-  transition: transform 0.18s cubic-bezier(0.2, 0, 0, 1);
-}
-
-.collapse-toggle[data-collapsed="false"] svg {
-  transform: rotate(90deg);
 }
 
 .collapse-toggle[data-has-children="false"] {
   cursor: default;
 }
 
-.outline-row:hover .collapse-toggle[data-has-children="true"],
-.outline-row:focus-within .collapse-toggle[data-has-children="true"],
-.collapse-toggle[data-collapsed="true"] {
-  opacity: 1;
+/*
+ * Clickable guide-rail hit targets (tree helper). The visible rail is the <li>
+ * background-image; these (now wider) transparent buttons sit over each
+ * ancestor rail so the rail is the disclosure control. Hover highlights only
+ * the collapsable part under the specific ancestor (scoped by ownerId), not
+ * the whole column.
+ */
+.rail-toggle {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 20px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  border-radius: 999px;
+  cursor: pointer;
+  z-index: 3;
+}
+
+/* A collapsed branch has no descendant rows, so it needs its own visible rail
+ * stub under the parent bullet. That stub is the expand target. */
+.collapsed-rail-toggle {
+  top: 22px;
+  bottom: auto;
+  height: 18px;
+  background-image: linear-gradient(
+    to right,
+    transparent calc(50% - 0.5px),
+    var(--tree-guide) calc(50% - 0.5px),
+    var(--tree-guide) calc(50% + 0.5px),
+    transparent calc(50% + 0.5px)
+  );
 }
 
 /*
- * The chevron lives in the empty left margin, so it can grow its tap target
+ * The target lives in the empty left margin, so it can grow its tap target
  * LEFTWARD (into nothing) for a full 44px width without colliding with the
- * bullet to its right. Anchored to the chevron's right edge so the boundary
+ * bullet to its right. Anchored to the target's right edge so the boundary
  * with the bullet stays clean.
  */
 .collapse-toggle.touch-hitbox::before {
@@ -450,14 +679,22 @@ h2 > span.protected-lock {
 }
 
 /*
- * Touch devices have no hover, so the reveal-on-hover chevron would be an
- * invisible (if tappable) target. Keep it visible for any parent row so the
- * collapse affordance is discoverable. Childless rows still render no glyph.
+ * Tree helper hover highlight. Hovering a rail (or its collapsed stub) sets
+ * --hovered-rail-x and adds .rail-hovered only to descendant rows under that
+ * specific ancestor (via railOwnerIds). The ::before draws the brighter line
+ * only on the collapsable part of that line (not the whole depth column).
+ * Clickable hit area for rails is widened for easier targeting.
  */
-@media (hover: none) {
-  .collapse-toggle[data-has-children="true"] {
-    opacity: 1;
-  }
+.outline-node.rail-hovered::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: calc(var(--hovered-rail-x, 0px) - 0.5px);
+  width: 1px;
+  background-color: var(--tree-guide-hover);
+  pointer-events: none;
+  z-index: 2;
 }
 
 .bullet {
@@ -816,7 +1053,6 @@ body.dragging-active * {
     animation: none !important;
   }
 
-  .collapse-toggle svg,
   .outline-children-wrap,
   .outline-children-wrap > .outline-children {
     transition: none !important;
@@ -825,13 +1061,13 @@ body.dragging-active * {
 
 /*
  * Comfortable touch target WITHOUT width inflation. The gutter controls
- * (chevron, bullet, checkbox) sit too close to each other -- and to the text
+ * (collapse target, bullet, checkbox) sit too close to each other -- and to the text
  * -- to each claim 44px of WIDTH, so two centered 44px boxes used to overlap
- * and fight over the same taps (later-painted element won, so chevron taps
+ * and fight over the same taps (later-painted element won, so collapse taps
  * zoomed). We expand the target VERTICALLY only; each box stays as wide as its
  * control, so the boxes no longer physically overlap and there's no z-index
  * race. Width-expansion is opt-in per control where there's room (see the
- * chevron override below).
+ * collapse-target override above).
  */
 @utility touch-hitbox {
   position: relative;


### PR DESCRIPTION
## What

Two tree-helper improvements:

1. **Scoped hover highlight** - Previously, hovering a guide rail highlighted the entire depth column (all branches at that indent level). Now scoped using the specific ancestor ownerId from railOwnerIds, so only the segments under the hovered collapsible ancestor light up. Normal guides stay flat.

2. **Wider clickable rails** - RAIL_HIT_WIDTH_PX 12px to 20px, making the vertical guide lines much easier to click for collapse/expand without changing visuals.

3. **Rail centering fix** - 1px guide lines now center precisely on bullet-dot axes (shifted 0.5px to account for sub-pixel rendering).

## Screenshots

**Base outline with tree guides:**

<img width="1000" height="520" alt="tree-base" src="https://github.com/user-attachments/assets/9e0252ac-cf85-4b52-837b-7370ae7f0ee4" />

**Hovering "Website redesign" rail — only its 3 children highlight:**

<img width="1000" height="520" alt="tree-hover-web" src="https://github.com/user-attachments/assets/a57c6fc0-f34c-4415-9e17-7d84a7b58dd2" />

**Hovering "Projects" rail — all 7 descendants highlight:**

<img width="1000" height="520" alt="tree-hover-projects" src="https://github.com/user-attachments/assets/95c22e3e-0dd6-430f-aef0-3a5adc697889" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visible guide rails beside outline rows to better show hierarchy and hover targets.
  * Collapse/expand now works from rail controls across branches and mirrors, with improved flashing feedback when items change state.

* **Bug Fixes**
  * Updated collapse behavior in mirrored and collapsed views so only the intended content is affected.
  * Refined spacing, hover highlighting, and touch behavior for a cleaner outline interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->