### PR TITLE
App OPML export: download as OPML (OPML build 6/7)

### DIFF
--- a/e2e/opml-export.spec.ts
+++ b/e2e/opml-export.spec.ts
@@ -1,0 +1,151 @@
+import { expect, test, type Page } from "@playwright/test";
+import { seedOutline, type SeedNode } from "./fixtures";
+
+// App OPML export (ADR 0037, issue #127): the "Export OPML" More-menu item /
+// Cmd+K global action downloads the current view (zoom root INCLUDED, or the
+// whole outline at home) serialized by the shared core (src/data/opml-export.ts).
+//
+// The download is intercepted IN PAGE (no real filesystem download): we shadow
+// HTMLAnchorElement.prototype.click for blob: hrefs and record the anchor's
+// `download` filename + the blob's text. `downloadTextFile` revokes the object
+// URL right after click, so the blob text is captured eagerly at click time.
+
+//   Project alpha (root)          <- the zoom target
+//     Done item (done)            completed
+//     Task item (task)            to-do
+//     Source item (source)        mirror source, has a child
+//       Source child (source-kid)
+//     (mirror of source) (mir)    mirror root
+//   Other top level (other)       <- must NOT appear in a zoomed export
+const TREE: SeedNode[] = [
+  { id: "root", parentId: null, prevSiblingId: null, text: "Project alpha" },
+  { id: "other", parentId: null, prevSiblingId: "root", text: "Other top level" },
+  { id: "done", parentId: "root", prevSiblingId: null, text: "Done item", completed: true },
+  { id: "task", parentId: "root", prevSiblingId: "done", text: "Task item", isTask: true },
+  { id: "source", parentId: "root", prevSiblingId: "task", text: "Source item" },
+  { id: "source-kid", parentId: "source", prevSiblingId: null, text: "Source child" },
+  { id: "mir", parentId: "root", prevSiblingId: "source", text: "mirror placeholder", mirrorOf: "source" },
+];
+
+interface CapturedDownload {
+  filename: string;
+  text: string;
+}
+
+declare global {
+  interface Window {
+    __downloads?: Promise<CapturedDownload>[];
+  }
+}
+
+/** Shadow blob-anchor clicks so a download is captured in page, not saved. */
+async function interceptDownloads(page: Page) {
+  await page.addInitScript(() => {
+    window.__downloads = [];
+    const blobs = new Map<string, Blob>();
+    const origCreate = URL.createObjectURL.bind(URL);
+    URL.createObjectURL = (b: Blob | MediaSource) => {
+      const url = origCreate(b);
+      if (b instanceof Blob) blobs.set(url, b);
+      return url;
+    };
+    // Shadows HTMLElement.prototype.click for anchors only; non-blob anchors
+    // fall through to the real click.
+    HTMLAnchorElement.prototype.click = function (this: HTMLAnchorElement) {
+      const blob = blobs.get(this.href);
+      if (!blob) return HTMLElement.prototype.click.call(this);
+      const filename = this.download;
+      window.__downloads!.push(blob.text().then((text) => ({ filename, text })));
+    };
+  });
+}
+
+async function capturedDownload(page: Page): Promise<CapturedDownload> {
+  await expect
+    .poll(() => page.evaluate(() => window.__downloads!.length))
+    .toBeGreaterThan(0);
+  return page.evaluate(() => Promise.all(window.__downloads!).then((d) => d[0]!));
+}
+
+const nodeText = (page: Page, id: string) =>
+  page.locator(`li[data-node-id="${id}"] > .outline-row .node-text`);
+
+async function runMenuExport(page: Page) {
+  await page.getByRole("button", { name: /more/i }).click();
+  await page.getByRole("menuitem", { name: /Export OPML/ }).click();
+}
+
+test.describe("OPML export (More menu + Cmd+K)", () => {
+  test("zoomed export: subtree only, root as top-level outline, dialect attrs, no ownerEmail", async ({
+    page,
+  }) => {
+    await interceptDownloads(page);
+    await seedOutline(page, TREE);
+    await page.goto("/root");
+    await expect(nodeText(page, "done")).toBeVisible();
+
+    await runMenuExport(page);
+    const { filename, text } = await capturedDownload(page);
+
+    // Filename: dotflowy-<slug>-<local date>.opml.
+    expect(filename).toMatch(/^dotflowy-project-alpha-\d{4}-\d{2}-\d{2}\.opml$/);
+
+    // OPML shell, title-only head -- never ownerEmail (privacy, ADR 0037).
+    expect(text).toContain('<opml version="2.0">');
+    expect(text).toContain("<title>Project alpha</title>");
+    expect(text).not.toContain("ownerEmail");
+
+    // Scope: the zoom root is the single top-level <outline>; the sibling
+    // top-level node is outside the subtree and absent.
+    expect(text).toContain('text="Project alpha"');
+    expect(text).not.toContain("Other top level");
+
+    // completed -> _complete="true"; to-do -> _task="true" (present-iff-true).
+    expect(text).toContain('_complete="true" text="Done item"');
+    expect(text).toContain('_task="true" text="Task item"');
+    expect(text.match(/_complete=/g)).toHaveLength(1);
+    expect(text.match(/_task=/g)).toHaveLength(1);
+
+    // Mirror dialect: the in-scope source carries id=..., the mirror root
+    // carries _mirror=<sourceId> and emits the fully resolved duplicate
+    // (source text AND its child, repeated inside the mirror's expansion).
+    expect(text).toContain('id="source"');
+    expect(text).toContain('_mirror="source" text="Source item"');
+    expect(text.match(/text="Source item"/g)).toHaveLength(2);
+    expect(text.match(/text="Source child"/g)).toHaveLength(2);
+  });
+
+  test("home export includes every top-level node under the default filename", async ({
+    page,
+  }) => {
+    await interceptDownloads(page);
+    await seedOutline(page, TREE);
+    await page.goto("/");
+    await expect(nodeText(page, "root")).toBeVisible();
+
+    await runMenuExport(page);
+    const { filename, text } = await capturedDownload(page);
+
+    expect(filename).toMatch(/^dotflowy-export-\d{4}-\d{2}-\d{2}\.opml$/);
+    expect(text).toContain('text="Project alpha"');
+    expect(text).toContain('text="Other top level"');
+  });
+
+  test("Cmd+K runs Export OPML through the global-actions bridge", async ({
+    page,
+  }) => {
+    await interceptDownloads(page);
+    await seedOutline(page, TREE);
+    await page.goto("/");
+    await expect(nodeText(page, "root")).toBeVisible();
+
+    await page.keyboard.press("ControlOrMeta+k");
+    const input = page.getByPlaceholder(/Search nodes and actions/);
+    await expect(input).toBeVisible();
+    await input.fill("export opml");
+    await page.getByRole("option", { name: /Export OPML/ }).click();
+
+    const { filename } = await capturedDownload(page);
+    expect(filename).toMatch(/^dotflowy-export-\d{4}-\d{2}-\d{2}\.opml$/);
+  });
+});

