### PR TITLE
Add /today daily-note route

### DIFF
--- a/e2e/daily-notes.spec.ts
+++ b/e2e/daily-notes.spec.ts
@@ -29,6 +29,13 @@ async function goHome(page: Page) {
   await expect(page).toHaveURL(/\/$/);
 }
 
+async function clientNavigate(page: Page, path: string) {
+  await page.evaluate((to) => {
+    window.history.pushState({}, "", to);
+    window.dispatchEvent(new PopStateEvent("popstate"));
+  }, path);
+}
+
 // Open the Cmd+K node switcher and type a query. cmdk autofocuses its input a
 // beat AFTER the dialog mounts; when Cmd+K fires right after a navigation, the
 // editor's post-nav focus effect can win that race and the dialog input never
@@ -628,8 +635,7 @@ test.describe("daily notes", () => {
   test("/today redirects to today's daily note, creating it on first visit", async ({
     page,
   }) => {
-    await load(page);
-
+    await seedOutline(page, STANDARD_TREE);
     await page.goto("/today");
 
     // The redirect is async (wait for collection ready + get-or-create day),
@@ -647,17 +653,16 @@ test.describe("daily notes", () => {
   test("/today is idempotent: a second visit lands on the same note", async ({
     page,
   }) => {
-    await load(page);
-
+    await seedOutline(page, STANDARD_TREE);
     await page.goto("/today");
     await expect(page).not.toHaveURL(/\/today$/, { timeout: 15000 });
     const firstUrl = page.url();
 
-    await page.goto("/");
-    await page.goto("/today");
+    await goHome(page);
+    await clientNavigate(page, "/today");
     await expect(page).toHaveURL(firstUrl);
 
-    await page.goto("/");
+    await goHome(page);
     await expect(page.locator("[data-daily-date]")).toHaveCount(1);
   });
 });

--- a/e2e/daily-notes.spec.ts
+++ b/e2e/daily-notes.spec.ts
@@ -624,4 +624,40 @@ test.describe("daily notes", () => {
     await page.keyboard.press(`${modifier()}+Shift+Backspace`);
     await expect(page.locator('li[data-node-id="bravo"]')).toHaveCount(0);
   });
+
+  test("/today redirects to today's daily note, creating it on first visit", async ({
+    page,
+  }) => {
+    await load(page);
+
+    await page.goto("/today");
+
+    // The redirect is async (wait for collection ready + get-or-create day),
+    // so wait for it to leave /today before asserting the zoom view.
+    await expect(page).not.toHaveURL(/\/today$/, { timeout: 15000 });
+    await expect(page).not.toHaveURL(/\/$/, { timeout: 10000 });
+    const year = String(new Date().getFullYear());
+    await expect(page.locator("h2.zoomed-title .node-text")).toContainText(year);
+
+    const titleBadge = page.locator("h2.zoomed-title [data-daily-date]");
+    await expect(titleBadge).toBeVisible();
+    await expect(titleBadge).toHaveAttribute("data-daily-today", "");
+  });
+
+  test("/today is idempotent: a second visit lands on the same note", async ({
+    page,
+  }) => {
+    await load(page);
+
+    await page.goto("/today");
+    await expect(page).not.toHaveURL(/\/today$/, { timeout: 15000 });
+    const firstUrl = page.url();
+
+    await page.goto("/");
+    await page.goto("/today");
+    await expect(page).toHaveURL(firstUrl);
+
+    await page.goto("/");
+    await expect(page.locator("[data-daily-date]")).toHaveCount(1);
+  });
 });

--- a/src/components/OutlineEditor.tsx
+++ b/src/components/OutlineEditor.tsx
@@ -212,7 +212,8 @@ export function OutlineEditor({ rootId }: OutlineEditorProps) {
     exposeHotkeyManagerForDev();
   }, []);
 
-  const routeSearch = useSearch({ strict: false }) as { q?: string };
+  const routeSearch = useSearch({ strict: false }) as { q?: string; focus?: string };
+  const focusLast = routeSearch.focus === "last";
 
   // Seam G (ADR 0001): the composed per-node visibility predicate. The core no
   // longer hardcodes `completed` -- it hides whatever the plugin view transforms
@@ -266,6 +267,7 @@ export function OutlineEditor({ rootId }: OutlineEditorProps) {
     navigate,
     pendingFocus,
     pendingFlash,
+    focusLast,
   });
 
   // Delegated tag-chip interaction. Chips live inside contentEditable text, so a
