### PR TITLE
Add GitHub link to header More menu

### DIFF
--- a/src/components/header-more-menu.tsx
+++ b/src/components/header-more-menu.tsx
@@ -3,6 +3,7 @@ import {
   ALargeSmallIcon,
   CircleCheckIcon,
   ClipboardCopyIcon,
+  CodeXmlIcon,
   LogOutIcon,
   MonitorIcon,
   MoonIcon,
@@ -100,6 +101,19 @@ export function HeaderMoreMenu() {
           <DropdownMenuItem onClick={() => setConnectOpen(true)}>
             <PlugZapIcon />
             Connect apps (MCP)
+          </DropdownMenuItem>
+
+          <DropdownMenuItem
+            onClick={() =>
+              window.open(
+                "https://git.new/dotflowy",
+                "_blank",
+                "noopener,noreferrer",
+              )
+            }
+          >
+            <CodeXmlIcon />
+            GitHub
           </DropdownMenuItem>
 
           <DropdownMenuSeparator />


### PR DESCRIPTION
Adds a **GitHub** item to the header More menu linking to <https://git.new/dotflowy>.

- Opens in a new tab (`noopener,noreferrer`)
- Sits under "Connect apps (MCP)"
- Uses `CodeXmlIcon` (lucide has no GitHub brand icon)

One file: `src/components/header-more-menu.tsx`. Typecheck passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)