### PR TITLE
Collapse all / Expand all (header More menu)

### DIFF
--- a/e2e/collapse-expand-all.spec.ts
+++ b/e2e/collapse-expand-all.spec.ts
@@ -1,0 +1,105 @@
+import { expect, test, type Page } from "@playwright/test";
+import { seedOutline, type SeedNode } from "./fixtures";
+
+// A deeper-than-STANDARD tree so "Collapse all" / "Expand all" have several
+// collapsible parents at more than one depth to fold:
+//
+//   Alpha (alpha)
+//     Alpha one (alpha-1)
+//       Alpha one deep (alpha-1-a)
+//     Alpha two (alpha-2)
+//   Bravo (bravo)
+//     Bravo one (bravo-1)
+//   Charlie (charlie)            <- leaf, never collapsible
+const TREE: SeedNode[] = [
+  { id: "alpha", parentId: null, prevSiblingId: null, text: "Alpha" },
+  { id: "bravo", parentId: null, prevSiblingId: "alpha", text: "Bravo" },
+  { id: "charlie", parentId: null, prevSiblingId: "bravo", text: "Charlie" },
+  { id: "alpha-1", parentId: "alpha", prevSiblingId: null, text: "Alpha one" },
+  {
+    id: "alpha-1-a",
+    parentId: "alpha-1",
+    prevSiblingId: null,
+    text: "Alpha one deep",
+  },
+  { id: "alpha-2", parentId: "alpha", prevSiblingId: "alpha-1", text: "Alpha two" },
+  { id: "bravo-1", parentId: "bravo", prevSiblingId: null, text: "Bravo one" },
+];
+
+// A node's OWN editable text span and its collapse chevron.
+const text = (page: Page, id: string) =>
+  page.locator(`li[data-node-id="${id}"] > .outline-row .node-text`);
+const chevron = (page: Page, id: string) =>
+  page.locator(`li[data-node-id="${id}"] > .outline-row > .collapse-toggle`);
+
+// Open the header "More" menu and click one of its items.
+async function runMenuAction(page: Page, name: RegExp) {
+  await page.getByRole("button", { name: /more/i }).click();
+  await page.getByRole("menuitem", { name }).click();
+}
+
+// When zoomed, the root renders as an `h2.zoomed-title`, not an `li` row.
+async function load(page: Page, path = "/", ready = text(page, "alpha")) {
+  await seedOutline(page, TREE);
+  await page.goto(path);
+  await expect(ready).toBeVisible();
+}
+
+test.describe("Collapse all / Expand all (header More menu)", () => {
+  test("Collapse all folds every nested bullet; Expand all restores them", async ({
+    page,
+  }) => {
+    await load(page);
+    // Everything starts expanded.
+    await expect(text(page, "alpha-1")).toBeVisible();
+    await expect(text(page, "alpha-1-a")).toBeVisible();
+    await expect(text(page, "bravo-1")).toBeVisible();
+
+    await runMenuAction(page, /Collapse all/);
+
+    // Top-level bullets stay; all descendants are gone (instant, windowed list).
+    await expect(text(page, "alpha")).toBeVisible();
+    await expect(text(page, "bravo")).toBeVisible();
+    await expect(text(page, "charlie")).toBeVisible();
+    await expect(text(page, "alpha-1")).toBeHidden();
+    await expect(text(page, "alpha-2")).toBeHidden();
+    await expect(text(page, "alpha-1-a")).toBeHidden();
+    await expect(text(page, "bravo-1")).toBeHidden();
+    // The parents themselves now read as collapsed.
+    await expect(chevron(page, "alpha")).toHaveAttribute("data-collapsed", "true");
+
+    await runMenuAction(page, /Expand all/);
+
+    // Every level is back, including the deepest.
+    await expect(text(page, "alpha-1")).toBeVisible();
+    await expect(text(page, "alpha-2")).toBeVisible();
+    await expect(text(page, "alpha-1-a")).toBeVisible();
+    await expect(text(page, "bravo-1")).toBeVisible();
+    await expect(chevron(page, "alpha")).toHaveAttribute(
+      "data-collapsed",
+      "false",
+    );
+  });
+
+  test("Collapse all is scoped to the zoom root and never collapses the root", async ({
+    page,
+  }) => {
+    // Zoom into Alpha: it renders as the page title, its children as rows.
+    await load(page, "/alpha", page.locator("h2.zoomed-title .node-text"));
+    await expect(text(page, "alpha-1")).toBeVisible();
+    await expect(text(page, "alpha-1-a")).toBeVisible();
+
+    await runMenuAction(page, /Collapse all/);
+
+    // The root's DIRECT children stay visible (root not collapsed -- that would
+    // hide the whole view); only their subtrees fold, so the deep node is gone.
+    await expect(text(page, "alpha-1")).toBeVisible();
+    await expect(text(page, "alpha-2")).toBeVisible();
+    await expect(text(page, "alpha-1-a")).toBeHidden();
+    // The now-childless-looking row is genuinely collapsed, not just off-screen.
+    await expect(chevron(page, "alpha-1")).toHaveAttribute(
+      "data-collapsed",
+      "true",
+    );
+  });
+});