@@ -936,6 +938,10 @@ interface ZoomNavigationArgs {
   // windowed list (the row claims pendingFocus/pendingFlash on its mount).
   pendingFocus: RefObject<string | null>;
   pendingFlash: RefObject<string | null>;
+  /** When true, land focus on the LAST visible child on mount (used by /today
+   *  via ?focus=last so a journal-style note opens ready to append). Only
+   *  applies on a fresh load (no pivotId). */
+  focusLast?: boolean;
 }
 
 /**
@@ -952,6 +958,7 @@ function useZoomNavigation({
   navigate,
   pendingFocus,
   pendingFlash,
+  focusLast,
 }: ZoomNavigationArgs): {
   navigateZoom: (toRootId: string | null, pivot: string) => void;
   pivotId: string | null;
@@ -1038,6 +1045,23 @@ function useZoomNavigation({
   // is written in OutlineNode's own passive effect, so only by now is the list
   // laid out at its real heights.
   useEffect(() => {
+    // Fresh load with ?focus=last (e.g. /today redirecting to a daily note):
+    // land on the last visible child so a journal-style note opens ready to
+    // append, not the title. No pivotId on a fresh page load.
+    if (!pivotId && focusLast && rootId) {
+      const children = childrenOf(getTreeIndex(), rootId).filter((n) => !isHidden(n));
+      const lastChild = children[children.length - 1];
+      if (!lastChild) return;
+      const el = refs.get(lastChild.id);
+      if (!el) {
+        if (scrollRowIntoView(lastChild.id)) pendingFocus.current = lastChild.id;
+        return;
+      }
+      el.focus({ preventScroll: true });
+      placeCaretAtEnd(el);
+      el.scrollIntoView({ block: "nearest" });
+      return;
+    }
     if (!pivotId) return;
     let targetId = pivotId;
     if (pivotId === rootId) {

--- a/src/plugins/daily/index.tsx
+++ b/src/plugins/daily/index.tsx
@@ -136,6 +136,11 @@ async function ensureDay(
     if (!index.byId.get(existing)!.text.trim()) {
       setText(existing, formatDayText(key));
     }
+    // Backfill a first bullet if the note exists but has no children (e.g.
+    // created before this seeding landed). Same atomic batch as the heal.
+    if (childrenOf(index, existing).length === 0) {
+      runStructural(() => appendChild(existing, null, ''));
+    }
     return existing;
   }
   const candidate = createId();
@@ -143,15 +148,18 @@ async function ensureDay(
   const ok = await ensureNodeExists(
     winner,
     () =>
-      runStructural(() =>
+      runStructural(() => {
         insertChildAtStart(
           index,
           containerId,
           false,
           formatDayText(key),
           winner,
-        ),
-      ),
+        );
+        // Seed a first empty bullet so the note is ready to type into,
+        // not a bare title. Same atomic batch as the day node itself.
+        appendChild(winner, null, '');
+      }),
     !won,
   );
   setMapping(key, winner);

--- a/src/plugins/daily/index.tsx
+++ b/src/plugins/daily/index.tsx
@@ -174,6 +174,8 @@ async function getOrCreateDay(
   });
 }
 
+export { getOrCreateDay };
+
 /** get-or-create the day, then zoom to it (the Today button + future picker). */
 async function goToDate(key: string, ctx: PluginContext): Promise<void> {
   const dayId = await getOrCreateDay(key, ctx.tree);

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -9,10 +9,16 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as TodayRouteImport } from './routes/today'
 import { Route as NodeIdRouteImport } from './routes/$nodeId'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as AdminWaitlistRouteImport } from './routes/admin.waitlist'
 
