### PR TITLE
Fix empty-task caret rendering before the checkbox

### DIFF
--- a/e2e/empty-task-caret.spec.ts
+++ b/e2e/empty-task-caret.spec.ts
@@ -1,0 +1,47 @@
+// Regression: an empty task's caret must sit AFTER the checkbox, not before it.
+// The checkbox floats left inside the block `.row-body`; an empty editable's
+// caret is drawn at its own content origin (x=0), which lands before the float.
+// The `.node-text:empty { display: flow-root }` rule places the empty span's box
+// beside the float so the caret renders after the checkbox (see styles.css).
+import { expect, test, type Page } from "@playwright/test";
+import { seedOutline, type SeedNode } from "./fixtures";
+
+const text = (page: Page, id: string) =>
+  page.locator(`li[data-node-id="${id}"] > .outline-row .node-text`);
+
+const TREE: SeedNode[] = [
+  { id: "t1", parentId: null, prevSiblingId: null, text: "", isTask: true },
+];
+
+test("empty task caret sits to the right of the checkbox", async ({ page }) => {
+  await seedOutline(page, TREE);
+  await page.goto("/");
+  await expect(text(page, "t1")).toBeVisible();
+
+  // Focus the empty task and place the caret in it.
+  await text(page, "t1").click();
+  await text(page, "t1").evaluate((el) => {
+    (el as HTMLElement).focus();
+    const sel = window.getSelection();
+    const range = document.createRange();
+    range.selectNodeContents(el);
+    range.collapse(false);
+    sel!.removeAllRanges();
+    sel!.addRange(range);
+  });
+
+  // The caret for an empty editable is drawn at the element's content-box
+  // origin, so the .node-text left edge is where the caret renders. It must be
+  // to the RIGHT of the checkbox, not before it.
+  const { textLeft, checkboxRight } = await page.evaluate(() => {
+    const row = document.querySelector('li[data-node-id="t1"] .outline-row')!;
+    const checkbox = row.querySelector(".checkbox")!;
+    const nodeText = row.querySelector(".node-text")!;
+    return {
+      textLeft: nodeText.getBoundingClientRect().left,
+      checkboxRight: checkbox.getBoundingClientRect().right,
+    };
+  });
+
+  expect(textLeft).toBeGreaterThanOrEqual(checkboxRight);
+});

--- a/src/styles.css
+++ b/src/styles.css
@@ -736,6 +736,25 @@ h2.zoomed-title {
   @apply line-through;
 }
 
+/*
+ * Empty-bullet caret placement. `.node-text` is a block, and any before-text
+ * decoration (the todo checkbox, daily/provenance badges) floats left ahead of
+ * it inside `.row-body`. For a NON-empty node the first line is shortened by the
+ * float, so text sits after the decoration; but an EMPTY editable's caret is
+ * drawn at the element's own content origin (x=0), which lands BEFORE the float
+ * -- a pseudo-element can't move it, since the caret only tracks editable
+ * content. Giving the empty span its own block formatting context (`flow-root`)
+ * places its border box BESIDE the float (a BFC can't overlap a float's margin
+ * box), so its content origin -- and the caret -- sits after the checkbox while
+ * the span still fills the remaining row width (click target intact). Reverts to
+ * a plain block the instant a character is typed, leaving the multiline
+ * wrap-under-icons behavior on real text untouched. The ::before keeps the empty
+ * line's box height so the caret renders at full height.
+ */
+.node-text:empty {
+  display: flow-root;
+}
+
 .node-text:empty::before {
   content: "";
   display: inline-block;


### PR DESCRIPTION
## The bug

An empty TODO node drew the caret **before** the checkbox, then snapped right the instant you typed.

```
- |[ ]     <- caret here (wrong)
- [ ]|     <- jumps here on first keystroke
```

## Why

`.node-text` is a block; the checkbox `float: left`s ahead of it in `.row-body`. For non-empty text the float shortens the first line so text sits after the checkbox — but an **empty** editable's caret is drawn at the element's own content origin (x=0), which lands *before* the float. The existing `:empty::before` couldn't help: a pseudo-element isn't editable content, so the caret ignores it.

## Fix

One rule in `styles.css`:

```css
.node-text:empty { display: flow-root; }
```

`flow-root` gives the empty span its own block formatting context, whose border box **can't overlap a float** — so it's placed beside the checkbox and the caret renders after it. Reverts to plain `block` on first keystroke, so multiline wrap-under-icons is untouched. Chose `flow-root` over `inline-block` to keep the empty span full-width (click target intact). Also covers empty daily-note / provenance nodes (same floated slot).

## Verify

- New regression spec `e2e/empty-task-caret.spec.ts` (asserts caret is right of the checkbox) ✅
- `lint` + `typecheck` clean ✅
- `todos` + `daily-notes` specs: 20 passed. The one failure (`todos.spec:73`, zoomed-title checkbox) is **pre-existing on main** — confirmed by stash-and-rerun; non-empty text, so `:empty` can't touch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved caret placement for empty tasks so the text cursor appears after the checkbox, matching expected editing behavior.
  * Adjusted empty task layout to better preserve line height and positioning in the editor.

* **Tests**
  * Added an end-to-end regression test to verify caret placement for empty tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->