### PR TITLE
Use GitHub brand glyph for header More menu link

### DIFF
--- a/src/components/header-more-menu.tsx
+++ b/src/components/header-more-menu.tsx
@@ -3,7 +3,6 @@ import {
   ALargeSmallIcon,
   CircleCheckIcon,
   ClipboardCopyIcon,
-  CodeXmlIcon,
   LogOutIcon,
   MonitorIcon,
   MoonIcon,
@@ -36,6 +35,24 @@ import { outlineToMarkdown } from "../data/markdown";
 import { getTreeIndex } from "../data/tree-store";
 import { getViewRootId } from "../data/view-state";
 import { childrenOf } from "../data/tree";
+
+/**
+ * GitHub's brand glyph (Simple Icons). lucide-react dropped its Github icon, so
+ * we inline the mark here -- fill-based (not lucide's stroke), currentColor, and
+ * left unsized so the menu item's `[&_svg]:size-4` rule matches it to the rest.
+ */
+function GitHubIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+    </svg>
+  );
+}
 
 /**
  * Copy the current view's subtree to the clipboard as a markdown bullet list.
@@ -112,7 +129,7 @@ export function HeaderMoreMenu() {
               )
             }
           >
-            <CodeXmlIcon />
+            <GitHubIcon />
             GitHub
           </DropdownMenuItem>
 


### PR DESCRIPTION
The header **More** menu's GitHub link used lucide's generic `CodeXmlIcon` because lucide-react dropped its `Github` icon. This swaps in [Simple Icons](https://simpleicons.org/?q=github)' GitHub brand glyph so the link reads as GitHub.

- Inline `GitHubIcon` SVG (fill-based, `currentColor`)
- Left unsized so the dropdown item's `[&_svg:not([class*='size-'])]:size-4` rule matches it to the sibling lucide icons
- Typecheck + oxlint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)