--- a/src/components/header-more-menu.tsx
+++ b/src/components/header-more-menu.tsx
@@ -1,6 +1,8 @@
 import { useState } from "react";
 import {
   ALargeSmallIcon,
+  ChevronsDownUpIcon,
+  ChevronsUpDownIcon,
   CircleCheckIcon,
   ClipboardCopyIcon,
   CodeXmlIcon,
@@ -36,6 +38,9 @@ import { outlineToMarkdown } from "../data/markdown";
 import { getTreeIndex } from "../data/tree-store";
 import { getViewRootId } from "../data/view-state";
 import { childrenOf } from "../data/tree";
+import { toggleCollapsed } from "../data/mutations";
+import { runStructural } from "../data/structural";
+import { capture } from "../data/history";
 
 /**
  * Copy the current view's subtree to the clipboard as a markdown bullet list.
@@ -57,6 +62,59 @@ async function copyOutlineAsMarkdown() {
   } catch {
     toast.error("Couldn't copy to clipboard");
   }
+}
+
+/**
+ * Collect the collapsible nodes under the current view whose `collapsed` flag
+ * needs to change to `collapsed`. Scope is the zoom root's subtree (read live at
+ * click time), or the whole outline at home -- same contextual rule as
+ * `copyOutlineAsMarkdown`. We seed the walk from the root's CHILDREN so the zoom
+ * root itself is never collapsed (that would hide the whole view). Only nodes
+ * that actually have children are collapsible; leaves are skipped. Already-in-
+ * target-state nodes are filtered out so a bulk toggle ships no redundant PATCHes.
+ * The walk descends through already-collapsed branches (the index is unaffected
+ * by the flag), so "Expand all" reaches every nested node.
+ */
+function collapsibleTargets(collapsed: boolean): {
+  ids: string[];
+  rootId: string | null;
+} {
+  const index = getTreeIndex();
+  const rootId = getViewRootId();
+  const targets: string[] = [];
+  const seen = new Set<string>();
+  const stack = childrenOf(index, rootId).map((n) => n.id);
+  while (stack.length) {
+    const id = stack.pop()!;
+    if (seen.has(id)) continue;
+    seen.add(id);
+    const kids = childrenOf(index, id);
+    if (kids.length === 0) continue;
+    if ((index.byId.get(id)?.collapsed ?? false) !== collapsed) targets.push(id);
+    for (const k of kids) stack.push(k.id);
+  }
+  return { ids: targets, rootId };
+}
+
+/**
+ * Collapse or expand every collapsible node under the current view in ONE
+ * atomic batch. Wrapped in `runStructural` so N `collapsed` field edits ship as
+ * a single DO frame (one round-trip, one broadcast) instead of N PATCHes, and a
+ * single `capture` before the batch makes it one undo step -- mirroring how the
+ * per-row `onToggleCollapsed` command captures once. `runStructural` is generic
+ * over any `nodesCollection` write; these are field edits, not chain relinks, so
+ * the sibling chain is untouched.
+ */
+function setViewCollapsed(collapsed: boolean) {
+  const { ids, rootId } = collapsibleTargets(collapsed);
+  if (ids.length === 0) {
+    toast(collapsed ? "Already collapsed" : "Already expanded");
+    return;
+  }
+  capture(getTreeIndex(), rootId);
+  runStructural(() => {
+    for (const id of ids) toggleCollapsed(id, collapsed);
+  });
 }
 
 /**
@@ -114,6 +172,18 @@ export function HeaderMoreMenu() {
           >
             <CodeXmlIcon />
             GitHub
+          </DropdownMenuItem>
+
+          <DropdownMenuSeparator />
+
+          <DropdownMenuItem onClick={() => setViewCollapsed(true)}>
+            <ChevronsDownUpIcon />
+            Collapse all
+          </DropdownMenuItem>
+
+          <DropdownMenuItem onClick={() => setViewCollapsed(false)}>
+            <ChevronsUpDownIcon />
+            Expand all
           </DropdownMenuItem>
 
           <DropdownMenuSeparator />


### PR DESCRIPTION
Fold or unfold the entire current view from the header **More** menu.

### What
- **Collapse all** / **Expand all** items, scoped to the current view — the zoom root's subtree, or the whole outline at home (same rule as *Copy as Markdown*).
- Never collapses the zoom root itself (that would hide everything you're looking at).
- Only touches nodes that have children; already-in-target-state nodes are skipped.

### How
- One `runStructural` batch → **one DO frame / one round-trip** instead of N PATCHes.
- One `capture` before the batch → **one clean undo step**.
- `collapsed` is a field edit, so the sibling chain is untouched (dev chain-invariant tripwire stays quiet).

### Tests
`e2e/collapse-expand-all.spec.ts` (2 tests, green):
1. Round trip at home — collapse folds every depth, expand restores it.
2. Zoom scoping — root stays expanded, subtrees fold.

`typecheck` + `lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)