### PR TITLE
Shared OPML core: parse, map, plan, serialize (OPML build 4/7)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
         "@fontsource-variable/geist": "^5.2.9",
         "@fontsource-variable/geist-mono": "^5.2.8",
         "@icons-pack/react-simple-icons": "^13.13.0",
+        "@rgrove/parse-xml": "^4",
         "@tanstack/query-core": "^5.101.1",
         "@tanstack/query-db-collection": "^1.0.42",
         "@tanstack/react-db": "^0.1.87",
@@ -411,6 +412,8 @@
     "@radix-ui/react-use-escape-keydown": ["@radix-ui/react-use-escape-keydown@1.1.2", "", { "dependencies": { "@radix-ui/react-use-callback-ref": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-2uVLvLjgO7NZCWw01/FdqRwmA42J0BcjPMUCA+koFEOAb+zjqIP7SiFz/7zWPrKnVmSqr76Omq2ALyCuX4dhLw=="],
 
     "@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA=="],
+
+    "@rgrove/parse-xml": ["@rgrove/parse-xml@4.2.1", "", {}, "sha512-ZOkOIicFSf5qXbC+8ps5hA+nEhCxsUDpm2U1xp1BACoUZyMkGXEQjsWLD30K77r1fzOTaqEZS85++fmzwCIOJQ=="],
 
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.1.2", "", { "os": "android", "cpu": "arm64" }, "sha512-2cZ+7xRS+DBcuJBJKnfzsbleumJhBqSlJVpuzHC0nTqfd3QQ7Vx2/x5YR/D7cBamKSeWplwo82Fn9lqYUDEMfA=="],
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@fontsource-variable/geist": "^5.2.9",
     "@fontsource-variable/geist-mono": "^5.2.8",
     "@icons-pack/react-simple-icons": "^13.13.0",
+    "@rgrove/parse-xml": "^4",
     "@tanstack/query-core": "^5.101.1",
     "@tanstack/query-db-collection": "^1.0.42",
     "@tanstack/react-db": "^0.1.87",

--- a/src/data/opml-export.test.ts
+++ b/src/data/opml-export.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Pure-logic tests for the shared OPML export core (src/data/opml-export.ts,
+ * ADR 0037): the Workflowy dialect (`_complete` present-iff-true, two-layer
+ * escaping, `&#10;`), the invented extensions (`_task`, the mirror dialect),
+ * the inline inverse projections, and the acceptance round-trip — a
+ * mirror-bearing export re-imports with the mirror RE-LINKED.
+ */
+
+import { describe, expect, it } from 'bun:test'
+import { Effect } from 'effect'
+import { exportOpml } from './opml-export'
+import {
+  OpmlEmpty,
+  OpmlImportTooLarge,
+  parseOpml,
+  planOpmlImport,
+  type OpmlImportResult,
+} from './opml-import'
+import { buildTreeIndex, makeNode, type TreeIndex } from './tree'
+import type { ChangeOp, Node } from './wire-schema'
+
+const index = (nodes: Node[]): TreeIndex => buildTreeIndex(nodes)
+const reimport = (opml: string): OpmlImportResult => Effect.runSync(parseOpml(opml))
+
+describe('document shape', () => {
+  const idx = index([
+    makeNode({ id: 'a', text: 'alpha' }),
+    makeNode({ id: 'b', parentId: 'a', text: 'bravo', isTask: true, completed: true }),
+  ])
+  const out = exportOpml(idx, null, { title: 'my export' })
+
+  it('emits the OPML 2.0 shell with a title-only head (no ownerEmail)', () => {
+    expect(out).toContain('<?xml version="1.0"?>')
+    expect(out).toContain('<opml version="2.0">')
+    expect(out).toContain('<title>my export</title>')
+    expect(out).not.toContain('ownerEmail')
+  })
+
+  it('emits _complete and _task present-iff-true', () => {
+    expect(out).toContain('<outline _complete="true" _task="true" text="bravo" />')
+    // The parent has neither flag — no attribute noise.
+    expect(out).toContain('<outline text="alpha">')
+  })
+
+  it('drops view state and provenance: no collapsed/bookmarked/origin/timestamps', () => {
+    for (const forbidden of ['collapsed', 'bookmarked', 'origin', 'createdAt']) {
+      expect(out).not.toContain(forbidden)
+    }
+  })
+
+  it('scopes to a zoom root, root included', () => {
+    const zoomed = exportOpml(idx, 'b', { title: 't' })
+    expect(zoomed).toContain('bravo')
+    expect(zoomed).not.toContain('alpha')
+  })
+})
+
+describe('escaping (the two layers, in reverse)', () => {
+  it('double-escapes a literal < (byte-matching Workflowy) and encodes quotes', () => {
+    const idx = index([makeNode({ id: 'a', text: `a < b & "c" 'd'` })])
+    const out = exportOpml(idx, null, { title: 't' })
+    expect(out).toContain(
+      'text="a &amp;lt; b &amp;amp; &amp;quot;c&amp;quot; &#39;d&#39;"',
+    )
+  })
+
+  it('round-trips special characters byte-exact through import', () => {
+    const text = `a < b & "c" 'd' > e`
+    const idx = index([makeNode({ id: 'a', text })])
+    const { forest } = reimport(exportOpml(idx, null, { title: 't' }))
+    expect(forest[0]!.text).toBe(text)
+  })
+
+  it('escapes a newline in text as &#10;', () => {
+    const idx = index([makeNode({ id: 'a', text: 'one\ntwo' })])
+    expect(exportOpml(idx, null, { title: 't' })).toContain('text="one&#10;two"')
+  })
+})
+
+describe('inline inverse projections', () => {
+  const project = (text: string, extra: Node[] = []): string =>
+    exportOpml(index([makeNode({ id: 'a', text }), ...extra]), null, { title: 't' })
+
+  it('projects emphasis, code, and links to Workflowy HTML', () => {
+    const out = project('**b** *i* ~u~ ~~s~~ `c` [l](https://e.com)')
+    expect(out).toContain('&lt;b&gt;b&lt;/b&gt;')
+    expect(out).toContain('&lt;i&gt;i&lt;/i&gt;')
+    expect(out).toContain('&lt;u&gt;u&lt;/u&gt;')
+    expect(out).toContain('&lt;s&gt;s&lt;/s&gt;')
+    expect(out).toContain('&lt;code&gt;c&lt;/code&gt;')
+    expect(out).toContain('&lt;a href=&quot;https://e.com&quot;&gt;l&lt;/a&gt;')
+  })
+
+  it('exports the underscore italic alias identically to *i*', () => {
+    expect(project('_i_')).toContain('&lt;i&gt;i&lt;/i&gt;')
+  })
+
+  it('projects highlights to bc-* classes, emoji stripped (blue -> bc-sky)', () => {
+    const out = project('==plain== and ==🔴hot==')
+    expect(out).toContain('&lt;mark class=&quot;colored bc-sky&quot;&gt;plain&lt;/mark&gt;')
+    expect(out).toContain('&lt;mark class=&quot;colored bc-red&quot;&gt;hot&lt;/mark&gt;')
+    expect(out).not.toContain('🔴')
+  })
+
+  it('rebuilds <time start…> from the date token with regenerated display', () => {
+    const out = project('due [[2026-07-08]]')
+    expect(out).toContain(
+      '&lt;time startYear=&quot;2026&quot; startMonth=&quot;7&quot; startDay=&quot;8&quot;&gt;Wed, Jul 8, 2026&lt;/time&gt;',
+    )
+  })
+
+  it('carries the token time into startHour (no startMinute for :00)', () => {
+    const out = project('[[2024-02-03 13:00]]')
+    expect(out).toContain('startHour=&quot;13&quot;')
+    expect(out).not.toContain('startMinute')
+    expect(out).toContain('at 1:00pm')
+  })
+
+  it('projects node links to app URLs labeled with the flattened target text', () => {
+    const targetId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+    const out = project(`see [[${targetId}]]`, [
+      makeNode({ id: targetId, text: 'target **bold**' }),
+    ])
+    expect(out).toContain(
+      `&lt;a href=&quot;https://app.dotflowy.com/${targetId}&quot;&gt;target bold&lt;/a&gt;`,
+    )
+  })
+
+  it('projects Bible refs to route.bible links', () => {
+    const out = project('read John 3:16 today')
+    expect(out).toContain('route.bible')
+    expect(out).toContain('&gt;John 3:16&lt;/a&gt;')
+  })
+
+  it('passes #tags and literal markers through as plain text', () => {
+    const out = project('#tag and a lone * star')
+    expect(out).toContain('text="#tag and a lone * star"')
+  })
+})
+
+describe('mirror dialect', () => {
+  const nodes = [
+    makeNode({ id: 'src', text: 'source' }),
+    makeNode({ id: 'kid', parentId: 'src', text: 'kid' }),
+    makeNode({ id: 'mir', text: 'source', mirrorOf: 'src', prevSiblingId: 'src' }),
+  ]
+
+  it('emits id on the in-scope source and _mirror over a resolved duplicate', () => {
+    const out = exportOpml(index(nodes), null, { title: 't' })
+    expect(out).toContain('id="src"')
+    expect(out).toContain('_mirror="src"')
+    // The mirror expands the full resolved duplicate — the kid appears twice.
+    expect(out.split('text="kid"').length - 1).toBe(2)
+  })
+
+  it('caps a mirror cycle: a mirror of its own ancestor emits no children', () => {
+    const cyclic = index([
+      makeNode({ id: 'a', text: 'ancestor' }),
+      makeNode({ id: 'm', parentId: 'a', text: 'ancestor', mirrorOf: 'a' }),
+    ])
+    const out = exportOpml(cyclic, null, { title: 't' })
+    // The mirror row is self-closing: its source is already on the path.
+    expect(out).toContain('<outline _mirror="a" text="ancestor" />')
+  })
+})
+
+describe('round-trip: export -> import re-links mirrors (the acceptance test)', () => {
+  const nodes = [
+    makeNode({ id: 'src', text: 'source **bold**' }),
+    makeNode({ id: 'kid', parentId: 'src', text: 'kid ==🟢go== [[2026-07-08]]' }),
+    makeNode({ id: 'mir', text: 'source **bold**', mirrorOf: 'src', prevSiblingId: 'src' }),
+    makeNode({ id: 'p', text: 'plain `code` last', prevSiblingId: 'mir' }),
+  ]
+  const opml = exportOpml(index(nodes), null, { title: 'round trip' })
+  const { forest, report } = reimport(opml)
+
+  it('re-links the mirror and drops its duplicate subtree', () => {
+    expect(report.mirrorsLinked).toBe(1)
+    expect(report.mirrorsDetached).toBe(0)
+    expect(forest[1]!.mirrorOfOpmlId).toBe('src')
+    expect(forest[1]!.children).toEqual([])
+  })
+
+  it('round-trips formatted text byte-exact', () => {
+    expect(forest[0]!.text).toBe('source **bold**')
+    expect(forest[0]!.children[0]!.text).toBe('kid ==🟢go== [[2026-07-08]]')
+    expect(forest[2]!.text).toBe('plain `code` last')
+    expect(report.degradedTotal).toBe(0)
+  })
+
+  it('plans the re-imported forest with a REAL mirror pointer', () => {
+    let n = 0
+    const plan = planOpmlImport(forest, {
+      parentId: null,
+      firstPrev: null,
+      timestamp: 7,
+      newId: () => `new${++n}`,
+      maxNodes: 100,
+    })
+    if (plan instanceof OpmlEmpty || plan instanceof OpmlImportTooLarge) {
+      throw new Error('expected a plan')
+    }
+    const inserted = plan.ops.flatMap((op: ChangeOp) =>
+      op.op === 'insert' ? [op.value] : [],
+    )
+    const source = inserted.find((v) => v.text === 'source **bold**' && v.mirrorOf === null)!
+    const mirror = inserted.find((v) => v.mirrorOf !== null)!
+    expect(mirror.mirrorOf).toBe(source.id)
+  })
+})

--- a/src/data/opml-export.ts
+++ b/src/data/opml-export.ts
@@ -1,0 +1,338 @@
+// Shared OPML export core (ADR 0037): a TreeIndex scope -> one OPML string in
+// the Workflowy dialect (`text` with escaped inline HTML, `_complete`
+// present-iff-true, `&#10;` newlines) plus dotflowy's invented extensions
+// (`_task`, and the mirror dialect: `id` on in-scope mirror sources,
+// `_mirror="<sourceId>"` on mirror roots over a fully resolved duplicate).
+// Both surfaces — the app's export action and the MCP `export_opml` tool —
+// serialize through THIS module, the wire-schema.ts shared-leaf precedent.
+//
+// The serializer is hand-rolled on purpose (~30 lines: escape `& < > " '`,
+// newlines as `&#10;` in attributes) — the output shape stays fully under our
+// control, and Workflowy imports it cleanly (live-verified, ADR 0037).
+// Content, never state: `collapsed`, `bookmarkedAt`, `origin`, and timestamps
+// are deliberately dropped.
+//
+// Pure leaf: imports only the pure token layers (plus the route-bible pure
+// module, the markdown.ts precedent) — no DOM globals, no workers types.
+
+import { LINK_PATTERN, sanitizeLinkLabel } from './links'
+import { DATE_LINK_PATTERN, parseDateLink } from './date-links'
+import {
+  BOLD_PATTERN,
+  ITALIC_PATTERN,
+  ITALIC_UNDERSCORE_PATTERN,
+  STRIKETHROUGH_PATTERN,
+  UNDERLINE_PATTERN,
+  emphasisMarkerLen,
+} from './emphasis'
+import { HIGHLIGHT_PATTERN, parseHighlight, type HighlightColor } from './highlight'
+import { NODE_LINK_PATTERN, linkTargetId, linkedNodeLabel } from './node-links'
+import { childrenOf, trueSourceOf, type TreeIndex } from './tree'
+import { bibleRefsToMarkdownLinks } from '../plugins/route-bible/bible'
+
+/** Where a `[[nodeId]]` link resolves for the export projection. Derives from
+ *  one place instead of being scattered as literals (ADR 0037). */
+export const DEFAULT_APP_ORIGIN = 'https://app.dotflowy.com'
+
+export interface OpmlExportOptions {
+  /** `<head><title>` — the ONLY head element (no `ownerEmail`: a privacy leak
+   *  in a shareable file, ADR 0037). */
+  title: string
+  /** Origin for node-link `<a href>` projections. */
+  appOrigin?: string
+}
+
+// --- Escaping -------------------------------------------------------------------
+// Export mirrors the two-layer decode in reverse (ADR 0037): compose the
+// inline HTML first (content HTML-escaped), then XML-escape the whole
+// attribute value — so a literal `<` in node.text lands as `&amp;lt;`,
+// byte-matching Workflowy's own output.
+
+/** Layer 1 (inner): escape text that becomes HTML *content* or an HTML
+ *  attribute value inside the composed rich-text string. */
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}
+
+/** Layer 2 (outer): escape a whole XML attribute value. Newlines become
+ *  `&#10;` — the dialect's only numeric reference. */
+function escapeXmlAttr(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+    .replace(/\n/g, '&#10;')
+}
+
+/** XML element text content (the `<title>`). */
+function escapeXmlText(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
+// --- Inline projection: dotflowy tokens -> Workflowy HTML --------------------------
+// The exact inverse of the import table (#114), plus the dotflowy-only
+// projections (node links, Bible refs). One combined scan in registry
+// precedence order — alternation order mirrors the token registry, so the
+// export tokenizes a line exactly as the editor renders it. Text that didn't
+// tokenize stays plain (never invent markup for literal `*`/`~`/`[`).
+
+const CODE_RUN_PATTERN = '`[^`\\n]+`'
+
+/** Alternation in ascending registry precedence: links 0 < node-links 5 <
+ *  date 6 < code 10 < bold 30 < strike 31 < italic 32 < underline 33 <
+ *  underscore-italic 34 < highlight 35. (Bible refs, precedence 15, are
+ *  pre-projected to markdown links before this scan — the markdown.ts
+ *  precedent — so the LINK branch handles them.) Built per call: a `g` regex
+ *  carries `lastIndex`. */
+function tokenRegex(): RegExp {
+  return new RegExp(
+    [
+      LINK_PATTERN,
+      NODE_LINK_PATTERN,
+      DATE_LINK_PATTERN,
+      CODE_RUN_PATTERN,
+      BOLD_PATTERN,
+      STRIKETHROUGH_PATTERN,
+      ITALIC_PATTERN,
+      UNDERLINE_PATTERN,
+      ITALIC_UNDERSCORE_PATTERN,
+      HIGHLIGHT_PATTERN,
+    ].join('|'),
+    'gu',
+  )
+}
+
+const MD_LINK_RE = /^\[([^\]]*)\]\(([^)]*)\)$/
+
+/** dotflowy highlight color -> the nearest OBSERVED Workflowy background
+ *  class (blue -> `bc-sky`; the leading circle emoji is encoding, not
+ *  content, and is stripped). Text-color provenance (`c-*`) is never
+ *  reconstructed — everything exports as `bc-*` (ADR 0037). */
+const HIGHLIGHT_CLASS: Record<HighlightColor, string> = {
+  red: 'bc-red',
+  orange: 'bc-orange',
+  yellow: 'bc-yellow',
+  green: 'bc-green',
+  blue: 'bc-sky',
+  purple: 'bc-purple',
+}
+
+const WEEKDAYS_SHORT = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as const
+const MONTHS_SHORT = [
+  'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+] as const
+
+/** `<time>` display text regenerated from the canonical date — Workflowy's
+ *  own shape ("Wed, Jul 8, 2026", "… at 1:00pm"). Deterministic English: the
+ *  Worker has no user locale, and Workflowy rebuilds its pill from the
+ *  ATTRIBUTES anyway (the display text is redundant, #112). */
+function formatTimeDisplay(key: string, time: string | null): string {
+  const [y, mo, d] = key.split('-').map(Number) as [number, number, number]
+  const date = new Date(Date.UTC(y, mo - 1, d, 12))
+  let display = `${WEEKDAYS_SHORT[date.getUTCDay()]}, ${MONTHS_SHORT[mo - 1]} ${d}, ${y}`
+  if (time !== null) {
+    const [hh, mm] = time.split(':').map(Number) as [number, number]
+    const h12 = hh % 12 === 0 ? 12 : hh % 12
+    display += ` at ${h12}:${String(mm).padStart(2, '0')}${hh < 12 ? 'am' : 'pm'}`
+  }
+  return display
+}
+
+/** The ADR 0038 date token -> `<time start…>display</time>` — a TRUE
+ *  round-trip: Workflowy rebuilds a live pill from the attrs, and our import
+ *  rebuilds the token. Attrs are unpadded, matching Workflowy's serializer;
+ *  `startMinute` is emitted only when non-zero (the dialect omits it for :00). */
+function dateTokenToTime(tok: string): string | null {
+  const parsed = parseDateLink(tok)
+  if (!parsed) return null
+  const [y, mo, d] = parsed.key.split('-').map(Number) as [number, number, number]
+  let attrs = ` startYear="${y}" startMonth="${mo}" startDay="${d}"`
+  if (parsed.time !== null) {
+    const [hh, mm] = parsed.time.split(':').map(Number) as [number, number]
+    attrs += ` startHour="${hh}"`
+    if (mm !== 0) attrs += ` startMinute="${mm}"`
+  }
+  return `<time${attrs}>${escapeHtml(formatTimeDisplay(parsed.key, parsed.time))}</time>`
+}
+
+function tokenToHtml(tok: string, index: TreeIndex, appOrigin: string): string {
+  // `[[…]]` family first: date-shaped and id-shaped interiors are disjoint.
+  if (tok.startsWith('[[')) {
+    const asTime = dateTokenToTime(tok)
+    if (asTime !== null) return asTime
+    // Node link -> an app URL with the target's flattened text as the label
+    // (one level deep; a missing target keeps the id so nothing is lost).
+    const targetId = linkTargetId(tok)
+    const target = index.byId.get(targetId)
+    const label = target
+      ? sanitizeLinkLabel(linkedNodeLabel(target.text)) || targetId
+      : targetId
+    return `<a href="${escapeHtml(`${appOrigin}/${targetId}`)}">${escapeHtml(label)}</a>`
+  }
+  if (tok.startsWith('[')) {
+    const m = MD_LINK_RE.exec(tok)
+    if (!m) return escapeHtml(tok)
+    return `<a href="${escapeHtml(m[2] ?? '')}">${escapeHtml(m[1] ?? '')}</a>`
+  }
+  if (tok.startsWith('==')) {
+    const { color, interior } = parseHighlight(tok)
+    return `<mark class="colored ${HIGHLIGHT_CLASS[color]}">${escapeHtml(interior)}</mark>`
+  }
+  if (tok.startsWith('`')) {
+    return `<code>${escapeHtml(tok.slice(1, -1))}</code>`
+  }
+  // Emphasis: same marker char both edges, length 1 or 2.
+  const markerLen = emphasisMarkerLen(tok)
+  if (markerLen === 0) return escapeHtml(tok) // defensive — patterns always match
+  const interior = escapeHtml(tok.slice(markerLen, tok.length - markerLen))
+  const marker = tok.slice(0, markerLen)
+  if (marker === '**') return `<b>${interior}</b>`
+  if (marker === '~~') return `<s>${interior}</s>`
+  if (marker === '~') return `<u>${interior}</u>`
+  // `*` and the render-only `_` alias both export as italic (#114).
+  return `<i>${interior}</i>`
+}
+
+/** One node's `text` -> the composed inline-HTML string (NOT yet
+ *  XML-escaped). `#tags` are plain text in Workflowy — direct pass-through. */
+function projectText(text: string, index: TreeIndex, appOrigin: string): string {
+  // Bible refs become ordinary markdown links first (resolve-or-literal with
+  // link/code ranges protected — reuses the shipped markdown-export path).
+  const source = bibleRefsToMarkdownLinks(text)
+  const re = tokenRegex()
+  let out = ''
+  let last = 0
+  for (let m = re.exec(source); m; m = re.exec(source)) {
+    if (m.index > last) out += escapeHtml(source.slice(last, m.index))
+    out += tokenToHtml(m[0], index, appOrigin)
+    last = re.lastIndex
+  }
+  if (last < source.length) out += escapeHtml(source.slice(last))
+  return out
+}
+
+// --- The scope walk + serializer ------------------------------------------------------
+
+const INDENT = '  '
+
+interface ExportState {
+  index: TreeIndex
+  appOrigin: string
+  /** In-scope mirror sources that need an `id` attribute. */
+  sourcesNeedingId: ReadonlySet<string>
+  lines: string[]
+}
+
+/**
+ * Emit one node at `depth`. `inExpansion` is true inside a mirror's resolved
+ * duplicate: those rows are interchange filler (Workflowy sees a plain copy),
+ * so they carry no `id`/`_mirror` attrs. `sourcesOnPath` caps mirror cycles —
+ * a mirror whose source is already an ancestor on this path emits its
+ * resolved text but no children (the flattenSubtree rule).
+ */
+function emitNode(
+  state: ExportState,
+  id: string,
+  depth: number,
+  sourcesOnPath: ReadonlySet<string>,
+  inExpansion: boolean,
+): void {
+  const { index } = state
+  const node = index.byId.get(id)
+  if (!node) return
+  const contentId = trueSourceOf(index, id)
+  const content = index.byId.get(contentId) ?? node
+  const isMirror = node.mirrorOf !== null
+  const capped = isMirror && sourcesOnPath.has(contentId)
+
+  let attrs = ''
+  if (content.completed) attrs += ' _complete="true"'
+  if (content.isTask) attrs += ' _task="true"'
+  if (!inExpansion) {
+    if (state.sourcesNeedingId.has(id)) attrs += ` id="${escapeXmlAttr(id)}"`
+    if (isMirror) attrs += ` _mirror="${escapeXmlAttr(contentId)}"`
+  }
+  attrs += ` text="${escapeXmlAttr(projectText(content.text, index, state.appOrigin))}"`
+
+  const children = capped ? [] : childrenOf(index, contentId)
+  const pad = INDENT.repeat(depth + 2) // inside <opml><body>
+  if (children.length === 0) {
+    state.lines.push(`${pad}<outline${attrs} />`)
+    return
+  }
+  state.lines.push(`${pad}<outline${attrs}>`)
+  const nextSources = new Set(sourcesOnPath)
+  nextSources.add(contentId)
+  for (const child of children) {
+    emitNode(state, child.id, depth + 1, nextSources, inExpansion || isMirror)
+  }
+  state.lines.push(`${pad}</outline>`)
+}
+
+/** Own-position pass: which node ids are in scope, and which of them are the
+ *  true source of an in-scope mirror. A mirror's expansion is NOT an own
+ *  position, so the walk doesn't descend into it. */
+function collectScope(
+  index: TreeIndex,
+  rootIds: readonly string[],
+): { scopeIds: Set<string>; mirrorSources: Set<string> } {
+  const scopeIds = new Set<string>()
+  const mirrorSources = new Set<string>()
+  const stack = [...rootIds]
+  while (stack.length) {
+    const id = stack.pop()!
+    const node = index.byId.get(id)
+    if (!node || scopeIds.has(id)) continue
+    scopeIds.add(id)
+    if (node.mirrorOf !== null) {
+      mirrorSources.add(trueSourceOf(index, id))
+      continue
+    }
+    for (const child of childrenOf(index, id)) stack.push(child.id)
+  }
+  return { scopeIds, mirrorSources }
+}
+
+/**
+ * Serialize a scope — the zoom root's subtree (root INCLUDED), or the whole
+ * outline for a null root — to one OPML 2.0 string in the Workflowy dialect.
+ * `<head>` is `<title>` only. View state (`collapsed`, filters) never reaches
+ * here: content, never state (ADR 0037).
+ */
+export function exportOpml(
+  index: TreeIndex,
+  rootId: string | null,
+  options: OpmlExportOptions,
+): string {
+  const appOrigin = options.appOrigin ?? DEFAULT_APP_ORIGIN
+  const rootIds =
+    rootId === null ? childrenOf(index, null).map((n) => n.id) : [rootId]
+
+  const { scopeIds, mirrorSources } = collectScope(index, rootIds)
+  const sourcesNeedingId = new Set<string>()
+  for (const sourceId of mirrorSources) {
+    if (scopeIds.has(sourceId)) sourcesNeedingId.add(sourceId)
+  }
+
+  const state: ExportState = { index, appOrigin, sourcesNeedingId, lines: [] }
+  for (const id of rootIds) emitNode(state, id, 0, new Set(), false)
+
+  return [
+    '<?xml version="1.0"?>',
+    '<opml version="2.0">',
+    '  <head>',
+    `    <title>${escapeXmlText(options.title)}</title>`,
+    '  </head>',
+    '  <body>',
+    ...state.lines,
+    '  </body>',
+    '</opml>',
+  ].join('\n')
+}

--- a/src/data/opml-import.test.ts
+++ b/src/data/opml-import.test.ts
@@ -1,0 +1,416 @@
+/**
+ * Pure-logic tests for the shared OPML import core (src/data/opml-import.ts,
+ * ADR 0037). The headline acceptance: the crafted Workflowy sample
+ * (docs/spec-assets/opml/workflowy-crafted-sample.opml) imports with the
+ * EXACT degradation counts the fidelity probe reported
+ * (docs/spec-assets/opml/fidelity-probe-report.md) — the "degraded, never
+ * silent" bar, pinned. Plus the failure modes the parser was chosen for:
+ * truncation fails with line/column (never a partial plan), the entity bomb
+ * is rejected, and the raw-size guard fires before parsing.
+ */
+
+import { describe, expect, it } from 'bun:test'
+import { Effect } from 'effect'
+import {
+  OpmlEmpty,
+  OpmlImportTooLarge,
+  OpmlParseError,
+  OpmlTooLarge,
+  parseOpml,
+  planOpmlImport,
+  type OpmlImportNode,
+  type OpmlImportResult,
+} from './opml-import'
+import type { ChangeOp, Node } from './wire-schema'
+
+const SAMPLE_PATH = `${import.meta.dir}/../../docs/spec-assets/opml/workflowy-crafted-sample.opml`
+const sampleOpml = await Bun.file(SAMPLE_PATH).text()
+
+const run = (src: string): OpmlImportResult => Effect.runSync(parseOpml(src))
+const runFail = (src: string, options?: { maxLength?: number }) =>
+  Effect.runSync(Effect.flip(parseOpml(src, options)))
+
+/** Wrap an escaped body in a minimal OPML shell. */
+const doc = (body: string): string =>
+  `<?xml version="1.0"?>\n<opml version="2.0"><head></head><body>${body}</body></opml>`
+
+describe('crafted Workflowy sample (the fidelity-probe pin)', () => {
+  const { forest, report } = run(sampleOpml)
+  const root = forest[0]!
+  const texts = root.children.map((c) => c.text)
+
+  it('reproduces the probe scale numbers: 21 pre -> 23 post-split', () => {
+    expect(report.nodesPre).toBe(21)
+    expect(report.nodesPost).toBe(23)
+    expect(report.emptyText).toBe(0)
+    expect(report.textNewlineSplits).toBe(0)
+  })
+
+  it('reproduces the probe degradation counts EXACTLY', () => {
+    expect(report.degraded).toEqual({
+      'nested <mark> dropped (outermost wins)': 2,
+      '<mention> -> @mention(id) (name unrecoverable)': 1,
+    })
+    expect(report.degradedTotal).toBe(3)
+  })
+
+  it('reproduces the probe note split: 1 note -> 2 bullets, 1 blank dropped', () => {
+    expect(report.notes).toBe(1)
+    expect(report.noteLines).toBe(2)
+    expect(report.noteBlanksDropped).toBe(1)
+  })
+
+  it('finds no anomalies, no unknown attributes, no mirrors in the sample', () => {
+    expect(report.anomalies).toEqual({})
+    expect(report.unknownAttributes).toEqual({})
+    expect(report.mirrorsLinked).toBe(0)
+    expect(report.mirrorsDetached).toBe(0)
+  })
+
+  it('two-layer decodes: &amp;lt; survives as a literal <', () => {
+    expect(texts[0]).toBe(
+      'plain text with special chars < > & " \' and emoji 🙂🚀',
+    )
+  })
+
+  it('maps the emphasis/code tags to the shipped tokens', () => {
+    expect(texts[1]).toBe('**bold text**')
+    expect(texts[2]).toBe('*italic text*')
+    expect(texts[3]).toBe('~underline text~')
+    expect(texts[4]).toBe('~~strikethrough and colored text~~') // nested marks dropped
+    expect(texts[5]).toBe('`inline code text`')
+  })
+
+  it('maps <a> to [label](url) with the XML layer decoded', () => {
+    expect(texts[6]).toBe('[a labeled link](https://example.com/path?q=1&r=2)')
+    expect(texts[7]).toBe(
+      'bare url [https://workflowy.com](https://workflowy.com) in text',
+    )
+  })
+
+  it('adopts <time> as the ADR 0038 date token, keyed on canonical attrs', () => {
+    expect(texts[8]).toBe('due [[2026-07-08]] ')
+  })
+
+  it('splits the _note into prepended child bullets, blanks dropped', () => {
+    const noteNode = root.children[9]!
+    expect(noteNode.text).toBe('bullet with a multi-line note')
+    expect(noteNode.children.map((c) => c.text)).toEqual([
+      'note line one with a link [https://example.com/notes?x=1&y=2](https://example.com/notes?x=1&y=2)',
+      'note line two after a hard newline',
+    ])
+  })
+
+  it('degrades <mention> to the @mention(id) placeholder', () => {
+    expect(texts[10]).toBe(
+      'tagged #dotflowy #import-test and a mention @mention(2544228)  and a tag-style time @work',
+    )
+  })
+
+  it('honors _complete and keeps deep nesting intact', () => {
+    expect(root.children[11]!.completed).toBe(true)
+    let cursor = root.children[14]!
+    const chain = [cursor.text]
+    while (cursor.children.length) {
+      cursor = cursor.children[0]!
+      chain.push(cursor.text)
+    }
+    expect(chain).toEqual([
+      'level 1 of deep nesting',
+      'level 2',
+      'level 3',
+      'level 4',
+      'level 5',
+      'level 6 deepest',
+    ])
+  })
+})
+
+describe('tolerant inline-HTML scanner', () => {
+  it('tolerates cross-bullet <b> spans: text kept, anomalies counted', () => {
+    const { forest, report } = run(
+      doc(
+        '<outline text="see &lt;b&gt;bold start" />' +
+          '<outline text="end&lt;/b&gt; here" />',
+      ),
+    )
+    // The unclosed <b> auto-closes at end of value (still a bold run); the
+    // stray </b> is ignored. Nothing is rejected, nothing lost.
+    expect(forest[0]!.text).toBe('see **bold start**')
+    expect(forest[1]!.text).toBe('end here')
+    expect(report.anomalies).toEqual({ 'unclosed <b>': 1, 'stray </b>': 1 })
+  })
+
+  it('drops formatting on a marker-char clash, keeping the text', () => {
+    const { forest, report } = run(doc('<outline text="&lt;b&gt;a*b&lt;/b&gt;" />'))
+    expect(forest[0]!.text).toBe('a*b')
+    expect(report.degraded['<b> dropped: marker char in interior']).toBe(1)
+  })
+
+  it('link wins over formatting: styling dropped, link intact', () => {
+    const { forest, report } = run(
+      doc(
+        '<outline text="&lt;b&gt;&lt;a href=&quot;https://e.com&quot;&gt;go&lt;/a&gt;&lt;/b&gt;" />',
+      ),
+    )
+    expect(forest[0]!.text).toBe('[go](https://e.com)')
+    expect(report.degraded['<b> dropped: contains a link (link wins)']).toBe(1)
+  })
+
+  it('strips unknown tags to their inner text, counted', () => {
+    const { forest, report } = run(
+      doc('<outline text="&lt;span&gt;kept&lt;/span&gt;" />'),
+    )
+    expect(forest[0]!.text).toBe('kept')
+    expect(report.degraded['unknown <span> stripped, text kept']).toBe(1)
+  })
+
+  it('maps gray marks to the bare default run (no white in the palette)', () => {
+    const { forest, report } = run(
+      doc(
+        '<outline text="&lt;mark class=&quot;colored bc-gray&quot;&gt;g&lt;/mark&gt;" />',
+      ),
+    )
+    expect(forest[0]!.text).toBe('==g==')
+    expect(report.degraded['<mark gray> -> bare == (no white in the palette)']).toBe(1)
+  })
+
+  it('canonicalizes bc-sky to the BARE default-blue run', () => {
+    const { forest } = run(
+      doc(
+        '<outline text="&lt;mark class=&quot;colored bc-sky&quot;&gt;s&lt;/mark&gt;" />',
+      ),
+    )
+    expect(forest[0]!.text).toBe('==s==')
+  })
+
+  it('maps bc-red to the red-emoji run', () => {
+    const { forest } = run(
+      doc(
+        '<outline text="&lt;mark class=&quot;colored bc-red&quot;&gt;hot&lt;/mark&gt;" />',
+      ),
+    )
+    expect(forest[0]!.text).toBe('==🔴hot==')
+  })
+})
+
+describe('<time> mapping (ADR 0038)', () => {
+  it('carries startHour into the token time', () => {
+    const { forest } = run(
+      doc(
+        '<outline text="&lt;time startYear=&quot;2024&quot; startMonth=&quot;2&quot; startDay=&quot;3&quot; startHour=&quot;13&quot;&gt;Sat, Feb 3, 2024 at 1:00pm&lt;/time&gt;" />',
+      ),
+    )
+    expect(forest[0]!.text).toBe('[[2024-02-03 13:00]]')
+  })
+
+  it('keeps the display text when the attrs are not a real calendar day', () => {
+    const { forest, report } = run(
+      doc(
+        '<outline text="&lt;time startYear=&quot;2026&quot; startMonth=&quot;13&quot; startDay=&quot;45&quot;&gt;bogus date&lt;/time&gt;" />',
+      ),
+    )
+    expect(forest[0]!.text).toBe('bogus date')
+    expect(
+      report.degraded['<time> missing canonical start attrs -> display text kept'],
+    ).toBe(1)
+  })
+
+  it('keeps the display text when the canonical attrs are missing', () => {
+    const { forest, report } = run(
+      doc('<outline text="&lt;time&gt;someday&lt;/time&gt;" />'),
+    )
+    expect(forest[0]!.text).toBe('someday')
+    expect(
+      report.degraded['<time> missing canonical start attrs -> display text kept'],
+    ).toBe(1)
+  })
+})
+
+describe('text newlines and notes', () => {
+  it('splits &#10; in text into continuation bullets BEFORE note lines', () => {
+    const { forest, report } = run(
+      doc('<outline text="first&#10;second" _note="note line" />'),
+    )
+    expect(forest[0]!.text).toBe('first')
+    expect(forest[0]!.children.map((c) => c.text)).toEqual(['second', 'note line'])
+    expect(report.textNewlineSplits).toBe(1)
+    expect(report.notes).toBe(1)
+    expect(report.noteLines).toBe(1)
+  })
+})
+
+describe('mirror re-link (the dotflowy dialect)', () => {
+  it('re-links a _mirror to an in-document id and drops the duplicate subtree', () => {
+    const { forest, report } = run(
+      doc(
+        '<outline id="src1" text="source"><outline text="kid" /></outline>' +
+          '<outline _mirror="src1" text="source"><outline text="kid" /></outline>',
+      ),
+    )
+    expect(report.mirrorsLinked).toBe(1)
+    expect(report.mirrorsDetached).toBe(0)
+    const mirror = forest[1]!
+    expect(mirror.mirrorOfOpmlId).toBe('src1')
+    expect(mirror.children).toEqual([])
+    expect(forest[0]!.opmlId).toBe('src1')
+    expect(forest[0]!.children.map((c) => c.text)).toEqual(['kid'])
+  })
+
+  it('imports an unresolvable _mirror as a disclosed detached copy', () => {
+    const { forest, report } = run(
+      doc('<outline _mirror="gone" text="copy"><outline text="kid" /></outline>'),
+    )
+    expect(report.mirrorsLinked).toBe(0)
+    expect(report.mirrorsDetached).toBe(1)
+    expect(report.degraded['mirror detached (source not in this document)']).toBe(1)
+    const copy = forest[0]!
+    expect(copy.mirrorOfOpmlId).toBeNull()
+    expect(copy.children.map((c) => c.text)).toEqual(['kid'])
+  })
+
+  it('imports _task and counts unknown attributes', () => {
+    const { forest, report } = run(doc('<outline text="t" _task="true" _uuid="x" />'))
+    expect(forest[0]!.isTask).toBe(true)
+    expect(report.unknownAttributes).toEqual({ _uuid: 1 })
+  })
+})
+
+describe('failure modes (never a partial plan)', () => {
+  it('fails a truncated document with line/column', () => {
+    const error = runFail(sampleOpml.slice(0, 200))
+    expect(error).toBeInstanceOf(OpmlParseError)
+    const parseError = error as OpmlParseError
+    expect(parseError.line).toBeGreaterThan(0)
+    expect(parseError.column).toBeGreaterThan(0)
+  })
+
+  it('rejects the entity bomb', () => {
+    const bomb =
+      '<?xml version="1.0"?><!DOCTYPE lolz [<!ENTITY lol "lol"><!ENTITY lol2 "&lol;&lol;&lol;">]>' +
+      '<opml version="2.0"><body><outline text="&lol2;" /></body></opml>'
+    expect(runFail(bomb)).toBeInstanceOf(OpmlParseError)
+  })
+
+  it('guards raw size BEFORE parsing', () => {
+    const error = runFail(sampleOpml, { maxLength: 100 })
+    expect(error).toBeInstanceOf(OpmlTooLarge)
+  })
+
+  it('rejects a well-formed non-OPML document', () => {
+    const error = runFail('<foo><bar /></foo>')
+    expect(error).toBeInstanceOf(OpmlParseError)
+    expect((error as OpmlParseError).line).toBeNull()
+  })
+})
+
+// --- Planner ---------------------------------------------------------------------
+
+const plain = (text: string, children: OpmlImportNode[] = []): OpmlImportNode => ({
+  text,
+  completed: false,
+  isTask: false,
+  opmlId: null,
+  mirrorOfOpmlId: null,
+  children,
+})
+
+const counterId = (): (() => string) => {
+  let n = 0
+  return () => `id${++n}`
+}
+
+const insertedNodes = (ops: ChangeOp[]): Node[] =>
+  ops.flatMap((op) => (op.op === 'insert' ? [op.value] : []))
+
+describe('planOpmlImport', () => {
+  it('wires sibling chains correct-by-construction as ONE batch', () => {
+    const forest = [plain('A', [plain('B'), plain('C')]), plain('D')]
+    const plan = planOpmlImport(forest, {
+      parentId: 'p',
+      firstPrev: 'anchor',
+      timestamp: 42,
+      newId: counterId(),
+      maxNodes: 100,
+    })
+    if (plan instanceof OpmlEmpty || plan instanceof OpmlImportTooLarge) {
+      throw new Error('expected a plan')
+    }
+    expect(plan.count).toBe(4)
+    const nodes = insertedNodes(plan.ops)
+    expect(nodes.map((n) => [n.text, n.parentId, n.prevSiblingId])).toEqual([
+      ['A', 'p', 'anchor'],
+      ['B', 'id1', null],
+      ['C', 'id1', 'id2'],
+      ['D', 'p', 'id1'],
+    ])
+    expect(plan.rootIds).toEqual(['id1', 'id4'])
+    for (const n of nodes) {
+      expect(n.createdAt).toBe(42)
+      expect(n.updatedAt).toBe(42)
+    }
+  })
+
+  it('carries completed / isTask / origin onto the inserted nodes', () => {
+    const forest: OpmlImportNode[] = [
+      { ...plain('done'), completed: true, isTask: true },
+    ]
+    const plan = planOpmlImport(forest, {
+      parentId: null,
+      firstPrev: null,
+      origin: 'test-agent',
+      timestamp: 1,
+      newId: counterId(),
+      maxNodes: 10,
+    })
+    if (plan instanceof OpmlEmpty || plan instanceof OpmlImportTooLarge) {
+      throw new Error('expected a plan')
+    }
+    const [node] = insertedNodes(plan.ops)
+    expect(node!.completed).toBe(true)
+    expect(node!.isTask).toBe(true)
+    expect(node!.origin).toBe('test-agent')
+  })
+
+  it('resolves a mirror to the minted id of its source, even forward-referenced', () => {
+    const mirror: OpmlImportNode = { ...plain('source'), mirrorOfOpmlId: 'src1' }
+    const source: OpmlImportNode = { ...plain('source'), opmlId: 'src1' }
+    const plan = planOpmlImport([mirror, source], {
+      parentId: null,
+      firstPrev: null,
+      timestamp: 1,
+      newId: counterId(),
+      maxNodes: 10,
+    })
+    if (plan instanceof OpmlEmpty || plan instanceof OpmlImportTooLarge) {
+      throw new Error('expected a plan')
+    }
+    const nodes = insertedNodes(plan.ops)
+    expect(nodes[0]!.mirrorOf).toBe('id2')
+    expect(nodes[1]!.mirrorOf).toBeNull()
+  })
+
+  it('fails the WHOLE call over the ceiling — no partial plan', () => {
+    const forest = [plain('A', [plain('B'), plain('C'), plain('D')])]
+    const plan = planOpmlImport(forest, {
+      parentId: null,
+      firstPrev: null,
+      timestamp: 1,
+      newId: counterId(),
+      maxNodes: 3,
+    })
+    expect(plan).toBeInstanceOf(OpmlImportTooLarge)
+    expect((plan as OpmlImportTooLarge).count).toBe(4)
+  })
+
+  it('rejects an empty forest', () => {
+    const plan = planOpmlImport([], {
+      parentId: null,
+      firstPrev: null,
+      timestamp: 1,
+      newId: counterId(),
+      maxNodes: 10,
+    })
+    expect(plan).toBeInstanceOf(OpmlEmpty)
+  })
+})

--- a/src/data/opml-import.ts
+++ b/src/data/opml-import.ts
@@ -1,0 +1,763 @@
+// Shared OPML import core (ADR 0037): OPML source -> intermediate forest ->
+// `ChangeOp[]` plan. The wire-schema.ts shared-leaf precedent, import
+// direction: BOTH the app UI dialog and the Worker MCP `import_opml` tool
+// consume THIS module, so the mapping, the degradation counting, and the
+// ceiling can never drift between the two surfaces. It imports only pure
+// leaves (`effect`, `@rgrove/parse-xml`, and the pure `src/data` token
+// layers) — no DOM globals, no workers types — so it compiles under the app,
+// worker, and test tsconfigs and runs under plain `bun test`.
+//
+// The fidelity bar is "degraded, never silent" (ADR 0037): content survives
+// byte-exact, presentation may shift, and every shift lands in the typed
+// {@link OpmlImportReport} the app dialog and the MCP receipt both disclose.
+// The mapping is the one the fidelity probe (docs/spec-assets/opml/
+// fidelity-probe.ts) validated against a real 16,882-node Workflowy export —
+// zero content-loss violations. The degradation message strings are kept
+// byte-compatible with the probe's report so counts stay comparable.
+
+import { Data, Effect } from 'effect'
+import { parseXml, XmlElement, XmlError } from '@rgrove/parse-xml'
+import { isValidDateKey } from './date-links'
+import {
+  buildHighlightRun,
+  type HighlightColor,
+} from './highlight'
+import { encodeUrlForMarkdown, sanitizeLinkLabel } from './links'
+import { makeNode } from './tree'
+import type { ChangeOp } from './wire-schema'
+
+// --- Typed failures -----------------------------------------------------------
+
+/** The document is not well-formed XML (or not OPML at all). Carries the
+ *  parser's line/column when it has one — truncation always does, which is the
+ *  whole point of the chosen parser (ADR 0037: fail loudly, never a silent
+ *  partial tree). */
+export class OpmlParseError extends Data.TaggedError('OpmlParseError')<{
+  reason: string
+  line: number | null
+  column: number | null
+}> {
+  get message() {
+    return this.line !== null
+      ? `${this.reason} (line ${this.line}, column ${this.column})`
+      : this.reason
+  }
+}
+
+/** Raw input over the byte ceiling — rejected BEFORE parsing so a hostile or
+ *  runaway file never reaches the parser. */
+export class OpmlTooLarge extends Data.TaggedError('OpmlTooLarge')<{
+  length: number
+  maxLength: number
+}> {
+  get message() {
+    return `OPML input is too large: ${this.length} > ${this.maxLength} characters`
+  }
+}
+
+/** The post-split node count is over the caller's ceiling (app 50k / MCP 5k —
+ *  the ceiling is a parameter, the counting is shared). */
+export class OpmlImportTooLarge extends Data.TaggedError('OpmlImportTooLarge')<{
+  count: number
+  max: number
+}> {
+  get message() {
+    return `too many nodes to import: ${this.count} exceeds the ${this.max}-node ceiling`
+  }
+}
+
+/** The document parsed but holds zero `<outline>` nodes — nothing to import. */
+export class OpmlEmpty extends Data.TaggedError('OpmlEmpty')<Record<never, never>> {
+  get message() {
+    return 'the OPML document contains no outline nodes'
+  }
+}
+
+/** ~20 MB of UTF-16 units. The real 17k-node Workflowy export is ~2 MB, so
+ *  this is a 10x safety margin, not a product limit — the node ceiling in
+ *  {@link planOpmlImport} is the real bound. */
+export const DEFAULT_MAX_OPML_LENGTH = 20 * 1024 * 1024
+
+/** App-UI import ceiling: 50,000 post-split nodes (ADR 0037). */
+export const OPML_APP_MAX_NODES = 50_000
+/** MCP `import_opml` ceiling: 5,000 post-split nodes (ADR 0037). */
+export const OPML_MCP_MAX_NODES = 5_000
+
+// --- The intermediate forest + report -------------------------------------------
+
+/** One imported node, post note-splitting, pre id-minting. */
+export interface OpmlImportNode {
+  text: string
+  completed: boolean
+  isTask: boolean
+  /** The document's `id` attribute (the dotflowy mirror dialect), if any. */
+  opmlId: string | null
+  /** An in-document `id` this node mirrors (`_mirror` resolved against the
+   *  document's `id` set), or null. When set, `children` is empty — the
+   *  exported duplicate subtree belongs to the source and is dropped on
+   *  re-link. An UNRESOLVED `_mirror` imports as a detached plain copy
+   *  (children kept, counted in the report). */
+  mirrorOfOpmlId: string | null
+  children: OpmlImportNode[]
+}
+
+/** The typed degradation tally both disclosure surfaces render (the app's
+ *  confirm dialog and the MCP receipt). `degraded` keys are stable
+ *  human-readable messages (byte-compatible with the fidelity probe's). */
+export interface OpmlImportReport {
+  /** `<outline>` elements in the document. */
+  nodesPre: number
+  /** Forest nodes after note/newline splitting — what the ceiling counts. */
+  nodesPost: number
+  emptyText: number
+  /** `_note` attributes converted (the counted #113 degradation)… */
+  notes: number
+  /** …and the child bullets they became. */
+  noteLines: number
+  noteBlanksDropped: number
+  /** `&#10;` inside `text` -> continuation child bullets. */
+  textNewlineSplits: number
+  mirrorsLinked: number
+  mirrorsDetached: number
+  /** Degradation message -> count. Empty object = full-fidelity import. */
+  degraded: Record<string, number>
+  degradedTotal: number
+  /** Malformed-inline-HTML anomalies TOLERATED (text always kept): stray close
+   *  tags ignored, unclosed tags auto-closed. Real Workflowy exports contain
+   *  these (cross-bullet `<b>` spans), so they are not errors. */
+  anomalies: Record<string, number>
+  /** Attribute names outside the known dialect, with counts — the loss-report
+   *  candidates surface. */
+  unknownAttributes: Record<string, number>
+}
+
+export interface OpmlImportResult {
+  forest: OpmlImportNode[]
+  report: OpmlImportReport
+}
+
+// --- Counters -------------------------------------------------------------------
+
+class Tally {
+  readonly map = new Map<string, number>()
+  bump(key: string, n = 1): void {
+    this.map.set(key, (this.map.get(key) ?? 0) + n)
+  }
+  toRecord(): Record<string, number> {
+    const entries = [...this.map.entries()].sort(
+      (a, b) => b[1] - a[1] || a[0].localeCompare(b[0]),
+    )
+    return Object.fromEntries(entries)
+  }
+  total(): number {
+    let n = 0
+    for (const v of this.map.values()) n += v
+    return n
+  }
+}
+
+// --- Layer 2: HTML entity decode --------------------------------------------------
+// The attribute value is HTML *inside* XML. The XML parser decoded layer 1; the
+// text segments the scanner slices out still carry HTML entities that are
+// CONTENT (a user-typed literal `<` arrives as `&amp;lt;` -> `&lt;` after the
+// XML decode -> `<` here). The two layers must never be conflated (ADR 0037).
+
+const NAMED_ENTITIES: Record<string, string> = {
+  lt: '<',
+  gt: '>',
+  amp: '&',
+  quot: '"',
+  apos: "'",
+  nbsp: ' ',
+}
+
+function decodeHtmlEntities(s: string): string {
+  if (!s.includes('&')) return s
+  return s.replace(/&(#x?[0-9a-fA-F]+|[a-zA-Z]+);/g, (m, body: string) => {
+    if (body[0] === '#') {
+      const code =
+        body[1] === 'x' || body[1] === 'X'
+          ? parseInt(body.slice(2), 16)
+          : parseInt(body.slice(1), 10)
+      return Number.isFinite(code) ? String.fromCodePoint(code) : m
+    }
+    return NAMED_ENTITIES[body] ?? m
+  })
+}
+
+// --- Tolerant inline-HTML scanner --------------------------------------------------
+// NEVER rejects: real Workflowy exports contain malformed cross-bullet `<b>`
+// spans (probe-verified — 3 unclosed `<b>` + 3 stray `</b>` in the real
+// export). Stray close tags are ignored, unclosed tags auto-close at end of
+// value, and text is ALWAYS kept; each tolerance is counted in `anomalies`.
+
+type HtmlNode =
+  | { kind: 'text'; value: string }
+  | { kind: 'el'; tag: string; attrs: Record<string, string>; children: HtmlNode[] }
+
+const TAG_RE = /<(\/)?([a-zA-Z][a-zA-Z0-9-]*)((?:"[^"]*"|'[^']*'|[^>"'])*?)(\/)?>/g
+const ATTR_RE = /([a-zA-Z_:][a-zA-Z0-9_:.-]*)\s*=\s*(?:"([^"]*)"|'([^']*)')/g
+
+interface ScanFrame {
+  tag: string
+  attrs: Record<string, string>
+  children: HtmlNode[]
+}
+
+function parseInlineHtml(src: string, anomalies: Tally): HtmlNode[] {
+  const root: HtmlNode[] = []
+  const stack: ScanFrame[] = []
+  const top = (): HtmlNode[] =>
+    stack.length ? stack[stack.length - 1]!.children : root
+  const popFrame = (): void => {
+    const frame = stack.pop()!
+    top().push({ kind: 'el', tag: frame.tag, attrs: frame.attrs, children: frame.children })
+  }
+
+  let last = 0
+  TAG_RE.lastIndex = 0
+  for (let m = TAG_RE.exec(src); m; m = TAG_RE.exec(src)) {
+    if (m.index > last) {
+      top().push({ kind: 'text', value: decodeHtmlEntities(src.slice(last, m.index)) })
+    }
+    last = TAG_RE.lastIndex
+    const [, close, rawTag, rawAttrs, selfClose] = m
+    const tag = rawTag!.toLowerCase()
+    if (close) {
+      const i = stack.map((f) => f.tag).lastIndexOf(tag)
+      if (i === -1) {
+        anomalies.bump(`stray </${tag}>`)
+        continue
+      }
+      while (stack.length > i + 1) {
+        anomalies.bump(`auto-closed <${stack[stack.length - 1]!.tag}>`)
+        popFrame()
+      }
+      popFrame()
+    } else {
+      const attrs: Record<string, string> = {}
+      ATTR_RE.lastIndex = 0
+      for (let a = ATTR_RE.exec(rawAttrs ?? ''); a; a = ATTR_RE.exec(rawAttrs ?? '')) {
+        attrs[a[1]!] = decodeHtmlEntities(a[2] ?? a[3] ?? '')
+      }
+      if (selfClose) top().push({ kind: 'el', tag, attrs, children: [] })
+      else stack.push({ tag, attrs, children: [] })
+    }
+  }
+  if (last < src.length) {
+    top().push({ kind: 'text', value: decodeHtmlEntities(src.slice(last)) })
+  }
+  while (stack.length) {
+    anomalies.bump(`unclosed <${stack[stack.length - 1]!.tag}>`)
+    popFrame()
+  }
+  return root
+}
+
+function flattenText(nodes: HtmlNode[]): string {
+  let out = ''
+  for (const n of nodes) {
+    out += n.kind === 'text' ? n.value : flattenText(n.children)
+  }
+  return out
+}
+
+function containsTag(nodes: HtmlNode[], tag: string): boolean {
+  return nodes.some(
+    (n) => n.kind === 'el' && (n.tag === tag || containsTag(n.children, tag)),
+  )
+}
+
+// --- HTML tree -> dotflowy token string ---------------------------------------------
+// The locked #114 mapping. Interiors that would break a token pattern (the
+// marker char, `=`/newline in a highlight) drop the formatting and keep the
+// text; nesting flattens to outermost-wins with links trumping everything; a
+// `<time>` with canonical attrs becomes the date token (ADR 0038 — adopted,
+// not degraded); unknown tags strip to inner text. Every drop is counted.
+
+interface MarkerSpec {
+  open: string
+  close: string
+  forbid: RegExp
+}
+
+const FORMAT_MARKERS: Record<string, MarkerSpec> = {
+  b: { open: '**', close: '**', forbid: /[*\n]/ },
+  i: { open: '*', close: '*', forbid: /[*\n]/ },
+  u: { open: '~', close: '~', forbid: /[~\n]/ },
+  s: { open: '~~', close: '~~', forbid: /[~\n]/ },
+  code: { open: '`', close: '`', forbid: /[`\n]/ },
+}
+
+/** Workflowy palette name -> dotflowy highlight color. `teal`->green and
+ *  `sky`/`pink` fold to their nearest neighbors; gray/brown have NO mapping
+ *  (the shipped ADR 0035 palette has no white emoji — probe amendment) and
+ *  degrade to the bare default-blue run. */
+const MARK_COLOR: Record<string, HighlightColor> = {
+  red: 'red',
+  orange: 'orange',
+  yellow: 'yellow',
+  green: 'green',
+  teal: 'green',
+  sky: 'blue',
+  blue: 'blue',
+  purple: 'purple',
+  pink: 'purple',
+}
+
+interface ConvertState {
+  degraded: Tally
+  /** Already inside a formatting tag — dotflowy emphasis is FLAT (ADR 0025). */
+  insideFormat: boolean
+}
+
+const pad2 = (n: number): string => String(n).padStart(2, '0')
+
+/** `<time start…>` -> the ADR 0038 date token, keyed on the CANONICAL
+ *  attributes (never the display text). Returns null when the attrs are
+ *  missing or don't name a real calendar day — the caller keeps the display
+ *  text and counts the degradation. */
+function timeToDateToken(attrs: Record<string, string>): string | null {
+  const y = Number(attrs['startYear'])
+  const mo = Number(attrs['startMonth'])
+  const d = Number(attrs['startDay'])
+  if (!Number.isInteger(y) || !Number.isInteger(mo) || !Number.isInteger(d)) return null
+  const key = `${String(y).padStart(4, '0')}-${pad2(mo)}-${pad2(d)}`
+  if (!isValidDateKey(key)) return null
+  const hourRaw = attrs['startHour']
+  if (hourRaw === undefined) return `[[${key}]]`
+  const hour = Number(hourRaw)
+  if (!Number.isInteger(hour) || hour < 0 || hour > 23) return `[[${key}]]`
+  const minute = Number(attrs['startMinute'] ?? '0')
+  const mm = Number.isInteger(minute) && minute >= 0 && minute <= 59 ? minute : 0
+  return `[[${key} ${pad2(hour)}:${pad2(mm)}]]`
+}
+
+function convert(nodes: HtmlNode[], state: ConvertState): string {
+  let out = ''
+  for (const n of nodes) {
+    out += n.kind === 'text' ? n.value : convertEl(n, state)
+  }
+  return out
+}
+
+function convertEl(el: Extract<HtmlNode, { kind: 'el' }>, state: ConvertState): string {
+  const { degraded } = state
+  switch (el.tag) {
+    case 'a': {
+      const rawLabel = flattenText(el.children)
+      // Formatting INSIDE a link is dropped — a working link beats any styling
+      // (in the combined token regex `**[l](u)**` would tokenize as bold and
+      // kill the link).
+      const walkInner = (nodes: HtmlNode[]): void => {
+        for (const n of nodes) {
+          if (n.kind === 'el') {
+            degraded.bump(`styling inside <a> dropped (<${n.tag}>)`)
+            walkInner(n.children)
+          }
+        }
+      }
+      walkInner(el.children)
+      const url = encodeUrlForMarkdown(el.attrs['href'] ?? '')
+      const label = sanitizeLinkLabel(rawLabel)
+      if (label !== rawLabel.trim() || rawLabel.includes(']')) {
+        degraded.bump('link label sanitized (`]` stripped / whitespace collapsed)')
+      }
+      return `[${label}](${url})`
+    }
+    case 'time': {
+      // Adopted, not degraded (ADR 0038) — but only where the token can
+      // actually render: inside a formatting run the interior is plain text,
+      // so the display text is the honest fallback there.
+      const display = flattenText(el.children)
+      if (state.insideFormat) {
+        degraded.bump('<time> inside formatting -> display text kept')
+        return display
+      }
+      const token = timeToDateToken(el.attrs)
+      if (token === null) {
+        degraded.bump('<time> missing canonical start attrs -> display text kept')
+        return display
+      }
+      return token
+    }
+    case 'mention': {
+      const id = el.attrs['id'] ?? '?'
+      degraded.bump('<mention> -> @mention(id) (name unrecoverable)')
+      return `@mention(${id})`
+    }
+    case 'b':
+    case 'i':
+    case 'u':
+    case 's':
+    case 'code': {
+      const spec = FORMAT_MARKERS[el.tag]!
+      if (containsTag(el.children, 'a')) {
+        degraded.bump(`<${el.tag}> dropped: contains a link (link wins)`)
+        return convert(el.children, state)
+      }
+      if (state.insideFormat) {
+        degraded.bump(`nested <${el.tag}> dropped (outermost wins)`)
+        return convert(el.children, state)
+      }
+      const interior = convert(el.children, { ...state, insideFormat: true })
+      if (interior.length === 0) {
+        degraded.bump(`empty <${el.tag}> dropped`)
+        return ''
+      }
+      if (spec.forbid.test(interior)) {
+        degraded.bump(`<${el.tag}> dropped: marker char in interior`)
+        return interior
+      }
+      return spec.open + interior + spec.close
+    }
+    case 'mark': {
+      if (containsTag(el.children, 'a')) {
+        degraded.bump('<mark> dropped: contains a link (link wins)')
+        return convert(el.children, state)
+      }
+      if (state.insideFormat) {
+        degraded.bump('nested <mark> dropped (outermost wins)')
+        return convert(el.children, state)
+      }
+      const interior = convert(el.children, { ...state, insideFormat: true })
+      if (interior.length === 0) {
+        degraded.bump('empty <mark> dropped')
+        return ''
+      }
+      if (/[=\n]/.test(interior)) {
+        degraded.bump('<mark> dropped: `=` or newline in interior')
+        return interior
+      }
+      // `c-*` (text color) and `bc-*` (background) both map to a highlight —
+      // parse the prefix liberally rather than allowlisting names (#112).
+      const cls = el.attrs['class'] ?? ''
+      const colorName = /(?:^|\s)(?:c|bc)-([a-z]+)/.exec(cls)?.[1]
+      const color = colorName ? MARK_COLOR[colorName] : undefined
+      if (colorName && color === undefined) {
+        if (colorName === 'gray' || colorName === 'brown') {
+          degraded.bump(`<mark ${colorName}> -> bare == (no white in the palette)`)
+        } else {
+          degraded.bump(`<mark ${colorName}> unrecognized -> bare ==`)
+        }
+      }
+      // buildHighlightRun canonicalizes: blue (the default) emits the BARE
+      // `==x==` form, so a `bc-sky` import round-trips as clean markdown.
+      return buildHighlightRun(color ?? 'blue', interior)
+    }
+    default: {
+      degraded.bump(`unknown <${el.tag}> stripped, text kept`)
+      return convert(el.children, state)
+    }
+  }
+}
+
+// --- <outline> walk -----------------------------------------------------------------
+
+/** The complete known attribute set: Workflowy's three + the dotflowy export
+ *  dialect's three (ADR 0037 mirror persistence + `_task`). */
+const KNOWN_ATTRS = new Set(['text', '_note', '_complete', '_task', 'id', '_mirror'])
+
+interface MapState {
+  degraded: Tally
+  anomalies: Tally
+  unknownAttrs: Tally
+  nodesPre: number
+  emptyText: number
+  notes: number
+  noteLines: number
+  noteBlanksDropped: number
+  textNewlineSplits: number
+  mirrorsLinked: number
+  mirrorsDetached: number
+  /** Every `id` attribute in the document — the `_mirror` resolution set. */
+  documentIds: ReadonlySet<string>
+}
+
+function convertValue(raw: string, state: MapState): { text: string; extraLines: string[] } {
+  const tree = parseInlineHtml(raw, state.anomalies)
+  const converted = convert(tree, { degraded: state.degraded, insideFormat: false })
+  const lines = converted.split('\n')
+  return { text: lines[0] ?? '', extraLines: lines.slice(1) }
+}
+
+function isOutline(child: unknown): child is XmlElement {
+  return child instanceof XmlElement && child.name === 'outline'
+}
+
+function collectDocumentIds(el: XmlElement, into: Set<string>): void {
+  const id = el.attributes['id']
+  if (id) into.add(id)
+  for (const child of el.children) {
+    if (isOutline(child)) collectDocumentIds(child, into)
+  }
+}
+
+function convertOutline(el: XmlElement, state: MapState): OpmlImportNode {
+  state.nodesPre++
+  for (const name of Object.keys(el.attributes)) {
+    if (!KNOWN_ATTRS.has(name)) state.unknownAttrs.bump(name)
+  }
+
+  const rawText = el.attributes['text'] ?? ''
+  if (rawText === '') state.emptyText++
+  const { text, extraLines } = convertValue(rawText, state)
+
+  // `&#10;` continuation lines in `text` become child bullets BEFORE any
+  // `_note`-derived lines (#114); blank continuations are formatting, dropped.
+  const prepend: OpmlImportNode[] = []
+  if (extraLines.length) {
+    state.textNewlineSplits++
+    for (const line of extraLines) {
+      if (line.trim() !== '') prepend.push(plainNode(line))
+    }
+  }
+
+  // `_note` -> prepended child bullets, one per non-blank line, order kept
+  // (#113). The trailing serializer `&#10;` shows up as a blank line and is
+  // dropped with the rest.
+  const noteRaw = el.attributes['_note']
+  if (noteRaw !== undefined) {
+    state.notes++
+    const { text: first, extraLines: rest } = convertValue(noteRaw, state)
+    for (const line of [first, ...rest]) {
+      if (line.trim() === '') state.noteBlanksDropped++
+      else {
+        prepend.push(plainNode(line))
+        state.noteLines++
+      }
+    }
+  }
+
+  const completed = el.attributes['_complete'] === 'true'
+  const isTask = el.attributes['_task'] === 'true'
+  const opmlId = el.attributes['id'] || null
+
+  // Mirror re-link (ADR 0037): a `_mirror` referencing an in-document `id`
+  // becomes a REAL mirror — its exported duplicate subtree belongs to the
+  // source and is dropped. An unresolvable `_mirror` (the source is outside
+  // this document, or the OPML passed through Workflowy, which strips the
+  // attrs) imports as a detached plain copy — disclosed, never silent.
+  const mirrorRef = el.attributes['_mirror']
+  if (mirrorRef !== undefined && state.documentIds.has(mirrorRef)) {
+    state.mirrorsLinked++
+    return { text, completed, isTask, opmlId, mirrorOfOpmlId: mirrorRef, children: [] }
+  }
+  if (mirrorRef !== undefined) {
+    state.mirrorsDetached++
+    state.degraded.bump('mirror detached (source not in this document)')
+  }
+
+  const realChildren: OpmlImportNode[] = []
+  for (const child of el.children) {
+    if (isOutline(child)) realChildren.push(convertOutline(child, state))
+  }
+  return {
+    text,
+    completed,
+    isTask,
+    opmlId,
+    mirrorOfOpmlId: null,
+    children: [...prepend, ...realChildren],
+  }
+}
+
+function plainNode(text: string): OpmlImportNode {
+  return {
+    text,
+    completed: false,
+    isTask: false,
+    opmlId: null,
+    mirrorOfOpmlId: null,
+    children: [],
+  }
+}
+
+function countForest(forest: readonly OpmlImportNode[]): number {
+  let n = 0
+  const stack = [...forest]
+  while (stack.length) {
+    const node = stack.pop()!
+    n++
+    for (const child of node.children) stack.push(child)
+  }
+  return n
+}
+
+function mapDocument(source: string): OpmlImportResult {
+  const doc = parseXml(source)
+  const opml = doc.children.find(
+    (c): c is XmlElement => c instanceof XmlElement && c.name === 'opml',
+  )
+  const body = opml?.children.find(
+    (c): c is XmlElement => c instanceof XmlElement && c.name === 'body',
+  )
+  if (!body) {
+    throw new OpmlParseError({
+      reason: 'not an OPML document (missing <opml>/<body>)',
+      line: null,
+      column: null,
+    })
+  }
+  const tops = body.children.filter(isOutline)
+
+  const documentIds = new Set<string>()
+  for (const el of tops) collectDocumentIds(el, documentIds)
+
+  const state: MapState = {
+    degraded: new Tally(),
+    anomalies: new Tally(),
+    unknownAttrs: new Tally(),
+    nodesPre: 0,
+    emptyText: 0,
+    notes: 0,
+    noteLines: 0,
+    noteBlanksDropped: 0,
+    textNewlineSplits: 0,
+    mirrorsLinked: 0,
+    mirrorsDetached: 0,
+    documentIds,
+  }
+  const forest = tops.map((el) => convertOutline(el, state))
+
+  const report: OpmlImportReport = {
+    nodesPre: state.nodesPre,
+    nodesPost: countForest(forest),
+    emptyText: state.emptyText,
+    notes: state.notes,
+    noteLines: state.noteLines,
+    noteBlanksDropped: state.noteBlanksDropped,
+    textNewlineSplits: state.textNewlineSplits,
+    mirrorsLinked: state.mirrorsLinked,
+    mirrorsDetached: state.mirrorsDetached,
+    degraded: state.degraded.toRecord(),
+    degradedTotal: state.degraded.total(),
+    anomalies: state.anomalies.toRecord(),
+    unknownAttributes: state.unknownAttrs.toRecord(),
+  }
+  return { forest, report }
+}
+
+/**
+ * OPML source -> intermediate forest + degradation report. The size guard runs
+ * BEFORE parsing; a malformed or truncated document fails into a typed
+ * {@link OpmlParseError} carrying the parser's line/column — never a partial
+ * forest. Undefined entities (the classic entity bomb) are rejected by the
+ * parser itself; DTD entity definitions are never expanded.
+ */
+export function parseOpml(
+  source: string,
+  options: { maxLength?: number } = {},
+): Effect.Effect<OpmlImportResult, OpmlParseError | OpmlTooLarge> {
+  const maxLength = options.maxLength ?? DEFAULT_MAX_OPML_LENGTH
+  if (source.length > maxLength) {
+    return Effect.fail(new OpmlTooLarge({ length: source.length, maxLength }))
+  }
+  return Effect.try({
+    try: () => mapDocument(source),
+    catch: (error) => {
+      if (error instanceof OpmlParseError) return error
+      if (error instanceof XmlError) {
+        return new OpmlParseError({
+          reason: error.message.split('\n')[0] ?? 'XML parse error',
+          line: error.line,
+          column: error.column,
+        })
+      }
+      return new OpmlParseError({
+        reason: error instanceof Error ? error.message : String(error),
+        line: null,
+        column: null,
+      })
+    },
+  })
+}
+
+// --- Forest -> ChangeOp[] plan --------------------------------------------------------
+
+/**
+ * Plan the whole forest as ONE atomic batch under `parentId`, anchored after
+ * `firstPrev` (the parent's existing anchor sibling, or null for the head).
+ *
+ * CORRECT BY CONSTRUCTION (the ADR 0028 lesson): sibling wiring comes from the
+ * emission order — the forest IS the shape, so nothing reads a tree index and
+ * nothing loops `planAddNode` (which would re-read a stale last-sibling and
+ * tear the chain). Ids are minted in a first pass so a `_mirror` may reference
+ * a source that appears LATER in the document (forward references resolve).
+ * The ceiling is a parameter — app 50k, MCP 5k — counted post-split, and a
+ * breach fails the WHOLE call: no partial plan, ever.
+ */
+export function planOpmlImport(
+  forest: readonly OpmlImportNode[],
+  args: {
+    parentId: string | null
+    firstPrev: string | null
+    origin?: string | null
+    timestamp: number
+    newId: () => string
+    maxNodes: number
+  },
+): { ops: ChangeOp[]; rootIds: string[]; count: number } | OpmlEmpty | OpmlImportTooLarge {
+  const count = countForest(forest)
+  if (count === 0) return new OpmlEmpty()
+  if (count > args.maxNodes) {
+    return new OpmlImportTooLarge({ count, max: args.maxNodes })
+  }
+
+  // Pass 1: mint every node's id, depth-first pre-order, and map the
+  // document's `id` attributes to the minted ids (first occurrence wins).
+  const minted = new Map<OpmlImportNode, string>()
+  const idByOpmlId = new Map<string, string>()
+  const mint = (nodes: readonly OpmlImportNode[]): void => {
+    for (const node of nodes) {
+      const id = args.newId()
+      minted.set(node, id)
+      if (node.opmlId && !idByOpmlId.has(node.opmlId)) idByOpmlId.set(node.opmlId, id)
+      mint(node.children)
+    }
+  }
+  mint(forest)
+
+  // Pass 2: emit inserts depth-first pre-order — every chunked-frame prefix is
+  // chain-valid for live remote viewers (ADR 0037), and each node's
+  // prevSiblingId is the previously-emitted sibling AT ITS LEVEL.
+  const ops: ChangeOp[] = []
+  const emit = (
+    siblings: readonly OpmlImportNode[],
+    parentId: string | null,
+    initialPrev: string | null,
+  ): string[] => {
+    const ids: string[] = []
+    let prev = initialPrev
+    for (const node of siblings) {
+      const id = minted.get(node)!
+      const mirrorOf = node.mirrorOfOpmlId
+        ? (idByOpmlId.get(node.mirrorOfOpmlId) ?? null)
+        : null
+      ops.push({
+        op: 'insert',
+        value: makeNode({
+          id,
+          parentId,
+          prevSiblingId: prev,
+          text: node.text,
+          isTask: node.isTask,
+          completed: node.completed,
+          mirrorOf,
+          origin: args.origin ?? null,
+          createdAt: args.timestamp,
+          updatedAt: args.timestamp,
+        }),
+      })
+      ids.push(id)
+      // A re-linked mirror has no children of its own (they belong to the
+      // source); the mapper already emptied them, this is belt-and-braces for
+      // hand-built forests.
+      if (mirrorOf === null && node.children.length) emit(node.children, id, null)
+      prev = id
+    }
+    return ids
+  }
+  const rootIds = emit(forest, args.parentId, args.firstPrev)
+  return { ops, rootIds, count }
+}


### PR DESCRIPTION
## Summary

The pure heart of ADR 0037: one shared OPML core in `src/data` that BOTH the app UI (build 5/7) and the Worker MCP tools (build 6/7) will consume — the `wire-schema.ts` shared-leaf precedent. Pure leaves only (`effect`, `@rgrove/parse-xml`, the pure token layers): verified to compile with `--lib es2022` alone — no DOM globals, no workers types — and fully covered by `bun test`.

### Import (`src/data/opml-import.ts`)

- **Parse**: `@rgrove/parse-xml` v4 wrapped in `Effect.try` → `OpmlParseError` carrying the parser's line/column. Truncated input fails loudly — never a partial forest, never a partial plan. Entity bombs are rejected by the parser (undefined entities error; DTD entities never expand). Raw-size guard (~20 MB) fires BEFORE parsing.
- **Two-layer decode, strictly ordered**: XML (the parser), then HTML entities (the scanner) — `&amp;lt;` survives as a literal `<` in content.
- **Tolerant HTML scanner** (grown from the fidelity probe's): stray close tags ignored, unclosed tags auto-closed, text always kept, each tolerance counted — real Workflowy exports contain cross-bullet `<b>` spans.
- **The locked #114 mapping**: `b/i/u/s/code/a` → tokens; `<mark c-*/bc-*>` → `==highlight==` nearest palette color via the real `buildHighlightRun` (gray/brown → bare `==`, the probe amendment; `bc-sky` canonicalizes to the bare default-blue run); **`<time start*>` → the real ADR 0038 date token** keyed on canonical attrs (adopted, not degraded); `<mention>` → `@mention(id)`; unknown tags strip to inner text. Marker-clash, nesting-flatten (link wins outright), and every other shift lands in the typed `OpmlImportReport` both disclosure surfaces will render.
- **Notes**: `_note` → prepended child bullets per non-blank line; `&#10;` inside `text` → continuation bullets BEFORE note lines.
- **Mirror re-link**: `_mirror` referencing an in-document `id` → real mirror (exported duplicate subtree dropped); unresolvable → disclosed detached copy.
- **Planner** (`planOpmlImport`): post-split counting against a parameterized ceiling (`OPML_APP_MAX_NODES` 50k / `OPML_MCP_MAX_NODES` 5k), ONE batch with sibling wiring **correct-by-construction** (the ADR 0028 lesson — nothing reads a tree index, nothing loops `planAddNode`), ids pre-minted so forward `_mirror` references resolve, depth-first pre-order emission so every chunked-frame prefix is chain-valid.

### Export (`src/data/opml-export.ts`)

- Hand-rolled serializer: escape `& < > " '`, `&#10;` in attrs; `<head>` = `<title>` only (no `ownerEmail`); `_complete`/`_task` present-iff-true; content-never-state (collapsed/bookmarks/origin/timestamps dropped).
- Mirror dialect: `id` on in-scope mirror sources, `_mirror` on mirror roots over a fully resolved duplicate (expansion rows carry no dialect attrs), `sourcesOnPath` cycle cap, text via `trueSourceOf`.
- Inline inverse projections, one combined scan in registry precedence order: tokens back to Workflowy HTML; highlight emoji → `bc-*` class (blue → `bc-sky`, emoji stripped); date token → `<time start*>` with regenerated display ("Wed, Jul 8, 2026", "at 1:00pm"); node links → `<a href="https://app.dotflowy.com/<id>">` labeled via `linkedNodeLabel` (origin parameterized); Bible refs → route.bible links (reuses `bibleRefsToMarkdownLinks`); `#tags` plain pass-through; unparsed literals never invent markup.

## Test evidence

All gates green:

| Gate | Result |
| --- | --- |
| `bun run lint` | clean |
| `bun run typecheck` | clean |
| `bun run typecheck:test` | clean |
| `bun run typecheck:worker` | clean |
| `bun run test` | **434 pass, 0 fail** (54 new across the two OPML test files) |
| pure-leaf check | `tsc --lib es2022` (no DOM) compiles both modules |

### Degradation counts vs the fidelity probe (crafted sample, pinned in tests)

| Metric | Probe report | This core |
| --- | --- | --- |
| nodes pre → post-split | 21 → 23 | 21 → 23 ✅ |
| notes → note bullets (blanks dropped) | 1 → 2 (1) | 1 → 2 (1) ✅ |
| `nested <mark> dropped (outermost wins)` | 2 | 2 ✅ |
| `<mention> -> @mention(id) (name unrecoverable)` | 1 | 1 ✅ |
| HTML anomalies / unknown attrs / content loss | none | none ✅ |

One deliberate divergence from the probe: `<time>` now emits the **real date token** (`due [[2026-07-08]] `) instead of the probe's display-text fallback — the soft dependency (ADR 0038) merged, so the adopted mapping applies and `<time>` is not a degradation.

Also proven: export of a mirror-bearing tree round-trips through import with the mirror re-linked to the minted source id (and formatted text byte-exact, zero degradations); truncated input fails with line/column; the entity bomb is rejected; the size guard fires pre-parse; the ceiling rejects the whole plan (never partial).

## Design deviations / notes

- **Degradation tally shape**: `OpmlImportReport.degraded` is `Record<message, count>` with message strings byte-compatible with the probe's, plus typed top-level counters (notes/splits/mirrors/anomalies/unknown attrs) — one report consumed by the app dialog and the MCP receipt.
- **`<time>` inside a formatting run** keeps its display text (counted) — a token can't render inside a flat emphasis interior.
- **Highlight canonicalization**: `bc-sky`/`blue` import as the BARE `==x==` (blue is the ADR 0035 default), so re-imports stay the cleanest markdown.
- **Size guard** measures UTF-16 length of the decoded string (`~20 MB` default) — the shells also see the raw file size before decode.
- New dependency: `@rgrove/parse-xml@4.2.1` (4 KB gz, zero deps — the ADR 0037 pick).

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)