### PR TITLE
Fix unclickable checkbox on zoomed-in task title

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -1154,6 +1154,20 @@ body.dragging-active * {
   opacity: 0.4;
 }
 
+/* The zoomed pivot's `.node-text` carries an inline `view-transition-name`
+   (the morph target) while it's the zoom root, which makes it its own stacking
+   context -- lifting the full-width title box above the floated before-text
+   decorations, so a click over the checkbox lands on the contentEditable title
+   instead. Float only shortens the text's LINE boxes, not the block box behind
+   them (see `.row-body > :not(.node-text)`). Positioning the decorations at
+   z-index 1 paints them back above the stacking-context title so the checkbox
+   is clickable again. Title-only: the list row's `.node-text` has no
+   view-transition-name, so its float already wins the hit-test. */
+.zoomed-title .row-body > :not(.node-text) {
+  position: relative;
+  z-index: 1;
+}
+
 /* During a zoom, the pivot's text box wraps its text tightly so the title
    and the list item morph cleanly into each other (no slide from a stretched
    flex box). Scoped to the active zoom transition so the live layout reverts


### PR DESCRIPTION
## What

You couldn't check the checkbox on a zoomed-in task. Now you can.

## Why it broke

The zoomed title's text span carries an inline `view-transition-name` (it's the zoom morph pivot), which makes it **its own stacking context** — painting the full-width title box on top of the floated checkbox. Clicks landed on the contentEditable title instead.

Float only shortens the *text's line boxes*, not the block box behind them, so the title box always covered the checkbox's spot.

Row-only difference: list rows have no `view-transition-name`, so their float already wins the hit-test. Only the zoomed title was affected — and only the *click* (row checkbox + `Cmd+Enter` in the title still worked).

## Fix

One title-scoped rule in `styles.css`:

```css
.zoomed-title .row-body > :not(.node-text) {
  position: relative;
  z-index: 1;
}
```

Lifts the before-text decorations back above the pivot's stacking context. Morph animation and the list-row path untouched.

## Test

Clears the consistent `todos.spec:73` failure (flagged since 2026-07-04). All 5 todos e2e tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved zoomed title interactions so title content remains clickable during zoom.
  * Kept title decorations and checkboxes correctly layered and clickable while preventing them from blocking text editing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->