### PR TITLE
Add Superset workspace setup/teardown scripts

### DIFF
--- a/.superset/config.json
+++ b/.superset/config.json
@@ -1,0 +1,4 @@
+{
+  "setup": ["./.superset/setup.sh"],
+  "run": ["./.superset/run.sh"]
+}

--- a/.superset/run.sh
+++ b/.superset/run.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Superset Run button: the dotflowy dev loop.
+# The SPA (vite, :3000) proxies /api -> the Worker (wrangler dev, :8787), so
+# BOTH servers must run. This starts the Worker in the background and Vite in
+# the foreground; closing the pane (or Vite exiting) tears the Worker down too.
+set -euo pipefail
+
+bun run dev:api &
+API_PID=$!
+trap 'kill "$API_PID" 2>/dev/null || true' EXIT INT TERM
+
+bun run dev

--- a/.superset/setup.sh
+++ b/.superset/setup.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Superset workspace setup. Runs on every new workspace creation — keep it fast.
+set -euo pipefail
+
+# 1. Install dependencies (bun is the package manager for this repo).
+bun install
+
+# 2. Local Worker secrets for `wrangler dev`. Prefer the root repo's real
+#    .dev.vars (so the workspace inherits BETTER_AUTH_SECRET etc.); fall back to
+#    the checked-in example if the root has none.
+if [ ! -f .dev.vars ]; then
+  if [ -n "${SUPERSET_ROOT_PATH:-}" ] && [ -f "$SUPERSET_ROOT_PATH/.dev.vars" ]; then
+    cp "$SUPERSET_ROOT_PATH/.dev.vars" .dev.vars
+    echo "Copied .dev.vars from the root repo."
+  else
+    cp .dev.vars.example .dev.vars
+    echo "Copied .dev.vars.example -> .dev.vars (set BETTER_AUTH_SECRET before using auth)."
+  fi
+fi
+
+# 3. Apply local D1 migrations (Better Auth identity tables + legacy import
+#    source). Idempotent — already-applied migrations are skipped.
+bun run db:migrate:local


### PR DESCRIPTION
Sets up [Superset workspace setup & teardown scripts](https://docs.superset.sh/setup-teardown-scripts) so new workspaces bootstrap the dotflowy dev environment automatically.

## What's here

- **`.superset/setup.sh`** (runs on every workspace creation):
  1. `bun install`
  2. Copies `.dev.vars` — prefers the root repo's real one (inherits `BETTER_AUTH_SECRET`, `INVITE_CODES`, ...), falls back to `.dev.vars.example`
  3. `bun run db:migrate:local` (Better Auth tables + legacy import source; idempotent)
- **`.superset/run.sh`** (Run button): starts both dev servers the app needs — `wrangler dev` (Worker + DO + local D1, :8787) in the background and `vite dev` (SPA, :3000, proxies `/api`) in the foreground; a trap kills the Worker when the pane closes.
- **`.superset/config.json`**: wires `setup` + `run`.

## Decisions

- **No teardown** — no Docker or external services; wrangler's local state lives in the worktree's `.wrangler/` and is removed with it.
- **Dev servers in `run`, not `setup`** — they're long-running/restartable and shouldn't block workspace creation. One script launches both since the SPA proxies `/api` to the Worker.
- **Env inheritance over a manual step** — the root repo already has a filled-in `.dev.vars`, so copying it beats regenerating a secret per workspace.

Caveat: local D1 state is per-workspace, so each new workspace starts with an empty outline/auth DB (fresh signup). Expected for isolated worktrees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a smoother workspace setup flow that installs dependencies, prepares local environment variables, and applies local database migrations automatically.
  * Added a one-step local dev loop that starts the API and app together, with automatic cleanup when you stop the session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->