### PR TITLE
Keyboard nav keeps the highlighted menu item in view

### DIFF
--- a/.changeset/slash-menu-scroll.md
+++ b/.changeset/slash-menu-scroll.md
@@ -2,4 +2,4 @@
 "dotflowy": patch
 ---
 
-The `/` command menu now scrolls the highlighted command into view, so arrowing past the sixth command no longer walks the selection off-screen. Thanks to Dylan Shade (@dpshde) for the fix.
+The `/` command palette and the `#` / `[[` caret pickers now scroll the highlighted item into view, so arrowing past the visible window no longer walks the selection off-screen. Hovering still picks the item under your cursor, but a scrolling list can no longer steal the highlight out from under the arrow keys. Thanks to Dylan Shade (@dpshde) for the fix.

--- a/.changeset/slash-menu-scroll.md
+++ b/.changeset/slash-menu-scroll.md
@@ -1,0 +1,5 @@
+---
+"dotflowy": patch
+---
+
+The `/` command menu now scrolls the highlighted command into view, so arrowing past the sixth command no longer walks the selection off-screen. Thanks to Dylan Shade (@dpshde) for the fix.

--- a/e2e/slash-menu-scroll.spec.ts
+++ b/e2e/slash-menu-scroll.spec.ts
@@ -1,0 +1,134 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { seedOutline, STANDARD_TREE } from "./fixtures";
+
+const text = (page: Page, id: string) =>
+  page.locator(`li[data-node-id="${id}"] > .outline-row .node-text`);
+
+/**
+ * One round-trip read of the open menu. Geometry lives here (not in locators)
+ * because the invariants are COUNTABLE -- an integer scroll offset and a rect
+ * containment -- which read identically on any hardware, unlike a wall clock.
+ * See AGENTS.md "Perf guards: assert the countable invariant".
+ */
+async function menuState(page: Page) {
+  return page.evaluate(() => {
+    const box = document.querySelector('[role="listbox"]');
+    if (!box) return null;
+    const sc = box.querySelector<HTMLElement>(".overflow-y-auto")!;
+    const opts = [...box.querySelectorAll('[role="option"]')];
+    const idx = opts.findIndex(
+      (o) => o.getAttribute("aria-selected") === "true",
+    );
+    const act = opts[idx]!;
+    const a = act.getBoundingClientRect();
+    const c = sc.getBoundingClientRect();
+    return {
+      count: opts.length,
+      activeIndex: idx,
+      activeLabel: (act as HTMLElement).innerText.split("\n")[0],
+      scrollTop: sc.scrollTop,
+      overflows: sc.scrollHeight > sc.clientHeight,
+      activeFullyVisible: a.top >= c.top - 0.5 && a.bottom <= c.bottom + 0.5,
+    };
+  });
+}
+
+/** Open the `/` palette on a bullet: the "/" must follow whitespace to trigger. */
+async function openSlashMenu(page: Page, id: string) {
+  await text(page, id).click();
+  await expect(text(page, id)).toBeFocused();
+  await page.keyboard.type(" /");
+  await expect(page.getByRole("listbox")).toBeVisible();
+}
+
+test.describe("slash menu keyboard scrolling", () => {
+  test.beforeEach(async ({ page }) => {
+    await seedOutline(page, STANDARD_TREE);
+    await page.goto("/");
+    await expect(text(page, "alpha")).toBeVisible();
+  });
+
+  test("scrolls the active option into view as the highlight walks past the window", async ({
+    page,
+  }) => {
+    await openSlashMenu(page, "bravo");
+
+    const initial = await menuState(page);
+    // Precondition: the palette must actually overflow, or this proves nothing.
+    expect(initial?.overflows).toBe(true);
+    expect(initial?.scrollTop).toBe(0);
+    expect(initial?.activeIndex).toBe(0);
+
+    // Walk far enough down that the highlight leaves the visible window.
+    await page.keyboard.press("ArrowDown");
+    await page.keyboard.press("ArrowDown");
+    await page.keyboard.press("ArrowDown");
+    await page.keyboard.press("ArrowDown");
+    await page.keyboard.press("ArrowDown");
+    await page.keyboard.press("ArrowDown");
+    await page.keyboard.press("ArrowDown");
+    await page.keyboard.press("ArrowDown");
+
+    const after = await menuState(page);
+    expect(after?.activeIndex).toBe(8);
+    expect(after?.scrollTop).toBeGreaterThan(0);
+    expect(after?.activeFullyVisible).toBe(true);
+  });
+
+  test("wrapping to the last option scrolls to the bottom, and back to the first returns to the top", async ({
+    page,
+  }) => {
+    await openSlashMenu(page, "bravo");
+    const { count } = (await menuState(page))!;
+
+    // ArrowUp from the first option wraps to the last (see `wrap` in slash-menu).
+    await page.keyboard.press("ArrowUp");
+    const atEnd = await menuState(page);
+    expect(atEnd?.activeIndex).toBe(count - 1);
+    expect(atEnd?.scrollTop).toBeGreaterThan(0);
+    expect(atEnd?.activeFullyVisible).toBe(true);
+
+    // ...and wrapping forward again lands back at the top, fully scrolled back.
+    await page.keyboard.press("ArrowDown");
+    const atStart = await menuState(page);
+    expect(atStart?.activeIndex).toBe(0);
+    expect(atStart?.scrollTop).toBe(0);
+    expect(atStart?.activeFullyVisible).toBe(true);
+  });
+
+  // The regression the scroll fix introduced: arrowing scrolls a NEW option
+  // under a stationary cursor, and the browser fires hover events for it. With
+  // `onMouseEnter` the highlight snapped back to the mouse, fighting the key.
+  test("a stationary cursor never steals the highlight while arrowing", async ({
+    page,
+  }) => {
+    await openSlashMenu(page, "bravo");
+
+    // Park the real cursor on an option -- a genuine move, so hover DOES apply.
+    const third = page.getByRole("option").nth(3);
+    const box = (await third.boundingBox())!;
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+    expect((await menuState(page))?.activeIndex).toBe(3);
+
+    // Now arrow away WITHOUT moving the mouse. The list scrolls beneath it.
+    for (let i = 0; i < 8; i++) await page.keyboard.press("ArrowDown");
+
+    const after = await menuState(page);
+    expect(after?.activeIndex).toBe(11); // the keyboard won, not the cursor
+    expect(after?.scrollTop).toBeGreaterThan(0); // and the list really did scroll
+    expect(after?.activeFullyVisible).toBe(true);
+  });
+
+  test("a real pointer move still selects the option under the cursor", async ({
+    page,
+  }) => {
+    await openSlashMenu(page, "bravo");
+
+    const second = page.getByRole("option").nth(2);
+    const box = (await second.boundingBox())!;
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+
+    expect((await menuState(page))?.activeIndex).toBe(2);
+  });
+});

