### PR TITLE
Export route-bible refs as markdown links

### DIFF
--- a/src/data/markdown.test.ts
+++ b/src/data/markdown.test.ts
@@ -43,7 +43,7 @@ describe('outlineToMarkdown', () => {
     )
   })
 
-  test('emits node.text verbatim (links, tags, code are already markdown)', () => {
+  test('emits markdown source for links, tags, and code', () => {
     const node = makeNode({
       id: 'n',
       text: 'see [docs](https://x.dev) #ref `code`',
@@ -52,6 +52,30 @@ describe('outlineToMarkdown', () => {
 
     expect(outlineToMarkdown(index, ['n'])).toBe(
       '- see [docs](https://x.dev) #ref `code`',
+    )
+  })
+
+  test('exports route-bible references as readable markdown links', () => {
+    const node = makeNode({
+      id: 'n',
+      text: 'Read John 3:16 and Genesis 1',
+    })
+    const index = buildTreeIndex([node])
+
+    expect(outlineToMarkdown(index, ['n'])).toBe(
+      '- Read [John 3:16](https://route.bible/jhn.3.16?src=dotflowy) and [Genesis 1](https://route.bible/gen.1?src=dotflowy)',
+    )
+  })
+
+  test('does not relink route-bible references inside existing links or code', () => {
+    const node = makeNode({
+      id: 'n',
+      text: 'see [John 3:16](https://example.com) and `Romans 8:28`',
+    })
+    const index = buildTreeIndex([node])
+
+    expect(outlineToMarkdown(index, ['n'])).toBe(
+      '- see [John 3:16](https://example.com) and `Romans 8:28`',
     )
   })
 

--- a/src/data/markdown.ts
+++ b/src/data/markdown.ts
@@ -1,5 +1,6 @@
 import type { Node } from './schema'
 import { childrenOf, type TreeIndex } from './tree'
+import { bibleRefsToMarkdownLinks } from '../plugins/route-bible/bible'
 
 /** Two spaces per depth level (CommonMark-friendly, readable). */
 const INDENT = '  '
@@ -14,10 +15,12 @@ function prefixFor(node: Node): string {
 function emit(index: TreeIndex, id: string, depth: number, lines: string[]): void {
   const node = index.byId.get(id)
   if (!node) return
-  // `node.text` is already the markdown source (links `[label](url)`, `#tags`,
-  // inline `code`) -- emit it verbatim, no transform. Empty text yields a bare
-  // `- ` bullet, preserving structure. See ADR 0017.
-  lines.push(INDENT.repeat(depth) + prefixFor(node) + node.text)
+  // `node.text` is mostly already the markdown source (links `[label](url)`,
+  // `#tags`, inline `code`). Route-bible chips are the exception: they store
+  // plain reference text and derive the URL at render time, so export projects
+  // them to portable markdown links. Empty text yields a bare `- ` bullet,
+  // preserving structure. See ADR 0017.
+  lines.push(INDENT.repeat(depth) + prefixFor(node) + bibleRefsToMarkdownLinks(node.text))
   // Full subtree, regardless of collapsed/completed/filter: childrenOf returns
   // the raw ordered children (view state never reaches here).
   for (const child of childrenOf(index, id)) {

--- a/src/plugins/route-bible/bible.test.ts
+++ b/src/plugins/route-bible/bible.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import { resolveBibleRef } from './bible'
+import { bibleRefsToMarkdownLinks, resolveBibleRef } from './bible'
 
 describe('resolveBibleRef', () => {
   test('resolves real references to a route.bible url with attribution', () => {
@@ -17,5 +17,21 @@ describe('resolveBibleRef', () => {
     expect(resolveBibleRef('Revelation 99:99')).toBeNull()
     expect(resolveBibleRef('just some plain text')).toBeNull()
     expect(resolveBibleRef('')).toBeNull()
+  })
+})
+
+describe('bibleRefsToMarkdownLinks', () => {
+  test('converts valid references to route.bible markdown links', () => {
+    expect(bibleRefsToMarkdownLinks('Read John 3:16 today')).toBe(
+      'Read [John 3:16](https://route.bible/jhn.3.16?src=dotflowy) today',
+    )
+  })
+
+  test('leaves invalid candidates and existing markdown/code alone', () => {
+    expect(
+      bibleRefsToMarkdownLinks(
+        'Hello 3 [John 3:16](https://example.com) `Romans 8:28`',
+      ),
+    ).toBe('Hello 3 [John 3:16](https://example.com) `Romans 8:28`')
   })
 })

--- a/src/plugins/route-bible/bible.ts
+++ b/src/plugins/route-bible/bible.ts
@@ -9,6 +9,7 @@
 // gate them.
 
 import { toResolverUrl, tryParsePassage } from "grab-bcv";
+import { LINK_PATTERN, encodeUrlForMarkdown } from "../../data/links";
 
 // The Seam-A token fragment: detection PROPOSES, the parser DISPOSES. Mirrors
 // grab-bcv's own (internal, unexported) natural-text reference pattern, plus a
@@ -50,4 +51,39 @@ export function resolveBibleRef(token: string): { url: string } | null {
   } catch {
     return null;
   }
+}
+
+const CODE_RUN_PATTERN = "`[^`\\n]+`";
+const MARKDOWN_LINK_OR_CODE_RE = () =>
+  new RegExp(`${LINK_PATTERN}|${CODE_RUN_PATTERN}`, "g");
+
+function protectedRanges(text: string): Array<{ start: number; end: number }> {
+  return Array.from(text.matchAll(MARKDOWN_LINK_OR_CODE_RE()), (m) => {
+    const start = m.index ?? 0;
+    return { start, end: start + m[0].length };
+  });
+}
+
+function isProtected(
+  start: number,
+  end: number,
+  ranges: Array<{ start: number; end: number }>,
+): boolean {
+  return ranges.some((r) => start < r.end && end > r.start);
+}
+
+/**
+ * Convert valid route-bible chip sources into ordinary markdown links for
+ * export. Stored text stays plain ("John 3:16"); copied markdown becomes
+ * readable and portable ("[John 3:16](https://route.bible/...)").
+ */
+export function bibleRefsToMarkdownLinks(text: string): string {
+  const ranges = protectedRanges(text);
+  return text.replace(new RegExp(BIBLE_REF_PATTERN, "g"), (token, offset: number) => {
+    const start = offset;
+    const end = start + token.length;
+    if (isProtected(start, end, ranges)) return token;
+    const ref = resolveBibleRef(token);
+    return ref ? `[${token}](${encodeUrlForMarkdown(ref.url)})` : token;
+  });
 }


### PR DESCRIPTION
## Summary
- Convert route-bible references in Markdown copy/export to readable Markdown links.
- Preserve existing Markdown links and inline code while projecting valid Bible refs.
- Add focused unit coverage for the route-bible projection and Markdown export path.

## Verification
- bun test src/data/markdown.test.ts src/plugins/route-bible/bible.test.ts
- bun run typecheck
- bun run lint
- bun run typecheck:test
- bun run test