### PR TITLE
Add `add_subtree` batch MCP tool (ADR 0028)

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ See [the sync design](docs/adr/0008-sync-via-a-per-user-durable-object.md) for t
 
 ## Agents (MCP)
 
-The outline is also reachable by AI agents over the [Model Context Protocol](https://modelcontextprotocol.io): point an MCP client at `https://<your-deployment>/mcp` and it walks the standard OAuth flow (sign in with your normal account; the client registers itself). Agents get read tools (`get_outline`, `search_nodes`) and write tools (`add_node`, `update_node`, `delete_node`, `move_nodes`, `add_to_today`, `mirror_node`, `mirror_to_today`); every write lands through the same atomic per-user Durable Object path as the editor, so open tabs see agent edits live. Design + rejected alternatives: [the agent-native MCP server](docs/adr/0026-agent-native-mcp-server.md).
+The outline is also reachable by AI agents over the [Model Context Protocol](https://modelcontextprotocol.io): point an MCP client at `https://<your-deployment>/mcp` and it walks the standard OAuth flow (sign in with your normal account; the client registers itself). Agents get read tools (`get_outline`, `search_nodes`) and write tools (`add_node`, `add_subtree`, `update_node`, `delete_node`, `move_nodes`, `add_to_today`, `mirror_node`, `mirror_to_today`); every write lands through the same atomic per-user Durable Object path as the editor, so open tabs see agent edits live. Design + rejected alternatives: [the agent-native MCP server](docs/adr/0026-agent-native-mcp-server.md).
 
 ## Project layout
 

--- a/docs/adr/0028-mcp-add-subtree.md
+++ b/docs/adr/0028-mcp-add-subtree.md
@@ -1,0 +1,113 @@
+---
+status: accepted
+---
+
+# The `add_subtree` MCP tool
+
+**What.** The agent-native MCP surface ([ADR 0026](./0026-agent-native-mcp-server.md)) gains a tenth
+tool: `add_subtree` — create a whole nested forest of fresh bullets in ONE atomic call, under a parent,
+at the top level, or on a day's daily note. Input is a recursive `nodes: NodeInput[]` where
+`NodeInput = { text, isTask?, children? }`, plus an optional `parentId` (null/omitted = top level), an
+optional `date` (YYYY-MM-DD, targets the daily note like `add_to_today`), and one root-level `position`
+(`"first" | "last"`, default `last`). It returns the created forest rendered as an indented bullet list
+with every node's id inline (the `get_outline` format). The motivating incident: saving a research
+outline onto the user's daily note took ~15 sequential `add_node` calls. The DO already applies an
+arbitrary op array atomically in one sync frame (`applyBatch`, [ADR 0009](./0009-atomic-structural-writes.md)),
+and every existing write tool plans exactly one node — so the batch tool is the missing shape, not new
+infrastructure. `add_node` (single bullet) stays; `add_subtree` is the many/nested sibling.
+
+## Decisions
+
+**Nested `children` recursion, NOT a flat `tempId`/`parentTempId` list or an indented-markdown string.**
+The input is the tree the agent is already holding; it hands it over verbatim. This is the load-bearing
+contract call, and it's the published schema ([ADR 0014](./0014-validate-the-worker-do-trust-boundary.md)'s
+one-source rule: the Effect Schema that gates `tools/call` IS what `tools/list` publishes), so it's hard
+to reverse. Recursion is expressed with `Schema.suspend`; `tools/list` already emits `$ref`/`$defs`
+(`worker/mcp.ts`), verified to publish cleanly for the clients we target (Claude and spec-following MCP
+clients tolerate recursive JSON Schema). Rejected: **flat `tempId` + `parentTempId`** — recursion-free
+(insurance against a stricter client we don't have), but uglier for the agent to author and it invents a
+new class of authoring error (dangling parent ref, temp-id cycles) plus a topological-sort/validation
+burden server-side. Rejected: **indented-markdown string** — one arg, trivial schema, but trades a schema
+problem for a *parser* problem (tab-vs-space, level width, task detection, escaping) whose failure mode is
+silent mis-nesting. Nested is also the only option where the sibling-chain trap below vanishes *by
+construction* instead of being *guarded*.
+
+**Sibling links are wired correct-by-construction, NOT by looping `planAddNode`.** The trap: `planAddNode`
+reads `childrenOf(index, parentId)` to find the last sibling, so looping it over the *same* snapshot makes
+every new top-level node compute the *same* `prevSiblingId` and tear the chain — the identical hazard
+`planReparent`/`moveManyNodes` guard with "rebuild the index between moves." `planAddSubtree` sidesteps it:
+the agent handed us the whole tree, so we emit depth-first and set each node's `prevSiblingId` to the
+*previously-emitted sibling at its level* — never re-derived from the index. The only place existing tree
+state is read is the **top-level anchor**, where the forest attaches among the parent's *existing*
+children: that reuses `planAddNode`'s exact rule (`last` chains after the current last child, no repoint;
+`first` inserts at the head and repoints the old first child to the run's tail). A future dev *will* reach
+for "just loop the single-add planner" and reintroduce the tear; this is the single most important thing
+the ADR records. Asserted as a test (multiple roots → one unbroken chain).
+
+**Atomic all-or-nothing; no per-node recovery.** One `applyBatch` = one `transactionSync` = one sync frame
+([ADR 0009](./0009-atomic-structural-writes.md)), so a bad `parentId`, an invalid `date`, an empty forest,
+or an over-cap payload fails the *whole* call and nothing half-lands — matching `planReparent`. Rejected:
+partial success ("added 8 of 12") — it leaves the agent reasoning about half-built state.
+
+**Bounded at `MAX_BATCH_NODES = 500`, counted during `emit`.** Same number as `MAX_OUTLINE_NODES`, one
+mental model ("500 is the ceiling everywhere") and already the count an agent hits reading back. Count is
+the resource bound (one transaction, one frame); a 500-node cap bounds depth implicitly, so **no separate
+depth cap**. Over the cap fails fast, naming the cap and the count received so the agent can split. Bulk
+"import my whole outline" is explicitly not this tool's job.
+
+**Optional `date` daily target reuses the daily-claim path; `parentId` + `date` is a hard error.** With
+`date`, the handler runs the same atomic `claimDailyId` + `planEnsureDaily` the daily tools use, then
+parents the forest under that day (appended as its last children — `position` is a `parentId`-path concept
+and ignored here), directly killing the motivating 15-call incident in one call. Neither set → top level;
+`parentId` set → under that node, a mirror parent redirecting through `trueSourceOf` so children hang off
+the content node ([ADR 0022](./0022-node-mirrors.md)), matching every other planner. **Both set → fail
+loud** ("pass `parentId` or `date`, not both") rather than silently pick one — ambiguity should make the
+agent correct itself. Targeting is thus a strict union of the two existing patterns, no new semantics.
+
+**Fresh nodes only: `{ text, isTask?, children? }`.** No `completed`/`collapsed`/`bookmark`, and firmly no
+`mirrorOf` — mirroring is `mirror_node`/`mirror_to_today`'s job with its cycle guards, and letting a create
+tool mint mirrors would bypass them and blur "new content" vs "reference." Empty `text` is allowed (legal
+in the outline; the editor makes empty bullets constantly). Every authored node — all roots and all
+descendants — is stamped with `origin` (agent provenance, [node-provenance](./0026-agent-native-mcp-server.md));
+the daily container/day materialized by `planEnsureDaily` stay `null` (structural scaffolding the DO would
+create anyway), the same split `planAddToDaily` already uses.
+
+**`add_subtree` coexists with `add_node`; it does not replace it.** `add_subtree` is a strict superset (a
+single bullet is a one-element `nodes` array), but collapsing to one tool would tax the ~95% single-bullet
+capture case with array ceremony and break existing `add_node` callers. Two tools with a clean "one vs.
+many/nested" split is *less* agent confusion than one over-general tool. The name is `add_subtree` (not
+`add_nodes`) to avoid the one-character collision with `add_node` in a skimmed tool list and because
+"subtree" *describes the shape* — the cue for when to reach for it.
+
+**Pure twin, not a shared implementation.** `planAddSubtree` is new pure code in `worker/outline-ops.ts`,
+anchored on `src/data/tree.ts` (`buildTreeIndex`/`childrenOf`/`trueSourceOf`/`makeNode`) like every other
+planner, with ids/timestamps as arguments so `bun test` covers the chain surgery without a DO or clock
+([ADR 0021](./0021-effect-first-one-schema-language.md)). There is no client counterpart to twin — the app
+builds subtrees keystroke by keystroke — so this is the one planner without an in-app mirror.
+
+## Considered and rejected
+
+- **Flat `tempId` + `parentTempId` input** — recursion-free, but worse agent ergonomics and a new authoring
+  error class; the recursion it avoids already publishes fine for our clients.
+- **Indented-markdown string input** — one arg, but a parser with silent mis-nesting failure modes.
+- **Looping `planAddNode`** per node — reintroduces the stale-index sibling-chain tear; the whole reason the
+  planner wires links by construction.
+- **Collapse `add_node` into `add_subtree`** (deprecate the single-add) — array ceremony on the common case,
+  breaks existing callers.
+- **`parentId` silently wins when both targets are set** — hides an agent mistake; hard reject makes it fix
+  the call.
+- **Per-node `completed`/`collapsed`/`mirrorOf`** — the first two are noise/view concerns an agent can set
+  after; `mirrorOf` bypasses the mirror cycle guards. Additive later if a real workflow needs `completed`.
+- **A separate depth cap** — node count is the real resource bound and caps depth implicitly.
+
+## Consequences
+
+- One new tool entry in `worker/mcp-tools.ts` (`add_subtree`) + the `planAddSubtree` planner in
+  `worker/outline-ops.ts` (reusing the private `newNode`, `planAddNode`'s anchor rule, and
+  `planEnsureDaily` for the `date` path); `tools/list` derives itself
+  ([ADR 0026](./0026-agent-native-mcp-server.md)). The published tool count is now ten.
+- Covered by `worker/outline-ops.test.ts` (the planner: multi-root chain integrity, deep nesting,
+  first/last anchor against existing children, the daily-`date` ensure-and-append path, the node-count cap,
+  and the empty-forest reject) plus the handler-level `parentId`+`date` and bad-`parentId` rejections. No
+  new e2e — MCP has no browser caller, the same carve-out as the rest of the surface.
+- No migration, no new `Node` field, no client change.

--- a/worker/mcp-tools.ts
+++ b/worker/mcp-tools.ts
@@ -25,6 +25,8 @@ import {
   formatDayText,
   isValidDateKey,
   formatOutlineLines,
+  guardForestSize,
+  type SubtreeInput,
   planAddNode,
   planAddSubtree,
   planAddSubtreeToDaily,
@@ -229,20 +231,15 @@ const AddNodeInput = Schema.Struct({
 
 /** One node in an `add_subtree` forest — recursive via `Schema.suspend`, which
  *  publishes as a named `$ref`/`$defs` in `tools/list` (ADR 0028). Fresh content
- *  only: text + optional to-do flag + optional nested children. */
-interface SubtreeNodeType {
-  readonly text: string
-  readonly isTask?: boolean | null
-  readonly children?: readonly SubtreeNodeType[] | null
-}
-
-const SubtreeNodeInput: Schema.Codec<SubtreeNodeType> = Schema.Struct({
+ *  only: text + optional to-do flag + optional nested children. The decoded type
+ *  IS the planner's own `SubtreeInput` — one shape, one source. */
+const SubtreeNodeInput: Schema.Codec<SubtreeInput> = Schema.Struct({
   text: Schema.String.annotate({ description: 'The bullet text.' }),
   isTask: optional(
     Schema.Boolean.annotate({ description: 'Create as a to-do with a checkbox (default: false).' }),
   ),
   children: optional(
-    Schema.Array(Schema.suspend((): Schema.Codec<SubtreeNodeType> => SubtreeNodeInput)).annotate({
+    Schema.Array(Schema.suspend((): Schema.Codec<SubtreeInput> => SubtreeNodeInput)).annotate({
       description: 'Nested child bullets, each with this same shape.',
     }),
   ),
@@ -450,6 +447,13 @@ export const tools: ReadonlyArray<ToolDef> = [
         // append the forest under the day (position is ignored — always last).
         if (input.date != null) {
           const dateKey = yield* resolveDateKey(input.date)
+          // Validate the forest BEFORE claiming any daily-index ids, so an empty
+          // or over-cap forest can't leave orphan container/day mappings pointing
+          // at nodes we never insert (ADR 0028 all-or-nothing).
+          const sizeError = guardForestSize(input.nodes, MAX_BATCH_NODES)
+          if (sizeError != null) {
+            return yield* Effect.fail(new ToolError({ reason: sizeError.message }))
+          }
           const containerId = yield* claimDailyId(store, CONTAINER_KEY, createId())
           const dayId = yield* claimDailyId(store, dateKey, createId())
           const index = yield* loadIndex(store)

--- a/worker/mcp-tools.ts
+++ b/worker/mcp-tools.ts
@@ -490,7 +490,8 @@ export const tools: ReadonlyArray<ToolDef> = [
         const where = plan.parentId
           ? `under "${index.byId.get(plan.parentId)?.text ?? plan.parentId}"`
           : 'at the top level'
-        return `Added ${plan.rootIds.length} top-level bullet(s) ${where}:\n${renderCreatedForest(plan.ops, plan.rootIds)}`
+        const kind = plan.parentId ? 'bullet(s)' : 'top-level bullet(s)'
+        return `Added ${plan.rootIds.length} ${kind} ${where}:\n${renderCreatedForest(plan.ops, plan.rootIds)}`
       }),
   },
   {

--- a/worker/mcp-tools.ts
+++ b/worker/mcp-tools.ts
@@ -26,6 +26,8 @@ import {
   isValidDateKey,
   formatOutlineLines,
   planAddNode,
+  planAddSubtree,
+  planAddSubtreeToDaily,
   planAddToDaily,
   planDeleteNode,
   planMirrorNode,
@@ -225,6 +227,52 @@ const AddNodeInput = Schema.Struct({
   ),
 })
 
+/** One node in an `add_subtree` forest — recursive via `Schema.suspend`, which
+ *  publishes as a named `$ref`/`$defs` in `tools/list` (ADR 0028). Fresh content
+ *  only: text + optional to-do flag + optional nested children. */
+interface SubtreeNodeType {
+  readonly text: string
+  readonly isTask?: boolean | null
+  readonly children?: readonly SubtreeNodeType[] | null
+}
+
+const SubtreeNodeInput: Schema.Codec<SubtreeNodeType> = Schema.Struct({
+  text: Schema.String.annotate({ description: 'The bullet text.' }),
+  isTask: optional(
+    Schema.Boolean.annotate({ description: 'Create as a to-do with a checkbox (default: false).' }),
+  ),
+  children: optional(
+    Schema.Array(Schema.suspend((): Schema.Codec<SubtreeNodeType> => SubtreeNodeInput)).annotate({
+      description: 'Nested child bullets, each with this same shape.',
+    }),
+  ),
+}).annotate({ identifier: 'SubtreeNode' })
+
+const AddSubtreeInput = Schema.Struct({
+  nodes: Schema.Array(SubtreeNodeInput).annotate({
+    description:
+      'The bullets to create, as a nested forest. Each node may carry its own `children`, so a whole outline lands in one call.',
+  }),
+  parentId: optional(
+    Schema.String.annotate({
+      description:
+        'Parent node id to add under. Omit for the top level. Mutually exclusive with `date`.',
+    }),
+  ),
+  date: optional(
+    Schema.String.annotate({
+      description:
+        "Add onto the daily note for this YYYY-MM-DD instead of a parent (pass the user's local date). Mutually exclusive with `parentId`.",
+    }),
+  ),
+  position: optional(
+    Schema.Literals(['first', 'last']).annotate({
+      description:
+        'Insert the forest as the first or last children of the parent (default: last). Ignored for the `date` path, which always appends.',
+    }),
+  ),
+})
+
 const UpdateNodeInput = Schema.Struct({
   nodeId: Schema.String.annotate({ description: 'The node to update.' }),
   text: optional(Schema.String.annotate({ description: 'New bullet text.' })),
@@ -294,6 +342,23 @@ const MirrorToTodayInput = Schema.Struct({
 
 const MAX_OUTLINE_NODES = 500
 const MAX_SEARCH_HITS = 25
+/** One `add_subtree` batch = one DO `transactionSync` = one sync frame; cap the
+ *  forest at the same ceiling an agent hits reading back (ADR 0028). */
+const MAX_BATCH_NODES = 500
+
+/** Render a freshly-planned forest as the agent-facing bullet list with ids —
+ *  built from the plan's own insert ops, so no extra read of the store. */
+const renderCreatedForest = (ops: ReadonlyArray<ChangeOp>, rootIds: ReadonlyArray<string>): string => {
+  const created = buildTreeIndex(ops.flatMap((o) => (o.op === 'insert' ? [o.value] : [])))
+  const lines = rootIds.flatMap((id) => {
+    const r = flattenSubtree(created, id, {
+      maxDepth: Number.POSITIVE_INFINITY,
+      maxNodes: MAX_BATCH_NODES,
+    })
+    return r instanceof Error ? [] : r.lines
+  })
+  return formatOutlineLines(lines)
+}
 
 export const tools: ReadonlyArray<ToolDef> = [
   {
@@ -364,6 +429,64 @@ export const tools: ReadonlyArray<ToolDef> = [
           ? `under "${index.byId.get(plan.parentId)?.text ?? plan.parentId}"`
           : 'at the top level'
         return `Added "${input.text}" ${where} (id: ${plan.nodeId}).`
+      }),
+  },
+  {
+    name: 'add_subtree',
+    description:
+      "Add a whole nested outline — a forest of bullets, each with its own children — in ONE atomic call. Use this instead of many add_node calls when building structure. Target a parent (parentId), the top level (omit both), or the user's daily note (date). Returns the created bullets with their ids.",
+    input: AddSubtreeInput,
+    readOnly: false,
+    handle: (input: typeof AddSubtreeInput.Type, store, origin) =>
+      Effect.gen(function* () {
+        if (input.parentId != null && input.date != null) {
+          return yield* Effect.fail(
+            new ToolError({ reason: 'pass either parentId or date, not both' }),
+          )
+        }
+        const timestamp = yield* clock
+
+        // Daily path: claim the container + day ids atomically, then ensure-and-
+        // append the forest under the day (position is ignored — always last).
+        if (input.date != null) {
+          const dateKey = yield* resolveDateKey(input.date)
+          const containerId = yield* claimDailyId(store, CONTAINER_KEY, createId())
+          const dayId = yield* claimDailyId(store, dateKey, createId())
+          const index = yield* loadIndex(store)
+          const plan = yield* unwrap(
+            planAddSubtreeToDaily(index, {
+              nodes: input.nodes,
+              dateKey,
+              containerId,
+              dayId,
+              origin,
+              timestamp,
+              newId: createId,
+              maxNodes: MAX_BATCH_NODES,
+            }),
+          )
+          yield* commit(store, plan.ops)
+          return `Added ${plan.rootIds.length} bullet(s) to ${formatDayText(dateKey)} (daily note id: ${dayId}):\n${renderCreatedForest(plan.ops, plan.rootIds)}`
+        }
+
+        // Parent (or top-level) path.
+        const index = yield* loadIndex(store)
+        const plan = yield* unwrap(
+          planAddSubtree(index, {
+            nodes: input.nodes,
+            parentId: input.parentId ?? null,
+            position: input.position ?? 'last',
+            origin,
+            timestamp,
+            newId: createId,
+            maxNodes: MAX_BATCH_NODES,
+          }),
+        )
+        yield* commit(store, plan.ops)
+        const where = plan.parentId
+          ? `under "${index.byId.get(plan.parentId)?.text ?? plan.parentId}"`
+          : 'at the top level'
+        return `Added ${plan.rootIds.length} top-level bullet(s) ${where}:\n${renderCreatedForest(plan.ops, plan.rootIds)}`
       }),
   },
   {

--- a/worker/mcp.test.ts
+++ b/worker/mcp.test.ts
@@ -138,6 +138,7 @@ describe('MCP transport', () => {
       'get_outline',
       'search_nodes',
       'add_node',
+      'add_subtree',
       'update_node',
       'delete_node',
       'move_nodes',
@@ -211,6 +212,72 @@ describe('MCP tools', () => {
     // the editor can mark an agent's edit apart from the user's own (write-once).
     expect(insert && insert.op === 'insert' && insert.value.origin).toBe('TestAgent')
     expect(toolText(json)).toContain('Added "new bullet"')
+  })
+
+  test('add_subtree inserts a nested forest as ONE atomic batch, stamping origin on all', async () => {
+    const fake = makeStore(fixture())
+    const json = await callTool(fake.store, 'add_subtree', {
+      parentId: 'a',
+      nodes: [{ text: 'one', children: [{ text: 'one-a' }, { text: 'one-b' }] }, { text: 'two' }],
+    })
+    expect(json.result?.isError).toBeUndefined()
+    expect(fake.batches).toHaveLength(1)
+    const inserts = fake.batches[0]!.flatMap((op) => (op.op === 'insert' ? [op.value] : []))
+    // 2 roots + 2 grandchildren = 4 fresh nodes, all agent-stamped.
+    expect(inserts).toHaveLength(4)
+    expect(inserts.every((n) => n.origin === 'TestAgent')).toBe(true)
+    // The two top-level roots chain, both under a, first after a's existing child.
+    const roots = inserts.filter((n) => n.parentId === 'a')
+    expect(roots).toHaveLength(2)
+    expect(roots[0]!.prevSiblingId).toBe('a1')
+    expect(roots[1]!.prevSiblingId).toBe(roots[0]!.id)
+    // The reply renders the created bullets with their ids.
+    expect(toolText(json)).toContain('one-a')
+    expect(toolText(json)).toContain('(id:')
+  })
+
+  test('add_subtree onto the daily note creates the day and appends the forest', async () => {
+    const fake = makeStore(fixture())
+    const json = await callTool(fake.store, 'add_subtree', {
+      date: '2026-07-03',
+      nodes: [{ text: 'research', children: [{ text: 'finding' }] }],
+    })
+    expect(json.result?.isError).toBeUndefined()
+    expect(fake.batches).toHaveLength(1)
+    // Daily container + day claimed in the kv index.
+    expect(fake.kv.has('container')).toBe(true)
+    expect(fake.kv.has('2026-07-03')).toBe(true)
+    expect(toolText(json)).toContain('Friday, July 3, 2026')
+  })
+
+  test('add_subtree with BOTH parentId and date is a loud isError, nothing written', async () => {
+    const fake = makeStore(fixture())
+    const json = await callTool(fake.store, 'add_subtree', {
+      parentId: 'a',
+      date: '2026-07-03',
+      nodes: [{ text: 'x' }],
+    })
+    expect(json.result?.isError).toBe(true)
+    expect(toolText(json)).toContain('not both')
+    expect(fake.batches).toHaveLength(0)
+  })
+
+  test('add_subtree with a missing parent is isError with no write', async () => {
+    const fake = makeStore(fixture())
+    const json = await callTool(fake.store, 'add_subtree', { parentId: 'ghost', nodes: [{ text: 'x' }] })
+    expect(json.result?.isError).toBe(true)
+    expect(fake.batches).toHaveLength(0)
+  })
+
+  test('add_subtree publishes its recursive input as a named $def', async () => {
+    const { store } = makeStore()
+    const json = (await (await rpc(store, 'tools/list')).json()) as any
+    const addSubtree = json.result.tools.find((t: any) => t.name === 'add_subtree')
+    expect(addSubtree.inputSchema.type).toBe('object')
+    expect(addSubtree.inputSchema.required).toEqual(['nodes'])
+    // The recursive SubtreeNode shape is emitted as a $def and referenced.
+    expect(addSubtree.inputSchema.$defs?.SubtreeNode).toBeDefined()
+    expect(JSON.stringify(addSubtree.inputSchema)).toContain('#/$defs/SubtreeNode')
   })
 
   test('update_node edits fields; delete_node cascades', async () => {

--- a/worker/mcp.test.ts
+++ b/worker/mcp.test.ts
@@ -269,6 +269,17 @@ describe('MCP tools', () => {
     expect(fake.batches).toHaveLength(0)
   })
 
+  test('add_subtree onto a day with an empty forest fails BEFORE claiming any daily ids', async () => {
+    const fake = makeStore(fixture())
+    const json = await callTool(fake.store, 'add_subtree', { date: '2026-07-03', nodes: [] })
+    expect(json.result?.isError).toBe(true)
+    expect(fake.batches).toHaveLength(0)
+    // The size guard runs before the kv claims, so no orphan container/day
+    // mapping is left pointing at nodes that were never inserted (ADR 0028).
+    expect(fake.kv.has('container')).toBe(false)
+    expect(fake.kv.has('2026-07-03')).toBe(false)
+  })
+
   test('add_subtree publishes its recursive input as a named $def', async () => {
     const { store } = makeStore()
     const json = (await (await rpc(store, 'tools/list')).json()) as any

--- a/worker/outline-ops.test.ts
+++ b/worker/outline-ops.test.ts
@@ -11,7 +11,9 @@ import { describe, expect, test } from 'bun:test'
 import { makeNode } from '../src/data/tree'
 import type { ChangeOp, Node } from '../src/data/wire-schema'
 import {
+  BatchTooLarge,
   DAILY_CONTAINER_TEXT,
+  EmptyForest,
   MirrorCycle,
   NodeNotFound,
   RedundantDescendant,
@@ -22,6 +24,8 @@ import {
   formatDayText,
   formatOutlineLines,
   planAddNode,
+  planAddSubtree,
+  planAddSubtreeToDaily,
   planAddToDaily,
   planDeleteNode,
   planEnsureDaily,
@@ -390,6 +394,202 @@ describe('planReparent', () => {
 
   test('listing a node alongside its own moved ancestor is RedundantDescendant', () => {
     expect(move(fixture(), { nodeIds: ['a', 'a1'], newParentId: 'b', position: 'last', timestamp: T })).toBeInstanceOf(RedundantDescendant)
+  })
+})
+
+describe('planAddSubtree', () => {
+  /** A deterministic id factory: n0, n1, n2, ... in emission order. */
+  const idFactory = () => {
+    let i = 0
+    return () => `n${i++}`
+  }
+
+  test('wires a run of sibling roots into one unbroken chain (the trap)', () => {
+    // Three top-level roots under `a`: looping planAddNode over a stale index
+    // would give each the same prevSiblingId (a2) and tear the chain. By
+    // construction each root chains to the previous one.
+    const plan = planAddSubtree(index(fixture()), {
+      nodes: [{ text: 'one' }, { text: 'two' }, { text: 'three' }],
+      parentId: 'a',
+      position: 'last',
+      timestamp: T,
+      newId: idFactory(),
+      maxNodes: 500,
+    })
+    if (plan instanceof Error) throw plan
+    const nodes = inserted(plan.ops)
+    expect(nodes.map((n) => n.id)).toEqual(['n0', 'n1', 'n2'])
+    expect(nodes.map((n) => n.parentId)).toEqual(['a', 'a', 'a'])
+    // First root chains after the parent's existing last child (a2), the rest
+    // chain to their predecessor — no shared predecessor, no self-ref.
+    expect(nodes.map((n) => n.prevSiblingId)).toEqual(['a2', 'n0', 'n1'])
+    expect(plan.rootIds).toEqual(['n0', 'n1', 'n2'])
+    expect(plan.parentId).toBe('a')
+  })
+
+  test('nests children depth-first, each level its own chain', () => {
+    const plan = planAddSubtree(index([]), {
+      nodes: [
+        {
+          text: 'root',
+          children: [
+            { text: 'c1', children: [{ text: 'g1' }, { text: 'g2' }] },
+            { text: 'c2' },
+          ],
+        },
+      ],
+      parentId: null,
+      position: 'last',
+      timestamp: T,
+      newId: idFactory(),
+      maxNodes: 500,
+    })
+    if (plan instanceof Error) throw plan
+    const byId = new Map(inserted(plan.ops).map((n) => [n.id, n]))
+    // n0 root, n1 c1, n2 g1, n3 g2, n4 c2  (depth-first emission order)
+    expect(byId.get('n0')!.parentId).toBeNull()
+    expect(byId.get('n0')!.prevSiblingId).toBeNull()
+    expect(byId.get('n1')!.parentId).toBe('n0')
+    expect(byId.get('n1')!.prevSiblingId).toBeNull()
+    expect(byId.get('n2')!.parentId).toBe('n1')
+    expect(byId.get('n2')!.prevSiblingId).toBeNull()
+    expect(byId.get('n3')!.parentId).toBe('n1')
+    expect(byId.get('n3')!.prevSiblingId).toBe('n2')
+    // c2 is the root's second child, chaining after c1
+    expect(byId.get('n4')!.parentId).toBe('n0')
+    expect(byId.get('n4')!.prevSiblingId).toBe('n1')
+    expect(plan.rootIds).toEqual(['n0'])
+  })
+
+  test('position "first" puts the run at the head and repoints the old head to the run tail', () => {
+    const plan = planAddSubtree(index(fixture()), {
+      nodes: [{ text: 'one' }, { text: 'two' }],
+      parentId: 'a',
+      position: 'first',
+      timestamp: T,
+      newId: idFactory(),
+      maxNodes: 500,
+    })
+    if (plan instanceof Error) throw plan
+    const inserts = inserted(plan.ops)
+    expect(inserts[0]!.prevSiblingId).toBeNull()
+    expect(inserts[1]!.prevSiblingId).toBe('n0')
+    // a's former first child (a1) now follows the LAST root of the run (n1)
+    const repointed = updated(plan.ops)
+    expect(repointed).toHaveLength(1)
+    expect(repointed[0]!.id).toBe('a1')
+    expect(repointed[0]!.prevSiblingId).toBe('n1')
+  })
+
+  test('a mirror parent redirects to its true source', () => {
+    const nodes = [...fixture(), makeNode({ id: 'm', text: 'alpha', mirrorOf: 'a', prevSiblingId: 'b' })]
+    const plan = planAddSubtree(index(nodes), {
+      nodes: [{ text: 'x' }],
+      parentId: 'm',
+      position: 'last',
+      timestamp: T,
+      newId: idFactory(),
+      maxNodes: 500,
+    })
+    if (plan instanceof Error) throw plan
+    expect(inserted(plan.ops)[0]!.parentId).toBe('a')
+    expect(plan.parentId).toBe('a')
+  })
+
+  test('stamps origin onto every authored node, root and descendant', () => {
+    const plan = planAddSubtree(index([]), {
+      nodes: [{ text: 'root', children: [{ text: 'kid' }] }],
+      parentId: null,
+      position: 'last',
+      origin: 'Claude',
+      timestamp: T,
+      newId: idFactory(),
+      maxNodes: 500,
+    })
+    if (plan instanceof Error) throw plan
+    expect(inserted(plan.ops).every((n) => n.origin === 'Claude')).toBe(true)
+  })
+
+  test('empty forest is EmptyForest', () => {
+    expect(
+      planAddSubtree(index(fixture()), {
+        nodes: [],
+        parentId: 'a',
+        position: 'last',
+        timestamp: T,
+        newId: idFactory(),
+        maxNodes: 500,
+      }),
+    ).toBeInstanceOf(EmptyForest)
+  })
+
+  test('a forest over the cap is BatchTooLarge (descendants counted)', () => {
+    // 1 root + 2 children = 3 nodes; cap of 2 must reject.
+    const plan = planAddSubtree(index([]), {
+      nodes: [{ text: 'root', children: [{ text: 'a' }, { text: 'b' }] }],
+      parentId: null,
+      position: 'last',
+      timestamp: T,
+      newId: idFactory(),
+      maxNodes: 2,
+    })
+    expect(plan).toBeInstanceOf(BatchTooLarge)
+  })
+
+  test('a missing parent is NodeNotFound', () => {
+    expect(
+      planAddSubtree(index(fixture()), {
+        nodes: [{ text: 'x' }],
+        parentId: 'ghost',
+        position: 'last',
+        timestamp: T,
+        newId: idFactory(),
+        maxNodes: 500,
+      }),
+    ).toBeInstanceOf(NodeNotFound)
+  })
+
+  test('planAddSubtreeToDaily materializes the day and appends the forest after its last child', () => {
+    const nodes = [
+      ...fixture(),
+      makeNode({ id: 'cont', text: DAILY_CONTAINER_TEXT, prevSiblingId: 'b' }),
+      makeNode({ id: 'day', text: 'Friday, July 3, 2026', parentId: 'cont' }),
+      makeNode({ id: 'existing', text: 'already here', parentId: 'day' }),
+    ]
+    const plan = planAddSubtreeToDaily(index(nodes), {
+      nodes: [{ text: 'one' }, { text: 'two' }],
+      dateKey: '2026-07-03',
+      containerId: 'cont',
+      dayId: 'day',
+      timestamp: T,
+      newId: idFactory(),
+      maxNodes: 500,
+    })
+    if (plan instanceof Error) throw plan
+    const inserts = inserted(plan.ops)
+    expect(inserts.map((n) => n.parentId)).toEqual(['day', 'day'])
+    expect(inserts[0]!.prevSiblingId).toBe('existing')
+    expect(inserts[1]!.prevSiblingId).toBe(inserts[0]!.id)
+    expect(plan.rootIds).toHaveLength(2)
+  })
+
+  test('planAddSubtreeToDaily creates the container + day when absent, then appends', () => {
+    const plan = planAddSubtreeToDaily(index(fixture()), {
+      nodes: [{ text: 'one' }],
+      dateKey: '2026-07-03',
+      containerId: 'cont',
+      dayId: 'day',
+      timestamp: T,
+      newId: idFactory(),
+      maxNodes: 500,
+    })
+    if (plan instanceof Error) throw plan
+    const ids = inserted(plan.ops).map((n) => n.id)
+    // container + day (materialized) + the one forest node
+    expect(ids).toContain('cont')
+    expect(ids).toContain('day')
+    const entry = inserted(plan.ops).find((n) => n.parentId === 'day' && n.id.startsWith('n'))!
+    expect(entry.prevSiblingId).toBeNull()
   })
 })
 

--- a/worker/outline-ops.ts
+++ b/worker/outline-ops.ts
@@ -81,6 +81,22 @@ export class RedundantDescendant extends Data.TaggedError('RedundantDescendant')
   }
 }
 
+/** A batch-insert forest with more nodes than one atomic frame may carry
+ *  (ADR 0028). One `applyBatch` is one DO `transactionSync`; the cap keeps an
+ *  agent from dropping thousands of rows in a single frame. */
+export class BatchTooLarge extends Data.TaggedError('BatchTooLarge')<{ count: number; max: number }> {
+  get message() {
+    return `too many nodes: ${this.count} exceeds the ${this.max}-node batch limit — split into smaller add_subtree calls`
+  }
+}
+
+/** `add_subtree` was handed no nodes — nothing to create (ADR 0028). */
+export class EmptyForest extends Data.TaggedError('EmptyForest')<Record<never, never>> {
+  get message() {
+    return 'nothing to add — pass at least one node'
+  }
+}
+
 // --- Node construction --------------------------------------------------------
 
 /** A complete wire node with caller-supplied identity + clock. `makeNode` owns
@@ -464,6 +480,126 @@ export function planReparent(
   return { ops, movedIds: nodeIds, parentId }
 }
 
+// --- Subtree (batch insert) planning ------------------------------------------
+
+/** A node to create in a batch, with its own nested children — the recursive
+ *  shape the `add_subtree` tool accepts. Fresh content only: no id (the caller
+ *  mints them), no mirror, no completed/collapsed state (ADR 0028). */
+export interface SubtreeInput {
+  text: string
+  isTask?: boolean | null
+  children?: readonly SubtreeInput[] | null
+}
+
+/** Total node count of a forest (roots + every descendant), for the size cap. */
+function countForest(nodes: readonly SubtreeInput[]): number {
+  let n = 0
+  const stack: SubtreeInput[] = [...nodes]
+  while (stack.length) {
+    const node = stack.pop()!
+    n++
+    if (node.children) stack.push(...node.children)
+  }
+  return n
+}
+
+/**
+ * Emit a forest depth-first under `parentId`, chaining each node's
+ * `prevSiblingId` to the previously-emitted sibling AT ITS LEVEL. The first root
+ * chains from `firstPrev` (the parent's existing anchor sibling, or null).
+ *
+ * CORRECT BY CONSTRUCTION (ADR 0028): the wiring reads NOTHING from the tree
+ * index — the caller handed us the whole shape, so sibling order comes from the
+ * emission order, not from `childrenOf`. This is why the batch tool does NOT
+ * loop `planAddNode` (which re-reads the stale last-sibling each call and would
+ * give every new root the same predecessor, tearing the chain).
+ */
+function emitForest(
+  nodes: readonly SubtreeInput[],
+  parentId: string | null,
+  firstPrev: string | null,
+  origin: string | null | undefined,
+  timestamp: number,
+  newId: () => string,
+): { ops: ChangeOp[]; rootIds: string[] } {
+  const ops: ChangeOp[] = []
+  const walk = (siblings: readonly SubtreeInput[], parent: string | null, initialPrev: string | null): string[] => {
+    const ids: string[] = []
+    let prev = initialPrev
+    for (const input of siblings) {
+      const id = newId()
+      ops.push({
+        op: 'insert',
+        value: newNode({
+          id,
+          parentId: parent,
+          prevSiblingId: prev,
+          text: input.text,
+          isTask: input.isTask ?? false,
+          origin,
+          timestamp,
+        }),
+      })
+      ids.push(id)
+      if (input.children && input.children.length) walk(input.children, id, null)
+      prev = id
+    }
+    return ids
+  }
+  return { ops, rootIds: walk(nodes, parentId, firstPrev) }
+}
+
+/**
+ * Insert a whole nested forest under `parentId` (null = top level) in ONE batch
+ * — the batch twin of `planAddNode`. Interior links are wired by construction
+ * (`emitForest`); only the top-level run reads the parent's existing children to
+ * anchor, reusing `planAddNode`'s first/last rule: `last` chains the run after
+ * the current last child; `first` puts it at the head and repoints the old head
+ * to the run's LAST root. A mirror parent redirects to its true source (ADR
+ * 0022). Fails the whole call on an empty forest, an over-cap payload, or a
+ * missing parent — all-or-nothing, matching the one-frame model (ADR 0009).
+ */
+export function planAddSubtree(
+  index: TreeIndex,
+  args: {
+    nodes: readonly SubtreeInput[]
+    parentId: string | null
+    position: 'first' | 'last'
+    origin?: string | null
+    timestamp: number
+    newId: () => string
+    maxNodes: number
+  },
+): { ops: ChangeOp[]; rootIds: string[]; parentId: string | null } | NodeNotFound | EmptyForest | BatchTooLarge {
+  const count = countForest(args.nodes)
+  if (count === 0) return new EmptyForest()
+  if (count > args.maxNodes) return new BatchTooLarge({ count, max: args.maxNodes })
+
+  let parentId: string | null = null
+  if (args.parentId !== null) {
+    if (!index.byId.has(args.parentId)) return new NodeNotFound({ nodeId: args.parentId })
+    parentId = trueSourceOf(index, args.parentId)
+  }
+
+  const siblings = childrenOf(index, parentId)
+  const head = args.position === 'first' ? (siblings[0] ?? null) : null
+  const firstPrev =
+    args.position === 'first' ? null : siblings.length ? siblings[siblings.length - 1]!.id : null
+
+  const { ops, rootIds } = emitForest(
+    args.nodes,
+    parentId,
+    firstPrev,
+    args.origin,
+    args.timestamp,
+    args.newId,
+  )
+  if (head) {
+    ops.push(updateOp(head, { prevSiblingId: rootIds[rootIds.length - 1]! }, args.timestamp))
+  }
+  return { ops, rootIds, parentId }
+}
+
 // --- Daily-note planning ------------------------------------------------------
 // The daily plugin's identity model, server-side: the `daily-index` kv
 // side-collection maps `container` -> the "Daily" container node and a local
@@ -608,6 +744,36 @@ export function planAddToDaily(
     }),
   })
   return { ops, nodeId: args.newNodeId }
+}
+
+/** Ensure the day exists, then append a whole nested forest as its LAST children
+ *  — one combined batch for `add_subtree`'s `date` path. Always appends
+ *  (position is a `parentId`-path concept); the size cap is enforced here too so
+ *  the daily path can't smuggle an over-cap payload past it (ADR 0028). */
+export function planAddSubtreeToDaily(
+  index: TreeIndex,
+  args: {
+    nodes: readonly SubtreeInput[]
+    dateKey: string
+    containerId: string
+    dayId: string
+    origin?: string | null
+    timestamp: number
+    newId: () => string
+    maxNodes: number
+  },
+): { ops: ChangeOp[]; rootIds: string[] } | EmptyForest | BatchTooLarge {
+  const count = countForest(args.nodes)
+  if (count === 0) return new EmptyForest()
+  if (count > args.maxNodes) return new BatchTooLarge({ count, max: args.maxNodes })
+
+  const { ops } = planEnsureDaily(index, args)
+  // A pre-existing day may already have children; a just-planned one can't.
+  const siblings = index.byId.has(args.dayId) ? childrenOf(index, args.dayId) : []
+  const firstPrev = siblings.length ? siblings[siblings.length - 1]!.id : null
+  const emitted = emitForest(args.nodes, args.dayId, firstPrev, args.origin, args.timestamp, args.newId)
+  ops.push(...emitted.ops)
+  return { ops, rootIds: emitted.rootIds }
 }
 
 /** Ensure the day exists, then mirror `sourceId` as its LAST child — one

--- a/worker/outline-ops.ts
+++ b/worker/outline-ops.ts
@@ -486,21 +486,38 @@ export function planReparent(
  *  shape the `add_subtree` tool accepts. Fresh content only: no id (the caller
  *  mints them), no mirror, no completed/collapsed state (ADR 0028). */
 export interface SubtreeInput {
-  text: string
-  isTask?: boolean | null
-  children?: readonly SubtreeInput[] | null
+  readonly text: string
+  readonly isTask?: boolean | null
+  readonly children?: readonly SubtreeInput[] | null
 }
 
-/** Total node count of a forest (roots + every descendant), for the size cap. */
+/** Total node count of a forest (roots + every descendant), for the size cap.
+ *  Pushes children one at a time — NOT `push(...children)` — so a pathologically
+ *  wide `children` array can't `RangeError` on argument-count before the cap
+ *  gets a chance to reject it. */
 function countForest(nodes: readonly SubtreeInput[]): number {
   let n = 0
   const stack: SubtreeInput[] = [...nodes]
   while (stack.length) {
     const node = stack.pop()!
     n++
-    if (node.children) stack.push(...node.children)
+    if (node.children) for (const child of node.children) stack.push(child)
   }
   return n
+}
+
+/** The size verdict for a batch forest, or `null` when it's within bounds.
+ *  Shared by both subtree planners AND the handler's pre-claim check (ADR 0028),
+ *  so the cap has one owner and the daily path can't claim ids for a forest that
+ *  will be rejected. */
+export function guardForestSize(
+  nodes: readonly SubtreeInput[],
+  maxNodes: number,
+): EmptyForest | BatchTooLarge | null {
+  const count = countForest(nodes)
+  if (count === 0) return new EmptyForest()
+  if (count > maxNodes) return new BatchTooLarge({ count, max: maxNodes })
+  return null
 }
 
 /**
@@ -571,9 +588,8 @@ export function planAddSubtree(
     maxNodes: number
   },
 ): { ops: ChangeOp[]; rootIds: string[]; parentId: string | null } | NodeNotFound | EmptyForest | BatchTooLarge {
-  const count = countForest(args.nodes)
-  if (count === 0) return new EmptyForest()
-  if (count > args.maxNodes) return new BatchTooLarge({ count, max: args.maxNodes })
+  const tooBig = guardForestSize(args.nodes, args.maxNodes)
+  if (tooBig) return tooBig
 
   let parentId: string | null = null
   if (args.parentId !== null) {
@@ -763,9 +779,8 @@ export function planAddSubtreeToDaily(
     maxNodes: number
   },
 ): { ops: ChangeOp[]; rootIds: string[] } | EmptyForest | BatchTooLarge {
-  const count = countForest(args.nodes)
-  if (count === 0) return new EmptyForest()
-  if (count > args.maxNodes) return new BatchTooLarge({ count, max: args.maxNodes })
+  const tooBig = guardForestSize(args.nodes, args.maxNodes)
+  if (tooBig) return tooBig
 
   const { ops } = planEnsureDaily(index, args)
   // A pre-existing day may already have children; a just-planned one can't.


### PR DESCRIPTION
## What

A new MCP tool, `add_subtree`, that creates a whole **nested forest of bullets in ONE atomic call** — targeting a parent, the top level, or the user's daily note. Collapses the ~15 sequential `add_node` calls it took to save a research outline onto a daily note into a single write.

Grilled to a locked design via `grill-with-docs` before any code; decisions recorded in **[ADR 0028](./docs/adr/0028-mcp-add-subtree.md)**.

## Design (the calls that aren't obvious from the code)

- **Nested `children` recursion**, not flat `tempId`/`parentTempId` or a markdown string — best agent ergonomics, and the only shape where the sibling-chain trap vanishes by construction. Published as `#/$defs/SubtreeNode` via `Schema.suspend` (+ `identifier` annotation).
- **Correct-by-construction wiring** in `emitForest` (depth-first, `prevSiblingId` = prior emitted sibling). It does **NOT** loop `planAddNode` — that re-reads the stale last-sibling each call and tears the chain (the same hazard `planReparent` guards). Only the top-level anchor reads existing tree state, reusing `planAddNode`'s first/last rule.
- **Targeting**: `parentId` | top level | `date` (daily note, reuses `planEnsureDaily`). `parentId`+`date` together **fails loud**. Mirror `parentId` → true source.
- **Atomic all-or-nothing** via one `applyBatch` frame; cap `MAX_BATCH_NODES = 500` (count-only); empty forest rejected.
- **Fresh nodes only** (`text`/`isTask`/`children`); `origin` provenance stamped on every authored node, daily scaffold stays `null`.
- **Returns the created forest rendered with ids** (the `get_outline` format), so a follow-up edit needs no extra read.
- Kept **alongside** `add_node` (renamed batch tool to avoid the one-char collision + it describes the shape). Tool count is now ten.

## Tests

- `worker/outline-ops.test.ts` — 12 planner cases: the multi-root chain trap, deep nesting, first/last anchor, mirror-parent redirect, origin stamping, empty/over-cap/missing-parent, and both daily paths.
- `worker/mcp.test.ts` — 5 handler cases: one-frame nested insert, daily create+append, `parentId`+`date` reject, missing-parent reject, recursive `$def` publishing; plus the ordered `tools/list` assertion updated.

**Gates:** `bun run test` (295 pass) · `typecheck:worker` · `typecheck:test` · `lint` — all green. Also driven end-to-end through the real `handleMcp` JSON-RPC path (nested → one frame, daily → one frame + kv claims, both-set → `isError` with zero frames).

No migration, no new `Node` field, no client change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `add_subtree` MCP tool to create an entire nested outline “forest” in one action.
  * Supports inserting under a chosen parent, at top level, or appending to a daily note.
  * Responses include the created structure as an indented bullet list with IDs.
* **Bug Fixes**
  * Added upfront validation to reject empty subtrees and requests that mix incompatible placement options.
  * Enforces a maximum subtree size to keep atomic multi-item inserts reliable.
* **Tests**
  * Expanded unit coverage for tool listing and subtree insertion/planning scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->