### PR TITLE
Parse markdown lists on paste

### DIFF
--- a/e2e/markdown-paste.spec.ts
+++ b/e2e/markdown-paste.spec.ts
@@ -1,0 +1,68 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+import { seedOutline, type SeedNode } from "./fixtures";
+
+const text = (page: Page, id: string) =>
+  page.locator(`li[data-node-id="${id}"] > .outline-row .node-text`);
+
+const visibleTexts = (page: Page) =>
+  page.locator(".outline-row .node-text").allTextContents();
+
+async function load(page: Page, tree: SeedNode[]) {
+  await seedOutline(page, tree);
+  await page.goto("/");
+  await expect(text(page, tree[0]!.id)).toBeVisible({ timeout: 15000 });
+}
+
+async function pasteInto(
+  locator: Locator,
+  data: { plain?: string; html?: string },
+) {
+  await locator.evaluate((el, d) => {
+    const dt = new DataTransfer();
+    if (d.plain) dt.setData("text/plain", d.plain);
+    if (d.html) dt.setData("text/html", d.html);
+    el.dispatchEvent(
+      new ClipboardEvent("paste", {
+        clipboardData: dt,
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+  }, data);
+}
+
+test.describe("Markdown list paste", () => {
+  test("turns pasted markdown list lines into outline bullets", async ({
+    page,
+  }) => {
+    await load(page, [
+      { id: "n", parentId: null, prevSiblingId: null, text: "" },
+    ]);
+
+    await text(page, "n").evaluate((el: HTMLElement) => el.focus());
+    await pasteInto(text(page, "n"), {
+      plain: "- Alpha\n  - Beta child\n- [x] Done\n- Gamma",
+    });
+
+    await expect(text(page, "n")).toHaveText("Alpha");
+    await expect(
+      page.locator('li[data-parent-id="n"] > .outline-row .node-text'),
+    ).toHaveText("Beta child");
+
+    const doneRow = page.locator("li[data-node-id] > .outline-row", {
+      hasText: /^Done$/,
+    });
+    await expect(doneRow.locator(".checkbox")).toBeVisible();
+    await expect(doneRow.locator(".node-text")).toHaveAttribute(
+      "data-completed",
+      "true",
+    );
+
+    expect(await visibleTexts(page)).toEqual([
+      "Alpha",
+      "Beta child",
+      "Done",
+      "Gamma",
+    ]);
+  });
+});

--- a/src/components/OutlineEditor.tsx
+++ b/src/components/OutlineEditor.tsx
@@ -71,6 +71,7 @@ import { SelectionActionsMenu, useSelectionMode } from "./selection-mode";
 import {
   indent,
   insertChildAtStart,
+  insertFromPaste,
   insertSibling,
   moveDown,
   moveNode,
@@ -98,6 +99,7 @@ import { hasLink } from "../data/links";
 import {
   copySourceSelection,
   cutSourceSelection,
+  type MultiLinePasteHandler,
   pasteIntoBullet,
 } from "./paste";
 import {
@@ -402,6 +404,10 @@ export function OutlineEditor({ rootId }: OutlineEditorProps) {
     commands,
   });
 
+  // Multi-line markdown paste (e.g. Obsidian lists): creates real sibling/child
+  // bullets from a pasted markdown list. Stable identity.
+  const multiLinePaste = useMultiLinePaste(pendingFocus, findFocusedId, refs);
+
   // Node multi-selection (ADR 0018): the while-selected keyboard handler + the
   // actions menu's ops. Installs window key/mouse listeners only while a
   // selection is active, and clears any stale selection on this view's mount.
@@ -611,6 +617,7 @@ export function OutlineEditor({ rootId }: OutlineEditorProps) {
                   isPivot={pivotId === zoomedNode.id}
                   registerRef={registerRef}
                   getCtx={pluginCtx}
+                  multiLinePaste={multiLinePaste}
                   onTextChange={(text) => setText(zoomedNode.id, text)}
                   onAddChild={() =>
                     runStructural(() => {
@@ -666,6 +673,7 @@ export function OutlineEditor({ rootId }: OutlineEditorProps) {
                           pivotId={pivotId}
                           isHidden={isHidden}
                           filter={filter}
+                          multiLinePaste={multiLinePaste}
                           pendingFocus={pendingFocus}
                           pendingFocusAtStart={pendingFocusAtStart}
                           pendingFlash={pendingFlash}
@@ -695,6 +703,7 @@ export function OutlineEditor({ rootId }: OutlineEditorProps) {
                         ancestorCompleted={false}
                         isHidden={isHidden}
                         filter={filter}
+                        multiLinePaste={multiLinePaste}
                       />
                     ))}
                   </ul>
@@ -1188,6 +1197,69 @@ function useMobileBarActions({
   }, [refs, findFocusedId, pendingFocus, commands]);
 }
 
+/**
+ * Build a stable callback for multi-line paste (markdown lists from Obsidian,
+ * etc.). The first line's text was already written to the focused bullet by
+ * `pasteIntoBullet`; this handler creates the remaining lines as real sibling/
+ * child bullets in ONE atomic `runStructural` batch (ADR 0009), then sets
+ * `pendingFocus` so the editor focuses the last created bullet.
+ *
+ * `findFocusedId` resolves the anchor node (the focused row, mirror-aware).
+ * Returns null when there's no focused node or no remaining items.
+ */
+function useMultiLinePaste(
+  pendingFocus: RefObject<string | null>,
+  findFocusedId: () => string | null,
+  refs: Map<string, HTMLSpanElement | null>,
+): MultiLinePasteHandler {
+  return useCallback<MultiLinePasteHandler>(
+    (allItems) => {
+      // allItems[0] is the first line (already written); remaining starts at 1.
+      if (allItems.length <= 1) return null;
+      const anchorKey = findFocusedId();
+      if (!anchorKey) return null;
+      const anchorId = instanceIdForKey(anchorKey);
+      if (!anchorId) return null;
+
+      const lastId = runStructural(() => {
+        // Apply the first line's task state to the anchor bullet.
+        const first = allItems[0]!;
+        if (first.isTask) {
+          const rowEl = refs.get(anchorKey)?.closest(".outline-row") ?? null;
+          if (!guardProtected(anchorId, "task", rowEl)) {
+            setIsTask(anchorId, true);
+            if (first.completed) {
+              if (!guardProtected(anchorId, "complete", rowEl)) {
+                toggleCompleted(anchorId, true);
+              }
+            } else {
+              toggleCompleted(anchorId, false);
+            }
+          }
+        }
+        const remaining = allItems.slice(1);
+        // Re-anchor depths relative to the first line's depth (baseline = 0).
+        const baseDepth = first.depth;
+        let prevDepth = 0;
+        const reindexed = remaining.map((it) => {
+          // Lines outdented above the first pasted line can't become parents of
+          // the focused bullet, so clamp them to same-level siblings. Also keep
+          // the no-skip-level invariant after re-basing to the first line.
+          const rawDepth = Math.max(0, it.depth - baseDepth);
+          const depth = Math.min(rawDepth, prevDepth + 1);
+          prevDepth = depth;
+          return { ...it, depth };
+        });
+        return insertFromPaste(anchorId, reindexed);
+      });
+
+      if (lastId) pendingFocus.current = lastId;
+      return lastId;
+    },
+    [pendingFocus, findFocusedId, refs],
+  );
+}
+
 interface NodeCommandsArgs {
   refs: Map<string, HTMLSpanElement | null>;
   pendingFocus: RefObject<string | null>;
@@ -1550,6 +1622,7 @@ function ZoomedTitle({
   isPivot,
   registerRef,
   getCtx,
+  multiLinePaste,
   onTextChange,
   onAddChild,
   onArrowDown,
@@ -1560,6 +1633,8 @@ function ZoomedTitle({
   /** The PluginContext factory, so the plugin keymap (Seam D) works on the
    *  title too -- Mod+Enter / Mod+D toggle completion of the zoomed node. */
   getCtx: () => PluginContext;
+  /** Multi-line paste handler (markdown lists). */
+  multiLinePaste: MultiLinePasteHandler;
   onTextChange: (text: string) => void;
   onAddChild: () => void;
   onArrowDown: () => void;
@@ -1680,7 +1755,14 @@ function ZoomedTitle({
           }}
           onPaste={(e) => {
             const el = e.currentTarget;
-            const next = pasteIntoBullet(e, el, node.id, getCtx, onTextChange);
+            const next = pasteIntoBullet(
+              e,
+              el,
+              node.id,
+              getCtx,
+              onTextChange,
+              multiLinePaste,
+            );
             if (next !== null) syncedRef.current = next;
           }}
           // Copy/cut hand back the markdown SOURCE (a folded link's rendered

--- a/src/components/OutlineNode.tsx
+++ b/src/components/OutlineNode.tsx
@@ -30,6 +30,7 @@ import { hasFoldingToken } from "../plugins/registry";
 import {
   copySourceSelection,
   cutSourceSelection,
+  type MultiLinePasteHandler,
   pasteIntoBullet,
 } from "./paste";
 import { healProtectedText } from "./protected-text";
@@ -69,6 +70,9 @@ interface OutlineNodeProps {
   // otherwise dimmed ancestor context. Filtering is render-time, so `collapsed`
   // is ignored -- matches inside collapsed subtrees are revealed. See ADR 0015.
   filter: TagFilter | null;
+  // Multi-line paste handler (markdown lists). Optional; when provided, a
+  // multi-line paste creates real sibling/child bullets instead of flattening.
+  multiLinePaste: MultiLinePasteHandler | null;
 }
 
 export interface NodeCommands {
@@ -131,6 +135,7 @@ function OutlineNodeBody({
   ancestorCompleted,
   isHidden,
   filter,
+  multiLinePaste,
 }: Omit<OutlineNodeProps, "nodeId"> & { node: Node }) {
   const textRef = useRef<HTMLSpanElement | null>(null);
   // Inline `code` is decorated LIVE -- the contentEditable always holds
@@ -396,8 +401,13 @@ function OutlineNodeBody({
             }}
             onPaste={(e) => {
               const el = e.currentTarget;
-              const next = pasteIntoBullet(e, el, node.id, pluginCtx, (t) =>
-                commands.onTextChange(node.id, t),
+              const next = pasteIntoBullet(
+                e,
+                el,
+                node.id,
+                pluginCtx,
+                (t) => commands.onTextChange(node.id, t),
+                multiLinePaste ?? undefined,
               );
               if (next !== null) syncedRef.current = next;
             }}
@@ -483,6 +493,7 @@ function OutlineNodeBody({
           pivotId={pivotId}
           isHidden={isHidden}
           filter={filter}
+          multiLinePaste={multiLinePaste}
         />
       )}
     </li>
@@ -508,13 +519,14 @@ function OutlineNodeChildren({
   pivotId,
   isHidden,
   filter,
+  multiLinePaste,
 }: {
   childIds: string[];
   collapsed: boolean;
   ancestorCompleted: boolean;
 } & Pick<
   OutlineNodeProps,
-  "commands" | "pluginCtx" | "registerRef" | "pivotId" | "isHidden" | "filter"
+  "commands" | "pluginCtx" | "registerRef" | "pivotId" | "isHidden" | "filter" | "multiLinePaste"
 >) {
   return (
     <div className="outline-children-wrap" data-collapsed={collapsed}>
@@ -530,6 +542,7 @@ function OutlineNodeChildren({
             ancestorCompleted={ancestorCompleted}
             isHidden={isHidden}
             filter={filter}
+            multiLinePaste={multiLinePaste}
           />
         ))}
       </ul>

--- a/src/components/OutlineRow.tsx
+++ b/src/components/OutlineRow.tsx
@@ -37,6 +37,7 @@ import { hasFoldingToken } from "../plugins/registry";
 import {
   copySourceSelection,
   cutSourceSelection,
+  type MultiLinePasteHandler,
   pasteIntoBullet,
 } from "./paste";
 import { healProtectedText } from "./protected-text";
@@ -108,6 +109,9 @@ export interface OutlineRowProps {
   pivotId: string | null;
   isHidden: (node: Node) => boolean;
   filter: TagFilter | null;
+  // Multi-line paste handler (markdown lists). Optional; when provided, a
+  // multi-line paste creates real sibling/child bullets instead of flattening.
+  multiLinePaste: MultiLinePasteHandler | null;
   // Focus plumbing, claimed on mount. Stable refs (from useOutlineFocus).
   pendingFocus: RefObject<string | null>;
   pendingFocusAtStart: RefObject<boolean>;
@@ -192,6 +196,7 @@ function RowChrome({
   pivotId,
   isHidden,
   filter,
+  multiLinePaste,
   pendingFocus,
   pendingFocusAtStart,
   pendingFlash,
@@ -491,8 +496,13 @@ function RowChrome({
             }}
             onPaste={(e) => {
               const el = e.currentTarget;
-              const next = pasteIntoBullet(e, el, content.id, pluginCtx, (t) =>
-                commands.onTextChange(content.id, t),
+              const next = pasteIntoBullet(
+                e,
+                el,
+                content.id,
+                pluginCtx,
+                (t) => commands.onTextChange(content.id, t),
+                multiLinePaste ?? undefined,
               );
               if (next !== null) syncedRef.current = next;
             }}

--- a/src/components/paste.ts
+++ b/src/components/paste.ts
@@ -15,6 +15,11 @@
 // splice into source space directly, then re-decorate.
 
 import type { ClipboardEvent } from "react";
+import {
+  normalizeDepths,
+  parseMarkdownPaste,
+  type ParsedItem,
+} from "../data/markdown-paste";
 import { afterPaste, pasteReplacement } from "../plugins/registry";
 import type { PluginContext } from "../plugins/types";
 import {
@@ -25,6 +30,15 @@ import {
 } from "./inline-code";
 
 /**
+ * When a multi-line paste is detected (and no plugin claimed it), this callback
+ * is invoked with all parsed items. The first item has already been written into
+ * the current bullet; the handler creates the remaining siblings/children.
+ * Returns the id of the last created bullet (for focus), or null to signal
+ * "no structural insert happened".
+ */
+export type MultiLinePasteHandler = (items: ParsedItem[]) => string | null;
+
+/**
  * Handle a paste into a (focused) contentEditable bullet/title. Returns the new
  * source text on success (so the caller can update its synced-text ref), or
  * null if there was no clipboard to read.
@@ -33,6 +47,10 @@ import {
  * `afterPaste`, ADR 0016) -- e.g. the links plugin fetching a pasted URL's title
  * and swapping it into the label. `getCtx` is the same stable PluginContext
  * factory used everywhere; it's only called when a paste actually happened.
+ *
+ * `onMultiLine` (optional) handles multi-line pastes (e.g. a markdown list from
+ * Obsidian). When provided and the paste spans multiple lines, it creates real
+ * sibling bullets via runStructural and returns the last id (for focus).
  */
 export function pasteIntoBullet(
   e: ClipboardEvent<HTMLElement>,
@@ -40,6 +58,7 @@ export function pasteIntoBullet(
   nodeId: string,
   getCtx: () => PluginContext,
   onText: (text: string) => void,
+  onMultiLine?: MultiLinePasteHandler,
 ): string | null {
   const cd = e.clipboardData;
   if (!cd) return null;
@@ -61,14 +80,38 @@ export function pasteIntoBullet(
   const hasSelection = end > start;
 
   // A plugin decides the replacement (e.g. the links plugin wraps a selection
-  // or auto-links a URL); otherwise plain text, formatting stripped (bullets
-  // are single-line, so newlines collapse to spaces -- no tree-from-paste v1).
+  // or auto-links a URL). If a plugin claims it, we use that string and skip
+  // multi-line parsing (a pasted URL is single-purpose).
   const replacement = pasteReplacement({
     plain,
     html,
     selectedText,
     hasSelection,
   });
+
+  // Multi-line paste: parse markdown list syntax into items and hand off to the
+  // editor's structural handler (creates real sibling/child bullets). Only when
+  // no plugin claimed the paste and a handler was provided.
+  if (!replacement && onMultiLine) {
+    const items = parseMarkdownPaste(plain);
+    if (items && items.length > 0) {
+      normalizeDepths(items);
+      const [first, ...rest] = items;
+      const firstText = first!.text;
+      // Write the first line into the current bullet (replacing the selection).
+      const next = source.slice(0, start) + firstText + source.slice(end);
+      onText(next);
+      decorate(el, next, start + firstText.length, false);
+      setCaretOffset(el, start + firstText.length);
+      // Fire afterPaste for the first line (e.g. a URL title unfurl).
+      afterPaste({ inserted: firstText, nodeId, el }, getCtx());
+      // Create the remaining bullets; the handler owns focus, and the
+      // synced-text ref update from `next` is the caller's job.
+      onMultiLine([first!, ...rest]);
+      return next;
+    }
+  }
+
   const inserted = replacement ?? plain.replace(/\r?\n/g, " ");
 
   const next = source.slice(0, start) + inserted + source.slice(end);

--- a/src/data/markdown-paste.test.ts
+++ b/src/data/markdown-paste.test.ts
@@ -1,0 +1,124 @@
+import { expect, test } from "bun:test";
+import {
+  type ParsedItem,
+  normalizeDepths,
+  parseMarkdownPaste,
+} from "./markdown-paste";
+
+function item(
+  text: string,
+  depth: number,
+  isTask = false,
+  completed = false,
+): ParsedItem {
+  return { text, depth, isTask, completed };
+}
+
+test("returns null for single-line input", () => {
+  expect(parseMarkdownPaste("hello world")).toBeNull();
+  expect(parseMarkdownPaste("")).toBeNull();
+});
+
+test("returns null for all-blank input", () => {
+  expect(parseMarkdownPaste("\n\n")).toBeNull();
+});
+
+test("parses a simple dash list", () => {
+  const input = "- Romans 5:3-6\n- 2 Corinthians 12:8-9\n- Philippians 4:11-13";
+  expect(parseMarkdownPaste(input)).toEqual([
+    item("Romans 5:3-6", 0),
+    item("2 Corinthians 12:8-9", 0),
+    item("Philippians 4:11-13", 0),
+  ]);
+});
+
+test("strips asterisk and plus markers", () => {
+  const input = "* one\n+ two\n- three";
+  expect(parseMarkdownPaste(input)).toEqual([
+    item("one", 0),
+    item("two", 0),
+    item("three", 0),
+  ]);
+});
+
+test("strips ordered list markers", () => {
+  const input = "1. first\n2. second\n10. tenth";
+  expect(parseMarkdownPaste(input)).toEqual([
+    item("first", 0),
+    item("second", 0),
+    item("tenth", 0),
+  ]);
+});
+
+test("strips a trailing empty line", () => {
+  const input = "- one\n- two\n";
+  expect(parseMarkdownPaste(input)).toEqual([item("one", 0), item("two", 0)]);
+});
+
+test("parses nested items via indentation (2-space)", () => {
+  const input = "- parent\n  - child\n    - grandchild\n- sibling";
+  expect(parseMarkdownPaste(input)).toEqual([
+    item("parent", 0),
+    item("child", 1),
+    item("grandchild", 2),
+    item("sibling", 0),
+  ]);
+});
+
+test("parses nested items via tabs", () => {
+  const input = "- parent\n\t- child\n\t\t- grandchild";
+  expect(parseMarkdownPaste(input)).toEqual([
+    item("parent", 0),
+    item("child", 1),
+    item("grandchild", 2),
+  ]);
+});
+
+test("parses task markers", () => {
+  const input = "- [ ] todo\n- [x] done";
+  expect(parseMarkdownPaste(input)).toEqual([
+    item("todo", 0, true, false),
+    item("done", 0, true, true),
+  ]);
+});
+
+test("parses plain text lines as bullets", () => {
+  const input = "first line\nsecond line";
+  expect(parseMarkdownPaste(input)).toEqual([
+    item("first line", 0),
+    item("second line", 0),
+  ]);
+});
+
+test("keeps empty lines as empty bullets", () => {
+  const input = "- one\n\n- three";
+  expect(parseMarkdownPaste(input)).toEqual([
+    item("one", 0),
+    item("", 0),
+    item("three", 0),
+  ]);
+});
+
+test("strips an empty trailing marker", () => {
+  const input = "- one\n-";
+  expect(parseMarkdownPaste(input)).toEqual([item("one", 0), item("", 0)]);
+});
+
+test("normalizeDepths flattens leading indent", () => {
+  const items = parseMarkdownPaste("  - a\n  - b")!;
+  expect(normalizeDepths(items)).toEqual([item("a", 0), item("b", 0)]);
+});
+
+test("normalizeDepths clamps skipped levels", () => {
+  // depth jumps 0 -> 2 (skipping 1), should clamp to 1
+  const items: ParsedItem[] = [
+    item("a", 0),
+    item("b", 2),
+    item("c", 3),
+  ];
+  expect(normalizeDepths(items)).toEqual([
+    item("a", 0),
+    item("b", 1),
+    item("c", 2),
+  ]);
+});

--- a/src/data/markdown-paste.ts
+++ b/src/data/markdown-paste.ts
@@ -1,0 +1,125 @@
+// Pure parser for multi-line markdown paste (Seam I extension). When the user
+// pastes text containing newlines (e.g. a markdown list copied from Obsidian),
+// we parse it into a flat list of {text, depth} items and the editor creates
+// real sibling/child bullets via runStructural. This module is PURE -- no React,
+// no collection, no DOM -- so it's unit-testable in isolation.
+//
+// Supported syntax (stripped from the text, not rendered as literal chars):
+//   - unordered list:  "- text", "* text", "+ text"
+//   - ordered list:    "1. text", "2. text", ...
+//   - task list:       "- [ ] text", "- [x] text"
+//   - nested via indentation: tabs or 2+ leading spaces per level
+//   - plain text lines (no marker) become bullets at their indent depth
+//
+// The first line's text replaces the current selection (if any) and the rest
+// become siblings/children of the focused bullet. Trailing empty lines are
+// ignored; a lone empty line within the list creates an empty bullet.
+
+/** One parsed item: the stripped text and its nesting depth (0 = top). */
+export interface ParsedItem {
+  text: string;
+  /** Indentation depth, derived from leading tabs or 2-space groups. */
+  depth: number;
+  /** Whether this line was a markdown task ("[ ]" or "[x]"). */
+  isTask: boolean;
+  /** Whether the task was checked ("[x]"). Only meaningful when isTask. */
+  completed: boolean;
+}
+
+// Matches a markdown list marker: "- ", "* ", "+ ", "N. ", or an empty
+// marker at end-of-line ("-") -- common when copying a trailing blank bullet.
+const LIST_MARKER = /^\s*(?:[-*+]|\d+\.)(?:\s+|$)/;
+
+// Matches a task marker after a list marker: "[ ]" or "[x]" (case-insensitive).
+const TASK_MARKER = /^\s*(?:[-*+]|\d+\.)\s+\[([xX ])\]\s+/;
+
+/**
+ * Parse multi-line clipboard text into a list of items. Returns null when the
+ * input is single-line (no newline) or all-blank -- signaling "not a meaningful
+ * multi-line paste, use the normal single-line path."
+ *
+ * Indentation rules (Obsidian-compatible):
+ *   - tabs: each tab = 1 depth
+ *   - spaces: every 2 leading spaces = 1 depth (1 space is flattened to 0)
+ *   - mixed: tabs count first, then leftover spaces / 2
+ */
+export function parseMarkdownPaste(plain: string): ParsedItem[] | null {
+  // Need at least one newline to be "multi-line paste."
+  if (!plain.includes("\n")) return null;
+
+  const lines = plain.replace(/\r\n/g, "\n").split("\n");
+  // Strip a single trailing empty line (common from copy-with-trailing-newline).
+  if (lines.length > 0 && lines[lines.length - 1] === "") lines.pop();
+
+  // All-blank input (every line empty) is not a meaningful multi-line paste.
+  if (lines.every((l) => l.trim() === "")) return null;
+
+  const items: ParsedItem[] = [];
+
+  for (const raw of lines) {
+    // Measure leading indentation.
+    let tabs = 0;
+    let spaces = 0;
+    for (const ch of raw) {
+      if (ch === "\t") tabs++;
+      else if (ch === " ") spaces++;
+      else break;
+    }
+    const depth = tabs + Math.floor(spaces / 2);
+
+    let rest = raw.slice(tabs + spaces);
+
+    // Task marker check first (it subsumes the list marker).
+    const taskMatch = TASK_MARKER.exec(rest);
+    if (taskMatch) {
+      const flag = taskMatch[1]!;
+      items.push({
+        text: rest.slice(taskMatch[0].length),
+        depth,
+        isTask: true,
+        completed: flag !== " ",
+      });
+      continue;
+    }
+
+    // Plain list marker: strip it.
+    const listMatch = LIST_MARKER.exec(rest);
+    if (listMatch) {
+      items.push({
+        text: rest.slice(listMatch[0].length),
+        depth,
+        isTask: false,
+        completed: false,
+      });
+      continue;
+    }
+
+    // Plain text line (could be a continuation, a heading, a paragraph, etc.).
+    // Treat it as a bullet at its indent depth.
+    items.push({ text: rest, depth, isTask: false, completed: false });
+  }
+
+  return items;
+}
+
+/**
+ * Normalize depths so the first item is depth 0 and all depths are relative
+ * (a paste indented from the start, e.g. all lines have 2 leading spaces, is
+ * flattened). This prevents the first bullet from being a child of nothing.
+ * Mutates the array in place for efficiency; returns it for chaining.
+ */
+export function normalizeDepths(items: ParsedItem[]): ParsedItem[] {
+  if (items.length === 0) return items;
+  const minDepth = Math.min(...items.map((i) => i.depth));
+  if (minDepth > 0) {
+    for (const item of items) item.depth -= minDepth;
+  }
+  // Clamp: no item can be deeper than prev.depth + 1 (skip levels).
+  // This prevents orphan children if the source skipped an indent level.
+  let maxAllowed = 0;
+  for (const item of items) {
+    maxAllowed = Math.min(item.depth, maxAllowed + 1);
+    item.depth = maxAllowed;
+  }
+  return items;
+}

--- a/src/data/mutations.ts
+++ b/src/data/mutations.ts
@@ -687,3 +687,76 @@ export function toggleCollapsed(nodeId: string, collapsed: boolean) {
 export function toggleBookmark(nodeId: string, bookmarked: boolean) {
   update(nodeId, { bookmarkedAt: bookmarked ? now() : null })
 }
+
+/**
+ * Insert a multi-line paste as a tree of bullets. The FIRST item replaces the
+ * text of the focused node (the caller already wrote that text); subsequent
+ * items are inserted as siblings/children relative to `afterId`, following the
+ * depth deltas in `items`. Depth 0 = same level as `afterId`; depth N+1 = child
+ * of the node at depth N.
+ *
+ * The index is rebuilt from the live collection between each insert (each insert
+ * mutates `nodesCollection` optimistically), so sibling-chain relinks read
+ * accurate state. Wrap the whole call in `runStructural` (ADR 0009) so the batch
+ * lands as one atomic frame.
+ *
+ * Returns the last inserted node id (for focus). `items[0]` is NOT inserted
+ * here -- the caller owns writing the first line's text into the existing node.
+ */
+export function insertFromPaste(
+  afterId: string,
+  items: { text: string; depth: number; isTask: boolean; completed: boolean }[],
+): string {
+  if (items.length === 0) return afterId
+
+  // Read the anchor's parent once (all depth-0 items share it).
+  let anchorParentId: string | null
+  {
+    const start = buildTreeIndex(nodesCollection.toArray)
+    const anchor = start.byId.get(afterId)
+    anchorParentId = anchor?.parentId ?? null
+  }
+
+  // Track the last-inserted node at EACH depth, so when we return to a
+  // shallower depth we use the right predecessor (not a deeply-nested one).
+  // lastAtDepth[0] starts as the anchor itself.
+  const lastAtDepth: (string | null)[] = [afterId]
+  // depthStack[n] = the node whose children are at depth n+1 (= lastAtDepth[n]
+  // when it opened that level). Initialized with the anchor at depth 0.
+  const depthStack: (string | null)[] = [null, afterId]
+  // Track the chronologically last inserted id (for focus).
+  let lastInserted = afterId
+
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i]!
+    const index = buildTreeIndex(nodesCollection.toArray)
+
+    if (item.depth === 0) {
+      // Sibling of the anchor: insert after the last depth-0 node.
+      const after = lastAtDepth[0] ?? afterId
+      const newId = insertSibling(index, anchorParentId, after, item.isTask, item.text)
+      if (item.isTask && item.completed) toggleCompleted(newId, true)
+      lastAtDepth[0] = newId
+      depthStack[1] = newId
+      lastInserted = newId
+    } else {
+      // Child: parent is the node that opened this depth (depthStack[depth]).
+      // Fallback to the anchor's parent if the stack is somehow empty.
+      const parentForThis =
+        depthStack[item.depth] ?? lastAtDepth[item.depth - 1] ?? afterId
+      while (depthStack.length <= item.depth + 1) depthStack.push(null)
+      while (lastAtDepth.length <= item.depth) lastAtDepth.push(null)
+
+      // Insert as the last child of parentForThis.
+      const siblings = childrenOf(index, parentForThis)
+      const after = siblings.length > 0 ? siblings[siblings.length - 1]!.id : null
+      const newId = insertSibling(index, parentForThis, after, item.isTask, item.text)
+      if (item.isTask && item.completed) toggleCompleted(newId, true)
+      lastAtDepth[item.depth] = newId
+      depthStack[item.depth + 1] = newId
+      lastInserted = newId
+    }
+  }
+
+  return lastInserted
+}

--- a/src/data/mutations.ts
+++ b/src/data/mutations.ts
@@ -689,19 +689,18 @@ export function toggleBookmark(nodeId: string, bookmarked: boolean) {
 }
 
 /**
- * Insert a multi-line paste as a tree of bullets. The FIRST item replaces the
- * text of the focused node (the caller already wrote that text); subsequent
- * items are inserted as siblings/children relative to `afterId`, following the
- * depth deltas in `items`. Depth 0 = same level as `afterId`; depth N+1 = child
- * of the node at depth N.
+ * Insert the remaining lines of a multi-line paste as a tree of bullets. The
+ * first pasted line has already replaced the focused node's text; these items
+ * are inserted as siblings/children relative to `afterId`, following the depth
+ * deltas in `items`. Depth 0 = same level as `afterId`; depth N+1 = child of
+ * the node at depth N.
  *
  * The index is rebuilt from the live collection between each insert (each insert
  * mutates `nodesCollection` optimistically), so sibling-chain relinks read
  * accurate state. Wrap the whole call in `runStructural` (ADR 0009) so the batch
  * lands as one atomic frame.
  *
- * Returns the last inserted node id (for focus). `items[0]` is NOT inserted
- * here -- the caller owns writing the first line's text into the existing node.
+ * Returns the last inserted node id (for focus).
  */
 export function insertFromPaste(
   afterId: string,


### PR DESCRIPTION
## Summary
- parse multi-line markdown list pastes into real outline bullets instead of flattening newline text
- preserve list hierarchy from tabs / two-space indents and clamp skipped depths into a valid tree
- support markdown task markers so `[ ]` / `[x]` pastes create task bullets
- add focused parser and browser coverage for the paste flow

## Validation
- `bun test src/data/markdown-paste.test.ts`
- `bun run typecheck`
- `bun run typecheck:test`
- `bun run lint`
- `bun run test:e2e -- e2e/markdown-paste.spec.ts --workers=1`

Closes #97.