+const TodayRoute = TodayRouteImport.update({
+  id: '/today',
+  path: '/today',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const NodeIdRoute = NodeIdRouteImport.update({
   id: '/$nodeId',
   path: '/$nodeId',
@@ -32,35 +38,46 @@ const AdminWaitlistRoute = AdminWaitlistRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/$nodeId': typeof NodeIdRoute
+  '/today': typeof TodayRoute
   '/admin/waitlist': typeof AdminWaitlistRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/$nodeId': typeof NodeIdRoute
+  '/today': typeof TodayRoute
   '/admin/waitlist': typeof AdminWaitlistRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/$nodeId': typeof NodeIdRoute
+  '/today': typeof TodayRoute
   '/admin/waitlist': typeof AdminWaitlistRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/$nodeId' | '/admin/waitlist'
+  fullPaths: '/' | '/$nodeId' | '/today' | '/admin/waitlist'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/$nodeId' | '/admin/waitlist'
-  id: '__root__' | '/' | '/$nodeId' | '/admin/waitlist'
+  to: '/' | '/$nodeId' | '/today' | '/admin/waitlist'
+  id: '__root__' | '/' | '/$nodeId' | '/today' | '/admin/waitlist'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   NodeIdRoute: typeof NodeIdRoute
+  TodayRoute: typeof TodayRoute
   AdminWaitlistRoute: typeof AdminWaitlistRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/today': {
+      id: '/today'
+      path: '/today'
+      fullPath: '/today'
+      preLoaderRoute: typeof TodayRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/$nodeId': {
       id: '/$nodeId'
       path: '/$nodeId'
@@ -88,6 +105,7 @@ declare module '@tanstack/react-router' {
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   NodeIdRoute: NodeIdRoute,
+  TodayRoute: TodayRoute,
   AdminWaitlistRoute: AdminWaitlistRoute,
 }
 export const routeTree = rootRouteImport

--- a/src/routes/today.tsx
+++ b/src/routes/today.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { createFileRoute } from "@tanstack/react-router";
 import { toast } from "sonner";
 import { nodesCollection } from "../data/collection";
@@ -11,15 +11,12 @@ export const Route = createFileRoute("/today")({
   component: TodayRedirect,
 });
 
-// Module-level guard: StrictMode double-mounts the effect, and the async
-// get-or-create should only run once. Set synchronously before the first
-// await so the second mount bails.
-let redirected = false;
-
 function TodayRedirect() {
+  const redirectStarted = useRef(false);
+
   useEffect(() => {
-    if (redirected) return;
-    redirected = true;
+    if (redirectStarted.current) return;
+    redirectStarted.current = true;
 
     // Subscribe to the tree store so the nodes collection's sync starts
     // (the WebSocket opens on the first subscribeChanges call, gated by

--- a/src/routes/today.tsx
+++ b/src/routes/today.tsx
@@ -33,7 +33,7 @@ function TodayRedirect() {
         const index = buildTreeIndex(nodesCollection.toArray);
         const dayId = await getOrCreateDay(localDateKey(), index);
         if (dayId) {
-          window.location.replace(`/${dayId}`);
+          window.location.replace(`/${dayId}?focus=last`);
         } else {
           toast.error("Couldn't open today's daily note");
           window.location.replace("/");

--- a/src/routes/today.tsx
+++ b/src/routes/today.tsx
@@ -1,0 +1,50 @@
+import { useEffect } from "react";
+import { createFileRoute } from "@tanstack/react-router";
+import { toast } from "sonner";
+import { nodesCollection } from "../data/collection";
+import { subscribeTree } from "../data/tree-store";
+import { buildTreeIndex } from "../data/tree";
+import { localDateKey } from "../plugins/daily/daily-index";
+import { getOrCreateDay } from "../plugins/daily";
+
+export const Route = createFileRoute("/today")({
+  component: TodayRedirect,
+});
+
+// Module-level guard: StrictMode double-mounts the effect, and the async
+// get-or-create should only run once. Set synchronously before the first
+// await so the second mount bails.
+let redirected = false;
+
+function TodayRedirect() {
+  useEffect(() => {
+    if (redirected) return;
+    redirected = true;
+
+    // Subscribe to the tree store so the nodes collection's sync starts
+    // (the WebSocket opens on the first subscribeChanges call, gated by
+    // tree-store's ensureStarted). Without this, toArrayWhenReady hangs --
+    // no other component on this route touches the store.
+    const unsub = subscribeTree(() => {});
+
+    void (async () => {
+      try {
+        await nodesCollection.toArrayWhenReady();
+        const index = buildTreeIndex(nodesCollection.toArray);
+        const dayId = await getOrCreateDay(localDateKey(), index);
+        if (dayId) {
+          window.location.replace(`/${dayId}`);
+        } else {
+          toast.error("Couldn't open today's daily note");
+          window.location.replace("/");
+        }
+      } catch {
+        window.location.replace("/");
+      } finally {
+        unsub();
+      }
+    })();
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- add a `/today` route that resolves or creates today's daily note, then redirects to the canonical node URL
- seed a first empty child for new or empty daily notes so the destination is ready for typing
- support `?focus=last` so `/today` lands the caret on the last visible child instead of the title
- harden repeated same-session `/today` visits by keeping the StrictMode guard component-local

## Validation
- `bun run typecheck`
- `bun run typecheck:test`
- `bun run lint`
- `bun run test:e2e -- e2e/daily-notes.spec.ts -g /today --workers=1`

Addresses the `/today` route portion of #95.