--- a/src/components/command-actions.tsx
+++ b/src/components/command-actions.tsx
@@ -7,6 +7,7 @@ import {
   ChevronsUpDownIcon,
   CircleCheckIcon,
   ClipboardCopyIcon,
+  DownloadIcon,
   ExternalLinkIcon,
   FocusIcon,
   LogOutIcon,
@@ -26,6 +27,7 @@ import { useTheme } from "./theme-provider";
 import { useTextSize, type TextSize } from "./text-size-provider";
 import {
   copyOutlineAsMarkdown,
+  exportOutlineAsOpml,
   setViewCollapsed,
 } from "./header-more-menu";
 
@@ -67,6 +69,15 @@ export function useGlobalActions(opts: {
         run: () => {
           void copyOutlineAsMarkdown();
         },
+      },
+      {
+        id: "g:export-opml",
+        label: "Export OPML",
+        description: "Download the current view as an OPML file",
+        icon: DownloadIcon,
+        scope: "global",
+        keywords: ["export", "opml", "download", "file", "workflowy", "backup"],
+        run: exportOutlineAsOpml,
       },
       {
         id: "g:collapse-all",

--- a/src/components/header-more-menu.tsx
+++ b/src/components/header-more-menu.tsx
@@ -5,6 +5,7 @@ import {
   ChevronsUpDownIcon,
   CircleCheckIcon,
   ClipboardCopyIcon,
+  DownloadIcon,
   FocusIcon,
   LogOutIcon,
   MonitorIcon,
@@ -39,6 +40,10 @@ import {
 import { useTheme } from "./theme-provider";
 import { useTextSize, type TextSize } from "./text-size-provider";
 import { outlineToMarkdown } from "../data/markdown";
+import { exportOpml } from "../data/opml-export";
+import { downloadTextFile } from "../data/download";
+import { localDateKey } from "../data/date-links";
+import { flattenInline } from "../data/inline-text";
 import { getTreeIndex } from "../data/tree-store";
 import { getViewRootId } from "../data/view-state";
 import { childrenOf } from "../data/tree";
@@ -84,6 +89,39 @@ export async function copyOutlineAsMarkdown() {
   } catch {
     toast.error("Couldn't copy to clipboard");
   }
+}
+
+/**
+ * Download the current view as an OPML file (ADR 0037). Scope mirrors
+ * `copyOutlineAsMarkdown`: the zoom root's subtree (root INCLUDED), or the
+ * whole outline at home -- read live at click time. Serialization is entirely
+ * the shared core (`exportOpml`); this shell only picks the scope, names the
+ * file, and hands the string to the browser.
+ *
+ * Filename: `dotflowy-export-<YYYY-MM-DD>.opml` at home; a zoomed export
+ * swaps `export` for a slug of the root's flattened text
+ * (`dotflowy-<slug>-<date>.opml`). The date is the LOCAL calendar day
+ * (`localDateKey`, never `toISOString` -- the daily-notes rule).
+ */
+export function exportOutlineAsOpml() {
+  const index = getTreeIndex();
+  const rootId = getViewRootId();
+  const root = rootId ? (index.byId.get(rootId) ?? null) : null;
+  const rootText = root ? flattenInline(root.text) : "";
+  const slug = rootText
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 40)
+    .replace(/-+$/, "");
+  const date = localDateKey();
+  const filename = slug
+    ? `dotflowy-${slug}-${date}.opml`
+    : `dotflowy-export-${date}.opml`;
+  const opml = exportOpml(index, root ? root.id : null, {
+    title: rootText || "dotflowy export",
+  });
+  downloadTextFile(filename, "text/x-opml;charset=utf-8", opml);
 }
 
 /**
@@ -177,6 +215,11 @@ export function HeaderMoreMenu() {
           <DropdownMenuItem onClick={copyOutlineAsMarkdown}>
             <ClipboardCopyIcon />
             Copy as Markdown
+          </DropdownMenuItem>
+
+          <DropdownMenuItem onClick={exportOutlineAsOpml}>
+            <DownloadIcon />
+            Export OPML
           </DropdownMenuItem>
 
           <DropdownMenuItem onClick={() => setConnectOpen(true)}>

--- a/src/data/download.ts
+++ b/src/data/download.ts
@@ -1,0 +1,20 @@
+// Client-only browser download helper (ADR 0037): Blob -> object URL -> a
+// programmatic `<a download>` click. The OPML export action rides this; any
+// future "save as file" surface (JSON backup, markdown file) should too.
+// Never import this from the Worker -- it touches DOM globals.
+
+/** Trigger a browser download of `text` as `filename` with the given MIME. */
+export function downloadTextFile(
+  filename: string,
+  mime: string,
+  text: string,
+): void {
+  const url = URL.createObjectURL(new Blob([text], { type: mime }))
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  a.remove()
+  URL.revokeObjectURL(url)
+}


### PR DESCRIPTION
## Summary

Adds the app-side OPML export UI (issue #127, OPML build 6/7). "Export OPML" now lives in the header More menu and as a Cmd+K global action (the ADR 0034 `useGlobalActions` bridge), sibling to Copy as Markdown.

- **Scope = zoom-root-or-all, root included** — the `copyOutlineAsMarkdown` precedent, read live at click time (`getTreeIndex` + `getViewRootId`).
- **Serialization is entirely the shared core** (`src/data/opml-export.ts`, merged in #133) — this PR adds no OPML logic, just the shell that picks scope, names the file, and downloads.
- **New `src/data/download.ts`**: `downloadTextFile(filename, mime, text)` — Blob → `URL.createObjectURL` → `<a download>` click → `revokeObjectURL`. Client-only.
- **Filename**: `dotflowy-export-<YYYY-MM-DD>.opml` at home; zoomed `dotflowy-<slug>-<date>.opml` (slug = `flattenInline` of the root text, lowercased, non-alphanumerics → `-`, capped ~40 chars). Local date via `localDateKey` (never `toISOString`). MIME `text/x-opml;charset=utf-8`.
- Touch on `command-actions.tsx` is minimal and additive (one import + one action row) so the sibling Import OPML branch merges cleanly.

## Test evidence

- `bun run lint` — pass
- `bun run typecheck` — pass
- `bun run typecheck:test` — pass
- `bun run test` — 434 pass, 0 fail
- `bunx playwright test e2e/opml-export.spec.ts` — 3/3 pass (run against this branch's own dev server on :3213; a stale main-checkout server held :3210)

The new spec intercepts the download **in page** (shadows `HTMLAnchorElement.prototype.click` for blob hrefs — no real filesystem download) and asserts: zoomed export contains only the subtree with the root as the single top-level `<outline>`; `_complete="true"` on the completed node; `_task="true"` on the to-do; the mirror emits the fully resolved duplicate plus `id` on the in-scope source and `_mirror="<sourceId>"` on the mirror root; no `ownerEmail` in `<head>`; home export includes every top-level node; and the Cmd+K action runs the same export.

## Manual check

Cam — the live-verified path is a real Workflowy paste-import, which I can't do:

1. Open a zoomed view with some formatting (bold, a highlight, a to-do, a completed item), run **More → Export OPML**.
2. Open the downloaded `.opml` in a text editor, select-all, copy.
3. Paste into a Workflowy bullet — structure, order, and inline formatting should land cleanly; completed items should arrive completed.
4. Repeat once from home (full outline) to sanity-check scale.

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)