### PR TITLE
Add Geist Mono for monospace text

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@base-ui/react": "^1.6.0",
         "@floating-ui/react-dom": "^2.1.8",
         "@fontsource-variable/geist": "^5.2.9",
+        "@fontsource-variable/geist-mono": "^5.2.8",
         "@icons-pack/react-simple-icons": "^13.13.0",
         "@tanstack/query-core": "^5.101.1",
         "@tanstack/query-db-collection": "^1.0.42",
@@ -226,6 +227,8 @@
     "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
 
     "@fontsource-variable/geist": ["@fontsource-variable/geist@5.2.9", "", {}, "sha512-TP+QSBG3wxKGPE33CbMy/L0Nu3qvJ6Fy81Yc4LnQ95xH+i+cfEp8fyU8/kfV14YwszxIFPhnoMTbjL71waVpyQ=="],
+
+    "@fontsource-variable/geist-mono": ["@fontsource-variable/geist-mono@5.2.8", "", {}, "sha512-KI5bj+hkkRiHttYHmccotUZ80ZuZyai+RwI1d7UId0clkx/jXxlo8qYK8j54WzmpBjtMoEMPyllV7faDcj+6RA=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@base-ui/react": "^1.6.0",
     "@floating-ui/react-dom": "^2.1.8",
     "@fontsource-variable/geist": "^5.2.9",
+    "@fontsource-variable/geist-mono": "^5.2.8",
     "@icons-pack/react-simple-icons": "^13.13.0",
     "@tanstack/query-core": "^5.101.1",
     "@tanstack/query-db-collection": "^1.0.42",

--- a/src/styles.css
+++ b/src/styles.css
@@ -2,6 +2,7 @@
 @import "shadcn/tailwind.css";
 @import "tw-animate-css";
 @import "@fontsource-variable/geist";
+@import "@fontsource-variable/geist-mono";
 
 @custom-variant dark (&:is(.dark *));
 
@@ -46,6 +47,7 @@
   --radius-4xl: calc(var(--radius) * 2.6);
   --font-heading: var(--font-sans);
   --font-sans: "Geist Variable", sans-serif;
+  --font-mono: "Geist Mono Variable", ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 
 :root {


### PR DESCRIPTION
Applies **Geist Mono** to all monospace text, self-hosted via Fontsource.

### What
- `bun add @fontsource-variable/geist-mono`
- `@import` it in `styles.css` + wire `--font-mono`

### Why self-host over Google Fonts CDN
- Same origin — no extra DNS/TLS, no CSP `font-src` exception
- One variable woff2, no render-blocking `@import`
- Mirrors the existing sans setup (`@fontsource-variable/geist`)

### Impact
Every `font-mono` class picks it up automatically — inline-code chip + MCP dialog snippets. System-mono fallback stack avoids a serif FOUT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)