### PR TITLE
Select route.bible chips with keyboard

### DIFF
--- a/e2e/route-bible.spec.ts
+++ b/e2e/route-bible.spec.ts
@@ -31,6 +31,71 @@ async function load(page: Page, tree: SeedNode[]) {
 const opened = (page: Page) =>
   page.evaluate(() => (window as unknown as { __opened: string[] }).__opened);
 
+async function caretAtSource(page: Page, id: string, target: number) {
+  await text(page, id).evaluate((el, target) => {
+    el.focus();
+    const sel = window.getSelection();
+    if (!sel) return;
+    let remaining = target as number;
+    let placed = false;
+    const visit = (node: Node): void => {
+      if (placed) return;
+      if (node.nodeType === 3 /* text */) {
+        const len = node.textContent?.length ?? 0;
+        if (remaining <= len) {
+          const r = document.createRange();
+          r.setStart(node, remaining);
+          r.collapse(true);
+          sel.removeAllRanges();
+          sel.addRange(r);
+          placed = true;
+        } else remaining -= len;
+        return;
+      }
+      if (node.nodeType === 1 && (node as HTMLElement).hasAttribute("data-src")) {
+        const e = node as HTMLElement;
+        const len =
+          Number(e.getAttribute("data-src-len")) ||
+          (e.getAttribute("data-src") ?? "").length;
+        if (remaining <= len) {
+          const parent = e.parentNode!;
+          const idx = Array.prototype.indexOf.call(parent.childNodes, e);
+          const r = document.createRange();
+          r.setStart(parent, remaining === 0 ? idx : idx + 1);
+          r.collapse(true);
+          sel.removeAllRanges();
+          sel.addRange(r);
+          placed = true;
+          return;
+        }
+        remaining -= len;
+        return;
+      }
+      node.childNodes.forEach(visit);
+    };
+    visit(el);
+    if (!placed) {
+      const r = document.createRange();
+      r.selectNodeContents(el);
+      r.collapse(false);
+      sel.removeAllRanges();
+      sel.addRange(r);
+    }
+  }, target);
+}
+
+const selectedBibleRef = (page: Page) =>
+  page.evaluate(() => {
+    const sel = window.getSelection();
+    if (!sel || sel.rangeCount !== 1) return null;
+    const range = sel.getRangeAt(0);
+    if (range.collapsed || range.startContainer !== range.endContainer) return null;
+    const node = range.startContainer.childNodes.item(range.startOffset);
+    return node instanceof HTMLElement && node.hasAttribute("data-bible-ref")
+      ? node.getAttribute("data-src")
+      : null;
+  });
+
 test.describe("Scripture reference chips", () => {
   test("a chapter:verse reference chips with the resolver URL; a non-reference stays plain text", async ({
     page,
@@ -102,6 +167,29 @@ test.describe("Scripture reference chips", () => {
 
     expect(await opened(page)).toEqual([
       "https://route.bible/1co.13.4-7?src=dotflowy",
+    ]);
+  });
+
+  test("Left/Right can select a chip and Enter opens it", async ({ page }) => {
+    await load(page, [
+      { id: "n", parentId: null, prevSiblingId: null, text: "See John 3:16 now" },
+    ]);
+
+    await caretAtSource(page, "n", "See ".length);
+    await page.keyboard.press("ArrowRight");
+    await expect.poll(() => selectedBibleRef(page)).toBe("John 3:16");
+    await expect(chip(page, "n")).toHaveAttribute("data-atom-selected", "true");
+
+    await page.keyboard.press("ArrowRight");
+    await expect.poll(() => selectedBibleRef(page)).toBeNull();
+    await expect(chip(page, "n")).not.toHaveAttribute("data-atom-selected", /.*/);
+    await page.keyboard.press("ArrowLeft");
+    await expect.poll(() => selectedBibleRef(page)).toBe("John 3:16");
+    await expect(chip(page, "n")).toHaveAttribute("data-atom-selected", "true");
+
+    await page.keyboard.press("Enter");
+    expect(await opened(page)).toEqual([
+      "https://route.bible/jhn.3.16?src=dotflowy",
     ]);
   });
 });

--- a/src/components/OutlineEditor.tsx
+++ b/src/components/OutlineEditor.tsx
@@ -90,6 +90,7 @@ import { OutlineNode, type NodeCommands } from "./OutlineNode";
 import {
   decorate,
   getCaretOffset,
+  getSelectedAtom,
   readSource,
   revealLinkAtCaret,
   watchCaretReveal,
@@ -283,8 +284,9 @@ export function OutlineEditor({ rootId }: OutlineEditorProps) {
   };
   const onContentKeyDown = (e: ReactKeyboardEvent<HTMLElement>) => {
     if (e.key !== "Enter" && e.key !== " ") return;
-    const rect = (e.target as HTMLElement).getBoundingClientRect();
-    dispatchClick(e.target as HTMLElement, pluginCtx(), {
+    const target = getSelectedAtom(e.currentTarget) ?? (e.target as HTMLElement);
+    const rect = target.getBoundingClientRect();
+    dispatchClick(target, pluginCtx(), {
       preventDefault: () => e.preventDefault(),
       stopPropagation: () => e.stopPropagation(),
       clientX: rect.left + rect.width / 2,

--- a/src/components/inline-code.ts
+++ b/src/components/inline-code.ts
@@ -146,6 +146,9 @@ function foldedSrcLen(el: HTMLElement): number {
     : (el.getAttribute("data-src") ?? "").length;
 }
 
+const SELECTED_ATOM_ATTR = "data-atom-selected";
+let atomSelectionListenerInstalled = false;
+
 // Reconstruct the markdown SOURCE from the live DOM. el.textContent is no longer
 // the source once a folding token hides part of its source (a folded link shows
 // only its label; folded code/emphasis hide their markers), so
@@ -312,6 +315,113 @@ export function setCaretOffset(el: HTMLElement, offset: number): void {
   }
 }
 
+/** Return the currently selected atomic token, if the DOM selection is exactly
+ *  one `data-src` atom inside `el`. */
+export function getSelectedAtom(el: HTMLElement): HTMLElement | null {
+  const child = selectedAtomFromSelection();
+  return child && el.contains(child) ? child : null;
+}
+
+function selectedAtomFromSelection(): HTMLElement | null {
+  const sel = window.getSelection();
+  if (!sel || sel.rangeCount !== 1) return null;
+  const range = sel.getRangeAt(0);
+  if (range.collapsed) return null;
+  if (range.startContainer !== range.endContainer) return null;
+  const parent = range.startContainer;
+  const child = parent.childNodes.item(range.startOffset);
+  if (
+    range.endOffset !== range.startOffset + 1 ||
+    !child ||
+    !isAtom(child)
+  ) {
+    return null;
+  }
+  return child;
+}
+
+/** Make Left/Right treat an adjacent atom as a selectable stop: first keypress
+ *  selects the chip, second keypress moves the caret past it. */
+export function selectAdjacentAtom(
+  el: HTMLElement,
+  direction: "left" | "right",
+): boolean {
+  const selected = getSelectedAtom(el);
+  if (selected) {
+    placeAtWidget(selected, direction === "left" ? "before" : "after");
+    return true;
+  }
+
+  const sel = window.getSelection();
+  if (!sel || sel.rangeCount !== 1) return false;
+  const range = sel.getRangeAt(0);
+  if (!range.collapsed || !el.contains(range.endContainer)) return false;
+
+  const caret = getCaretOffset(el);
+  const atom = atomAtSourceBoundary(el, caret, direction);
+  if (!atom) return false;
+  selectAtom(atom);
+  return true;
+}
+
+function atomAtSourceBoundary(
+  el: HTMLElement,
+  offset: number,
+  direction: "left" | "right",
+): HTMLElement | null {
+  let total = 0;
+  let found: HTMLElement | null = null;
+  const visit = (node: Node) => {
+    if (found) return;
+    if (node.nodeType === 3 /* text */) {
+      total += node.textContent?.length ?? 0;
+      return;
+    }
+    if (isAtom(node)) {
+      const atom = node as HTMLElement;
+      const len = foldedSrcLen(atom);
+      if (
+        (direction === "left" && total + len === offset) ||
+        (direction === "right" && total === offset)
+      ) {
+        found = atom;
+        return;
+      }
+      total += len;
+      return;
+    }
+    node.childNodes.forEach(visit);
+  };
+  el.childNodes.forEach(visit);
+  return found;
+}
+
+function selectAtom(atom: HTMLElement): void {
+  const sel = window.getSelection();
+  if (!sel) return;
+  installAtomSelectionListener();
+  const range = document.createRange();
+  range.selectNode(atom);
+  sel.removeAllRanges();
+  sel.addRange(range);
+  syncAtomSelectionMarkers(atom);
+}
+
+function installAtomSelectionListener(): void {
+  if (atomSelectionListenerInstalled) return;
+  atomSelectionListenerInstalled = true;
+  document.addEventListener("selectionchange", () => {
+    syncAtomSelectionMarkers(selectedAtomFromSelection());
+  });
+}
+
+function syncAtomSelectionMarkers(selected: HTMLElement | null): void {
+  document.querySelectorAll(`[${SELECTED_ATOM_ATTR}]`).forEach((el) => {
+    if (el !== selected) el.removeAttribute(SELECTED_ATOM_ATTR);
+  });
+  selected?.setAttribute(SELECTED_ATOM_ATTR, "true");
+}
+
 // Collapse the selection just before/after an atomic folded-link widget, by
 // addressing the position in its parent (the caret never goes inside it).
 function placeAtWidget(widget: HTMLElement, side: "before" | "after"): void {
@@ -324,6 +434,7 @@ function placeAtWidget(widget: HTMLElement, side: "before" | "after"): void {
   range.collapse(true);
   sel.removeAllRanges();
   sel.addRange(range);
+  widget.removeAttribute(SELECTED_ATOM_ATTR);
 }
 
 // Per-link reveal reflow. While a bullet is focused, watch the caret: as it

--- a/src/components/use-bullet-keymap.ts
+++ b/src/components/use-bullet-keymap.ts
@@ -1,10 +1,15 @@
 import { useHotkeys, type UseHotkeyDefinition } from "@tanstack/react-hotkeys";
 import { useLayoutEffect, useState, type RefObject } from "react";
 import type { Node } from "../data/schema";
-import { keymapSpecs } from "../plugins/registry";
+import { dispatchClick, keymapSpecs } from "../plugins/registry";
 import type { PluginContext } from "../plugins/types";
 import { selectSingle } from "../data/selection-state";
-import { getCaretOffset, readSource } from "./inline-code";
+import {
+  getCaretOffset,
+  getSelectedAtom,
+  readSource,
+  selectAdjacentAtom,
+} from "./inline-code";
 import { openLinkAtCaret } from "./link-keymap";
 import type { NodeCommands } from "./OutlineNode";
 
@@ -110,8 +115,21 @@ export function useBulletKeymap({
             // text to its right moves into a new sibling below (caret at the end is
             // just the empty-tail case of the same split).
             hotkey: "Enter",
-            callback: () => {
+            callback: (e) => {
               const el = textRef.current;
+              if (el) {
+                const atom = getSelectedAtom(el);
+                if (atom) {
+                  const rect = atom.getBoundingClientRect();
+                  const handled = dispatchClick(atom, pluginCtx(), {
+                    preventDefault: () => e.preventDefault(),
+                    stopPropagation: () => e.stopPropagation(),
+                    clientX: rect.left + rect.width / 2,
+                    clientY: rect.top + rect.height / 2,
+                  });
+                  if (handled) return;
+                }
+              }
               commands.onEnter(
                 node.id,
                 el ? getCaretOffset(el) : node.text.length,
@@ -283,6 +301,11 @@ export function useBulletKeymap({
             hotkey: "ArrowLeft",
             callback: (e) => {
               const el = textRef.current;
+              if (el && selectAdjacentAtom(el, "left")) {
+                e.preventDefault();
+                e.stopPropagation();
+                return;
+              }
               if (!el || !isCollapsedCaretAtStart(el)) return;
               e.preventDefault();
               e.stopPropagation();
@@ -295,6 +318,11 @@ export function useBulletKeymap({
             hotkey: "ArrowRight",
             callback: (e) => {
               const el = textRef.current;
+              if (el && selectAdjacentAtom(el, "right")) {
+                e.preventDefault();
+                e.stopPropagation();
+                return;
+              }
               if (!el || !isCaretAtEnd(el)) return;
               e.preventDefault();
               e.stopPropagation();

--- a/src/styles.css
+++ b/src/styles.css
@@ -1399,6 +1399,24 @@ body.dragging-active * {
   margin-left: 0;
 }
 
+dotflowy-widget[data-bible-ref][data-atom-selected] > span {
+  border-color: oklch(0.62 0.15 250);
+  background: oklch(0.94 0.05 250);
+  color: oklch(0.33 0.14 255);
+  box-shadow:
+    0 0 0 1px oklch(0.62 0.15 250),
+    0 0 0 4px oklch(0.62 0.15 250 / 0.18);
+}
+
+.dark dotflowy-widget[data-bible-ref][data-atom-selected] > span {
+  border-color: oklch(0.74 0.13 245);
+  background: oklch(0.3 0.08 250);
+  color: oklch(0.9 0.05 245);
+  box-shadow:
+    0 0 0 1px oklch(0.74 0.13 245),
+    0 0 0 4px oklch(0.74 0.13 245 / 0.24);
+}
+
 :root {
   --link-edit-icon: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z"/><path d="m15 5 4 4"/></svg>');
 }


### PR DESCRIPTION
## Summary

- Treat atomic inline widgets as selectable stops when moving left/right through bullet text.
- Dispatch Enter on a selected route.bible chip through the existing plugin click handler instead of splitting the bullet.
- Add an explicit data-atom-selected styling hook and selected visual treatment for route.bible chips.
- Cover the keyboard selection/open flow in the route-bible Playwright spec.

## Why

The chip could be selected by DOM range after keyboard navigation, but there was no clear visual state to signify that selection. Enter also needed to route to the chip interaction when that atom is selected.

## Validation

- bun run lint
- bun run typecheck
- bun run typecheck:test

These checks passed in the primary checkout with dependencies installed. A clean temporary worktree was used for the PR branch so unrelated local changes on main were excluded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bible reference chips can now be selected with the keyboard using the Left and Right arrow keys.
  * Pressing Enter on a selected chip opens its reference link in a new tab.

* **Bug Fixes**
  * Improved keyboard and click behavior for inline chips so selection and activation feel more consistent.
  * Selected chips now show clearer visual highlighting, including in dark mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->