--- a/src/components/menu-list.tsx
+++ b/src/components/menu-list.tsx
@@ -4,6 +4,8 @@ import { cn } from "@/lib/utils";
 
 import type { MenuEntry } from "../plugins/types";
 
+import { useMenuActiveItem } from "./use-menu-active-item";
+
 export function MenuList({
   entries,
   activeIndex,
@@ -23,6 +25,12 @@ export function MenuList({
   style?: CSSProperties;
   ref?: Ref<HTMLDivElement>;
 }) {
+  const { itemRef, onItemPointerMove } = useMenuActiveItem({
+    activeIndex,
+    itemCount: entries.length,
+    onHover,
+  });
+
   return (
     <div
       ref={ref}
@@ -42,11 +50,13 @@ export function MenuList({
           entries.map((entry, i) => (
             <button
               key={entry.key}
+              ref={itemRef(i)}
               type="button"
               role="option"
               aria-selected={i === activeIndex}
               className={cn(
-                "flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm",
+                // scroll-my-10 clears the scroll-fade mask -- see SlashMenuList.
+                "flex w-full scroll-my-10 items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm",
                 i === activeIndex && "bg-accent text-accent-foreground",
               )}
               // mousedown (not click) so the contentEditable keeps focus.
@@ -54,7 +64,7 @@ export function MenuList({
                 e.preventDefault();
                 onSelect(i);
               }}
-              onMouseEnter={() => onHover(i)}
+              onPointerMove={onItemPointerMove(i)}
             >
               {entry.render(i === activeIndex)}
             </button>

--- a/src/components/slash-menu-list.tsx
+++ b/src/components/slash-menu-list.tsx
@@ -1,4 +1,10 @@
-import type { ComponentType, CSSProperties, Ref } from "react";
+import {
+  useEffect,
+  useRef,
+  type ComponentType,
+  type CSSProperties,
+  type Ref,
+} from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -38,6 +44,15 @@ export function SlashMenuList({
   /** Attach the floating element (e.g. floating-ui's `refs.setFloating`). */
   ref?: Ref<HTMLDivElement>;
 }) {
+  const activeItemRef = useRef<HTMLButtonElement | null>(null);
+
+  // Keyboard nav walks past the visible window (the list scrolls at max-h-72),
+  // so follow the highlight. `items.length` is a dep because a refiltered list
+  // can leave the container scrolled while `activeIndex` stays 0.
+  useEffect(() => {
+    activeItemRef.current?.scrollIntoView({ block: "nearest" });
+  }, [activeIndex, items.length]);
+
   return (
     <div
       ref={ref}
@@ -59,6 +74,7 @@ export function SlashMenuList({
             return (
               <button
                 key={item.id}
+                ref={i === activeIndex ? activeItemRef : null}
                 type="button"
                 role="option"
                 aria-selected={i === activeIndex}

--- a/src/components/slash-menu-list.tsx
+++ b/src/components/slash-menu-list.tsx
@@ -79,7 +79,10 @@ export function SlashMenuList({
                 role="option"
                 aria-selected={i === activeIndex}
                 className={cn(
-                  "flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm",
+                  // scroll-my-10 clears the scroll-fade mask (min(12%, 40px)):
+                  // `block: "nearest"` would otherwise park the active item
+                  // flush against the edge, where the fade dims the highlight.
+                  "flex w-full scroll-my-10 items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm",
                   i === activeIndex && "bg-accent text-accent-foreground",
                 )}
                 // mousedown (not click) so the contentEditable keeps focus.

--- a/src/components/slash-menu-list.tsx
+++ b/src/components/slash-menu-list.tsx
@@ -1,12 +1,8 @@
-import {
-  useEffect,
-  useRef,
-  type ComponentType,
-  type CSSProperties,
-  type Ref,
-} from "react";
+import type { ComponentType, CSSProperties, Ref } from "react";
 
 import { cn } from "@/lib/utils";
+
+import { useMenuActiveItem } from "./use-menu-active-item";
 
 /** The minimal item shape this list renders: an id, the two text lines, and a
  *  leading icon. `CommandSpec` satisfies it, and so do the synthetic core items
@@ -44,14 +40,11 @@ export function SlashMenuList({
   /** Attach the floating element (e.g. floating-ui's `refs.setFloating`). */
   ref?: Ref<HTMLDivElement>;
 }) {
-  const activeItemRef = useRef<HTMLButtonElement | null>(null);
-
-  // Keyboard nav walks past the visible window (the list scrolls at max-h-72),
-  // so follow the highlight. `items.length` is a dep because a refiltered list
-  // can leave the container scrolled while `activeIndex` stays 0.
-  useEffect(() => {
-    activeItemRef.current?.scrollIntoView({ block: "nearest" });
-  }, [activeIndex, items.length]);
+  const { itemRef, onItemPointerMove } = useMenuActiveItem({
+    activeIndex,
+    itemCount: items.length,
+    onHover,
+  });
 
   return (
     <div
@@ -74,7 +67,7 @@ export function SlashMenuList({
             return (
               <button
                 key={item.id}
-                ref={i === activeIndex ? activeItemRef : null}
+                ref={itemRef(i)}
                 type="button"
                 role="option"
                 aria-selected={i === activeIndex}
@@ -90,7 +83,7 @@ export function SlashMenuList({
                   e.preventDefault();
                   onSelect(i);
                 }}
-                onMouseEnter={() => onHover(i)}
+                onPointerMove={onItemPointerMove(i)}
               >
                 <Icon className="size-4 shrink-0 opacity-70" />
                 <span className="flex flex-col">

--- a/src/components/use-menu-active-item.ts
+++ b/src/components/use-menu-active-item.ts
@@ -1,0 +1,56 @@
+import {
+  useEffect,
+  useRef,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
+
+/**
+ * The shared active-item behavior for the two caret menus -- `SlashMenuList`
+ * (the `/` palette) and `MenuList` (the `#` / `[[` pickers). Both render a
+ * `max-h-72 scroll-fade overflow-y-auto` list driven by an `activeIndex` the
+ * parent owns, so both need the same two things:
+ *
+ * 1. **Follow the highlight.** Keyboard nav walks past the visible window, so
+ *    the active item is scrolled into view. Pair with `scroll-my-10` on the
+ *    item: `block: "nearest"` parks it flush against the container edge, which
+ *    is exactly where the `scroll-fade` mask is strongest, and the highlight
+ *    would render dimmed.
+ * 2. **Don't let the scroll steal the highlight.** Scrolling in (1) slides a
+ *    new item under a stationary cursor, and the browser fires hover events for
+ *    it -- so plain `onMouseEnter` would snap `activeIndex` back to wherever the
+ *    mouse happens to sit, fighting the arrow key. `onItemPointerMove` only
+ *    hovers when the pointer's client coords ACTUALLY changed (a scroll-induced
+ *    move repeats the last coords), which is how cmdk and Radix draw the line.
+ */
+export function useMenuActiveItem({
+  activeIndex,
+  itemCount,
+  onHover,
+}: {
+  activeIndex: number;
+  /** A dep of the scroll effect: a refiltered list can leave the container
+   *  scrolled while `activeIndex` stays put. */
+  itemCount: number;
+  onHover: (index: number) => void;
+}) {
+  const activeItemRef = useRef<HTMLButtonElement | null>(null);
+  const lastPointer = useRef<{ x: number; y: number } | null>(null);
+
+  useEffect(() => {
+    activeItemRef.current?.scrollIntoView({ block: "nearest" });
+  }, [activeIndex, itemCount]);
+
+  return {
+    /** Spread onto each option: attaches the ref to the active one only. */
+    itemRef: (i: number) => (i === activeIndex ? activeItemRef : null),
+    onItemPointerMove: (i: number) => (e: ReactPointerEvent<HTMLElement>) => {
+      const prev = lastPointer.current;
+      const moved = !prev || prev.x !== e.clientX || prev.y !== e.clientY;
+      // Track every move, including ones we ignore below -- else a later
+      // scroll-induced event would compare against stale coords and read as real.
+      lastPointer.current = { x: e.clientX, y: e.clientY };
+      if (!moved || i === activeIndex) return;
+      onHover(i);
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Arrowing through the `/` palette or the `#` / `[[` pickers walked the highlight off-screen once it passed the visible window, because neither menu scrolled to follow it. Both now do, and a list scrolling under a stationary cursor can no longer steal the highlight back.

## Changes

1. The `/` palette scrolls the highlighted command into view as the keyboard walks past the visible window.
2. The `#` and `[[` caret pickers get the same fix — identical structure, identical bug, previously untouched.
3. The highlighted item stops clear of the `scroll-fade` mask (#262) instead of parking flush against the container edge, where the fade dimmed the very item it had just scrolled to.
4. Hovering only follows a real pointer move, so arrowing through a scrolling list no longer snaps the highlight to whatever slid under the cursor.
5. The menu scrollbar stays visible — `scroll-fade` already signals more content, and hiding the scrollbar removed the other affordance.
6. Both menus share one `useMenuActiveItem` hook rather than carrying two copies of the behavior.

**Start here:** change 4 — a scroll-induced hover repeats the pointer's last coords, which is the only thing separating it from a real move.

## Test plan

- `bun run typecheck`, `typecheck:worker`, `typecheck:test`, `lint`, `fmt:check` — clean
- `bun test` — 659 passed
- `bunx playwright test --workers=2` — 344 passed, including `tag-menu.spec.ts` over the shared `MenuList`
- New `e2e/slash-menu-scroll.spec.ts` (4 specs) asserts countable invariants — scroll offset and rect containment, no wall clocks
- Confirmed that spec isn't vacuous: reverting change 4 to `onMouseEnter` fails it with `activeIndex` 8 instead of 11
- Drove both menus in `bun run cf:dev`: with the cursor parked, the keyboard reached index 11 while item 10 sat under it and the list had scrolled 380px; hover still selects on a genuine move

**Needs manual check:** the `#` picker with enough tags to overflow its window — the local outline had only 6, so that menu's scroll path rides on the shared hook rather than a direct observation.
