### PR TITLE
App OPML import: file picker → summary dialog → one atomic commit (OPML build 5/7)

### DIFF
--- a/e2e/opml-import.spec.ts
+++ b/e2e/opml-import.spec.ts
@@ -1,0 +1,186 @@
+// App OPML import (ADR 0037, issue #126): "Import OPML…" (More menu + Cmd+K)
+// opens a hidden file input; parse is client-side; ONE dialog carries
+// summary/confirm (with the core's degradation disclosures), modal progress,
+// and success/error. The commit is one history capture + ONE runStructural
+// batch, landing under a fresh top-level container created collapsed. A
+// malformed file errors cleanly at the summary step and writes NOTHING.
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { expect, test, type FileChooser, type Page } from "@playwright/test";
+import { seedOutline, STANDARD_TREE } from "./fixtures";
+
+const SAMPLE_PATH = fileURLToPath(
+  new URL(
+    "../docs/spec-assets/opml/workflowy-crafted-sample.opml",
+    import.meta.url,
+  ),
+);
+
+const text = (page: Page, id: string) =>
+  page.locator(`li[data-node-id="${id}"] > .outline-row .node-text`);
+
+// The freshly-created import container row (its id is minted at import time,
+// so locate it by its "Imported from Workflowy — {date}" text).
+const containerRow = (page: Page) =>
+  page.locator("li[data-node-id]", { hasText: "Imported from Workflowy" });
+
+async function load(page: Page) {
+  await seedOutline(page, STANDARD_TREE);
+  await page.goto("/");
+  await expect(text(page, "alpha")).toBeVisible();
+}
+
+// Open the More menu, click "Import OPML…", and answer the native file picker.
+async function pickFile(
+  page: Page,
+  files: Parameters<FileChooser["setFiles"]>[0],
+) {
+  await page.getByRole("button", { name: /more/i }).click();
+  const chooserPromise = page.waitForEvent("filechooser");
+  await page.getByRole("menuitem", { name: /Import OPML/ }).click();
+  const chooser = await chooserPromise;
+  await chooser.setFiles(files);
+}
+
+test.describe("OPML import", () => {
+  test("crafted sample: summary discloses degradations; import lands one collapsed container that persists", async ({
+    page,
+  }) => {
+    await load(page);
+    await pickFile(page, SAMPLE_PATH);
+
+    // Summary/confirm: counts + every degradation line from the core's tally.
+    const summary = page.getByTestId("opml-summary");
+    await expect(summary).toBeVisible();
+    await expect(summary).toContainText("23 bullets");
+    const disclosures = page.getByTestId("opml-disclosures");
+    await expect(disclosures).toContainText("1 note became 2 child bullets");
+    await expect(disclosures).toContainText(
+      "2× nested <mark> dropped (outermost wins)",
+    );
+    await expect(disclosures).toContainText(
+      "1× <mention> -> @mention(id) (name unrecoverable)",
+    );
+
+    // Confirm -> (modal progress flashes by) -> success.
+    await page.getByTestId("opml-confirm").click();
+    await expect(page.getByTestId("opml-success")).toBeVisible();
+    await expect(page.getByTestId("opml-success")).toContainText("23 bullets");
+
+    // "Go to imported" zooms into the container; the imported subtree renders
+    // (zooming shows a collapsed root's children).
+    await page.getByRole("button", { name: "Go to imported" }).click();
+    await expect(page.locator("h2.zoomed-title")).toContainText(
+      "Imported from Workflowy",
+    );
+    const sampleRoot = page.locator("li[data-node-id]", {
+      hasText: "dotflowy OPML sample (safe to delete)",
+    });
+    await expect(sampleRoot.first()).toBeVisible();
+    // Inline mapping applied (folded bold token renders its interior) and the
+    // _note became child bullets.
+    await expect(
+      page.locator(".node-text", { hasText: "bold text" }).first(),
+    ).toBeVisible();
+    await expect(
+      page
+        .locator(".node-text", { hasText: "note line two after a hard newline" })
+        .first(),
+    ).toBeVisible();
+    await expect(
+      page.locator(".node-text", { hasText: "level 6 deepest" }).first(),
+    ).toBeVisible();
+
+    // Back home (a full reload): the container is a NEW top-level row appended
+    // after the seeded tree, created collapsed — none of its 23 descendants
+    // render. Surviving the reload proves the batch persisted to the (mock)
+    // server store, not just the optimistic overlay.
+    await page.goto("/");
+    await expect(text(page, "alpha")).toBeVisible();
+    const container = containerRow(page);
+    await expect(container).toHaveCount(1);
+    await expect(container).not.toHaveAttribute("data-parent-id", /.+/);
+    await expect(
+      page.locator("li[data-node-id]", {
+        hasText: "dotflowy OPML sample",
+      }),
+    ).toHaveCount(0);
+  });
+
+  test("one Cmd+Z removes the whole import (single pre-batch capture)", async ({
+    page,
+  }) => {
+    await load(page);
+    await pickFile(page, SAMPLE_PATH);
+    await page.getByTestId("opml-confirm").click();
+    await expect(page.getByTestId("opml-success")).toBeVisible();
+    await page.getByRole("button", { name: "Done" }).click();
+
+    // The collapsed container landed at home. (No reload here — the undo stack
+    // is session state; a reload would wipe it by design.)
+    await expect(containerRow(page)).toHaveCount(1);
+
+    await text(page, "alpha").click();
+    await expect(text(page, "alpha")).toBeFocused();
+    await page.keyboard.press("ControlOrMeta+z");
+    await expect(containerRow(page)).toHaveCount(0);
+    // The seeded outline is intact.
+    for (const id of ["alpha", "bravo", "charlie"]) {
+      await expect(text(page, id)).toBeVisible();
+    }
+    // And the undo's restore batch persisted: a reload still shows no container.
+    await page.reload();
+    await expect(text(page, "alpha")).toBeVisible();
+    await expect(containerRow(page)).toHaveCount(0);
+    await expect(page.locator("li[data-node-id]")).toHaveCount(
+      STANDARD_TREE.length,
+    );
+  });
+
+  test("a truncated file shows the parse error (line/column) and writes nothing", async ({
+    page,
+  }) => {
+    await load(page);
+    const truncated = readFileSync(SAMPLE_PATH, "utf8").slice(0, 400);
+    await pickFile(page, {
+      name: "truncated.opml",
+      mimeType: "text/xml",
+      buffer: Buffer.from(truncated),
+    });
+
+    const error = page.getByTestId("opml-error");
+    await expect(error).toBeVisible();
+    await expect(error).toContainText(/line \d+, column \d+/);
+    await expect(error).toContainText("Nothing was imported");
+    // No summary, no confirm — the flow never reaches a write.
+    await expect(page.getByTestId("opml-confirm")).toHaveCount(0);
+
+    await page.getByTestId("opml-error-close").click();
+    await expect(containerRow(page)).toHaveCount(0);
+    // Reload: the (mock) server store received no write at all.
+    await page.reload();
+    await expect(text(page, "alpha")).toBeVisible();
+    await expect(containerRow(page)).toHaveCount(0);
+    await expect(page.locator("li[data-node-id]")).toHaveCount(
+      STANDARD_TREE.length,
+    );
+  });
+
+  test("Cmd+K runs the same Import OPML action (the ADR 0034 bridge)", async ({
+    page,
+  }) => {
+    await load(page);
+    await page.keyboard.press("ControlOrMeta+k");
+    const input = page.getByPlaceholder(/Search nodes and actions/);
+    await expect(input).toBeVisible();
+    await input.fill("import opml");
+    await expect(
+      page.getByRole("option", { name: /Import OPML/ }),
+    ).toBeVisible();
+    const chooserPromise = page.waitForEvent("filechooser");
+    await page.getByRole("option", { name: /Import OPML/ }).click();
+    // The action fired the same hidden file input — the picker opening IS the
+    // proof both surfaces share one entry point.
+    await chooserPromise;
+  });
+});

--- a/src/components/command-actions.tsx
+++ b/src/components/command-actions.tsx
@@ -9,6 +9,7 @@ import {
   ClipboardCopyIcon,
   DownloadIcon,
   ExternalLinkIcon,
+  FileUpIcon,
   FocusIcon,
   LogOutIcon,
   MonitorIcon,
@@ -30,6 +31,7 @@ import {
   exportOutlineAsOpml,
   setViewCollapsed,
 } from "./header-more-menu";
+import { openOpmlImport } from "./opml-import-opener";
 
 /**
  * The GLOBAL-scope half of the Cmd+K command center (ADR 0034): the header +
@@ -69,6 +71,15 @@ export function useGlobalActions(opts: {
         run: () => {
           void copyOutlineAsMarkdown();
         },
+      },
+      {
+        id: "g:import-opml",
+        label: "Import OPML…",
+        description: "Import a Workflowy OPML export",
+        icon: FileUpIcon,
+        scope: "global",
+        keywords: ["import", "opml", "workflowy", "migrate", "file"],
+        run: () => openOpmlImport(),
       },
       {
         id: "g:export-opml",

--- a/src/components/header-more-menu.tsx
+++ b/src/components/header-more-menu.tsx
@@ -6,6 +6,7 @@ import {
   CircleCheckIcon,
   ClipboardCopyIcon,
   DownloadIcon,
+  FileUpIcon,
   FocusIcon,
   LogOutIcon,
   MonitorIcon,
@@ -50,6 +51,7 @@ import { childrenOf } from "../data/tree";
 import { toggleCollapsed } from "../data/mutations";
 import { runStructural } from "../data/structural";
 import { capture } from "../data/history";
+import { openOpmlImport } from "./opml-import-opener";
 
 /**
  * GitHub's brand glyph (Simple Icons). lucide-react dropped its Github icon, so
@@ -215,6 +217,11 @@ export function HeaderMoreMenu() {
           <DropdownMenuItem onClick={copyOutlineAsMarkdown}>
             <ClipboardCopyIcon />
             Copy as Markdown
+          </DropdownMenuItem>
+
+          <DropdownMenuItem onClick={() => openOpmlImport()}>
+            <FileUpIcon />
+            Import OPML…
           </DropdownMenuItem>
 
           <DropdownMenuItem onClick={exportOutlineAsOpml}>

--- a/src/components/opml-import-dialog.tsx
+++ b/src/components/opml-import-dialog.tsx
@@ -1,0 +1,419 @@
+import { useEffect, useRef, useState, type ChangeEvent } from "react";
+import { Effect } from "effect";
+import { useNavigate } from "@tanstack/react-router";
+import {
+  CircleCheckIcon,
+  Loader2Icon,
+  TriangleAlertIcon,
+} from "lucide-react";
+import { Button } from "./ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "./ui/dialog";
+import { setOpmlImportOpener } from "./opml-import-opener";
+import {
+  OPML_APP_MAX_NODES,
+  OpmlEmpty,
+  OpmlImportTooLarge,
+  parseOpml,
+  planOpmlImport,
+  type OpmlImportResult,
+  type OpmlImportReport,
+} from "../data/opml-import";
+import { nodesCollection } from "../data/collection";
+import { capture, drop } from "../data/history";
+import { runStructuralTracked } from "../data/structural";
+import { getTreeIndex } from "../data/tree-store";
+import { childrenOf, makeNode, now } from "../data/tree";
+
+/**
+ * OPML import (ADR 0037, app surface): "Import OPML…" opens the hidden file
+ * input below; the chosen file is parsed CLIENT-side and ONE dialog carries the
+ * whole flow — summary/confirm with explicit degradation disclosure, modal
+ * progress, then success ("Go to imported") or an error that states plainly
+ * that nothing was imported. Mounted once in `__root.tsx`; both entry surfaces
+ * (More menu + Cmd+K) reach it through `openOpmlImport()`.
+ *
+ * The commit is the client write path, not a new endpoint: one history
+ * `capture` (a single Cmd+Z removes the whole import), then ONE
+ * `runStructuralTracked` batch — every insert lands as one `POST /api/nodes
+ * {ops}` → DO `applyBatch`, whose reply carries the FINAL seq of the chunked
+ * changelog (>500-op batches echo as several frames) and `waitForSeq` holds the
+ * optimistic overlay across all of them. Any fault rejects the transaction,
+ * TanStack rolls the optimistic state back, and the dialog reports "nothing was
+ * imported" — retry-safe, never a half-import.
+ *
+ * Everything lands under one fresh top-level container ("Imported from
+ * Workflowy — {date}"), ALWAYS appended (re-import = a second container, no
+ * dedup) and created `collapsed: true` — the perf guard: `buildVisibleRows`
+ * never descends into a collapsed root, so a huge optimistic insert can't
+ * thrash the windowed list mid-commit.
+ */
+
+type Stage =
+  | { kind: "closed" }
+  | { kind: "summary"; data: OpmlImportResult; fileName: string }
+  | { kind: "importing"; count: number }
+  | { kind: "success"; containerId: string; count: number }
+  | { kind: "error"; title: string; detail: string | null };
+
+function plural(n: number, unit: string): string {
+  return `${n} ${unit}${n === 1 ? "" : "s"}`;
+}
+
+/** Every disclosure line the summary shows — the core report's tally rendered
+ *  verbatim ("N notes became child bullets", each counted degradation, each
+ *  tolerated HTML anomaly, each unknown attribute). Empty = full fidelity. */
+function disclosureLines(report: OpmlImportReport): string[] {
+  const lines: string[] = [];
+  if (report.notes > 0) {
+    lines.push(
+      `${plural(report.notes, "note")} became ${plural(report.noteLines, "child bullet")}`,
+    );
+  }
+  if (report.noteBlanksDropped > 0) {
+    lines.push(`${plural(report.noteBlanksDropped, "blank note line")} dropped`);
+  }
+  if (report.textNewlineSplits > 0) {
+    lines.push(
+      `${plural(report.textNewlineSplits, "multi-line bullet")} split into child bullets`,
+    );
+  }
+  if (report.mirrorsLinked > 0) {
+    lines.push(`${plural(report.mirrorsLinked, "mirror")} re-linked`);
+  }
+  for (const [message, count] of Object.entries(report.degraded)) {
+    lines.push(`${count}× ${message}`);
+  }
+  for (const [message, count] of Object.entries(report.anomalies)) {
+    lines.push(`${count}× ${message} (malformed HTML tolerated)`);
+  }
+  for (const [name, count] of Object.entries(report.unknownAttributes)) {
+    lines.push(`${count}× unknown attribute "${name}" ignored`);
+  }
+  return lines;
+}
+
+/** A parse failure's one-line detail. `OpmlParseError.reason` may already end
+ *  with the parser's own "(line X, column Y)" (its `message` getter would then
+ *  double it), so only append the location when the reason lacks it. */
+function parseErrorDetail(error: {
+  _tag: string;
+  message: string;
+  reason?: string;
+  line?: number | null;
+  column?: number | null;
+}): string {
+  if (error._tag !== "OpmlParseError" || error.reason === undefined) {
+    return error.message;
+  }
+  if (error.line != null && !error.reason.includes(`line ${error.line}`)) {
+    return `${error.reason} (line ${error.line}, column ${error.column})`;
+  }
+  return error.reason;
+}
+
+function containerText(timestamp: number): string {
+  const date = new Date(timestamp).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+  return `Imported from Workflowy — ${date}`;
+}
+
+export function OpmlImportDialog() {
+  const [stage, setStage] = useState<Stage>({ kind: "closed" });
+  const inputRef = useRef<HTMLInputElement>(null);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    setOpmlImportOpener(() => inputRef.current?.click());
+    return () => setOpmlImportOpener(null);
+  }, []);
+
+  const onFile = async (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    // Reset so re-picking the same file fires change again.
+    e.target.value = "";
+    if (!file) return;
+    let source: string;
+    try {
+      source = await file.text();
+    } catch {
+      setStage({
+        kind: "error",
+        title: "Couldn't read the file",
+        detail: "The file could not be read. Nothing was imported.",
+      });
+      return;
+    }
+    // Parse is pure + synchronous (~29ms for a 17k-node export). A malformed or
+    // truncated file fails HERE, with the parser's line/column — the clean
+    // error at the summary step, never a half-import.
+    const parsed = Effect.runSync(
+      Effect.match(parseOpml(source), {
+        onSuccess: (data) => ({ ok: true as const, data }),
+        onFailure: (error) => ({ ok: false as const, error }),
+      }),
+    );
+    if (!parsed.ok) {
+      setStage({
+        kind: "error",
+        title: "Couldn't read this OPML file",
+        detail: `${parseErrorDetail(parsed.error)}. Nothing was imported.`,
+      });
+      return;
+    }
+    const { report } = parsed.data;
+    if (report.nodesPost === 0) {
+      setStage({
+        kind: "error",
+        title: "Nothing to import",
+        detail: "The file contains no outline bullets. Nothing was imported.",
+      });
+      return;
+    }
+    // The friendly ceiling (ADR 0037): counted post note-splitting, rejected
+    // here in the dialog before any plan or write exists.
+    if (report.nodesPost > OPML_APP_MAX_NODES) {
+      setStage({
+        kind: "error",
+        title: "This file is too large to import",
+        detail: `It holds ${report.nodesPost.toLocaleString()} bullets after note splitting; the limit is ${OPML_APP_MAX_NODES.toLocaleString()}. Nothing was imported.`,
+      });
+      return;
+    }
+    setStage({ kind: "summary", data: parsed.data, fileName: file.name });
+  };
+
+  const onConfirm = async () => {
+    if (stage.kind !== "summary") return;
+    const { forest, report } = stage.data;
+    setStage({ kind: "importing", count: report.nodesPost });
+    // Let the modal progress state paint before the synchronous optimistic
+    // insert burst occupies the main thread.
+    await new Promise((r) => setTimeout(r, 0));
+
+    const index = getTreeIndex();
+    const tops = childrenOf(index, null);
+    const lastTop = tops.length ? tops[tops.length - 1]!.id : null;
+    const timestamp = now();
+    const containerId = crypto.randomUUID();
+    const plan = planOpmlImport(forest, {
+      parentId: containerId,
+      firstPrev: null,
+      timestamp,
+      newId: () => crypto.randomUUID(),
+      maxNodes: OPML_APP_MAX_NODES,
+    });
+    if (plan instanceof OpmlEmpty || plan instanceof OpmlImportTooLarge) {
+      setStage({
+        kind: "error",
+        title: "Nothing was imported",
+        detail: plan.message,
+      });
+      return;
+    }
+
+    // ONE undo point BEFORE the batch: a single Cmd+Z removes the whole import.
+    capture(index, null);
+    const { persisted } = runStructuralTracked(() => {
+      nodesCollection.insert(
+        makeNode({
+          id: containerId,
+          prevSiblingId: lastTop,
+          text: containerText(timestamp),
+          collapsed: true,
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        }),
+      );
+      // The plan is insert-only, emitted depth-first pre-order with the sibling
+      // chain wired by construction — replayed verbatim into the collection.
+      for (const op of plan.ops) {
+        if (op.op !== "delete") nodesCollection.insert(op.value);
+      }
+    });
+    try {
+      await persisted;
+      setStage({ kind: "success", containerId, count: plan.count });
+    } catch {
+      // The transaction rolled back, so the outline already matches the
+      // captured snapshot — drop the redundant undo point.
+      drop();
+      setStage({
+        kind: "error",
+        title: "Import failed",
+        detail: "The outline could not be saved. Nothing was imported.",
+      });
+    }
+  };
+
+  const open = stage.kind !== "closed";
+  const importing = stage.kind === "importing";
+
+  return (
+    <>
+      <input
+        ref={inputRef}
+        type="file"
+        accept=".opml,.xml,text/xml,text/x-opml,application/xml"
+        className="hidden"
+        data-testid="opml-file-input"
+        onChange={onFile}
+      />
+      <Dialog
+        open={open}
+        onOpenChange={(next) => {
+          // Editing is blocked while the modal progress is up: the dialog can't
+          // be dismissed mid-commit (Escape/backdrop are ignored).
+          if (!next && !importing) setStage({ kind: "closed" });
+        }}
+      >
+        <DialogContent
+          className="sm:max-w-md"
+          showCloseButton={!importing}
+          data-testid="opml-import-dialog"
+        >
+          {stage.kind === "summary" && (
+            <SummaryStage
+              data={stage.data}
+              fileName={stage.fileName}
+              onCancel={() => setStage({ kind: "closed" })}
+              onConfirm={onConfirm}
+            />
+          )}
+          {stage.kind === "importing" && (
+            <div
+              className="flex flex-col items-center gap-3 py-6"
+              data-testid="opml-importing"
+            >
+              <Loader2Icon className="size-6 animate-spin text-muted-foreground" />
+              <DialogTitle>Importing…</DialogTitle>
+              <DialogDescription>
+                Saving {stage.count.toLocaleString()} bullets as one atomic
+                batch.
+              </DialogDescription>
+            </div>
+          )}
+          {stage.kind === "success" && (
+            <>
+              <DialogHeader>
+                <DialogTitle className="flex items-center gap-2">
+                  <CircleCheckIcon className="size-4 text-primary" />
+                  Import complete
+                </DialogTitle>
+                <DialogDescription data-testid="opml-success">
+                  Imported {stage.count.toLocaleString()} bullets into a new
+                  collapsed container at the bottom of your outline. One undo
+                  (Cmd+Z) removes it all.
+                </DialogDescription>
+              </DialogHeader>
+              <DialogFooter>
+                <Button
+                  variant="outline"
+                  onClick={() => setStage({ kind: "closed" })}
+                >
+                  Done
+                </Button>
+                <Button
+                  onClick={() => {
+                    const nodeId = stage.containerId;
+                    setStage({ kind: "closed" });
+                    navigate({ to: "/$nodeId", params: { nodeId } });
+                  }}
+                >
+                  Go to imported
+                </Button>
+              </DialogFooter>
+            </>
+          )}
+          {stage.kind === "error" && (
+            <>
+              <DialogHeader>
+                <DialogTitle className="flex items-center gap-2">
+                  <TriangleAlertIcon className="size-4 text-destructive" />
+                  {stage.title}
+                </DialogTitle>
+                <DialogDescription data-testid="opml-error">
+                  {stage.detail ?? "Nothing was imported."}
+                </DialogDescription>
+              </DialogHeader>
+              <DialogFooter>
+                <Button
+                  variant="outline"
+                  data-testid="opml-error-close"
+                  onClick={() => setStage({ kind: "closed" })}
+                >
+                  Close
+                </Button>
+              </DialogFooter>
+            </>
+          )}
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+function SummaryStage({
+  data,
+  fileName,
+  onCancel,
+  onConfirm,
+}: {
+  data: OpmlImportResult;
+  fileName: string;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  const { report } = data;
+  const lines = disclosureLines(report);
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>Import OPML</DialogTitle>
+        <DialogDescription data-testid="opml-summary">
+          {fileName}: {report.nodesPost.toLocaleString()} bullets will be added
+          under a new collapsed "Imported from Workflowy" container.
+        </DialogDescription>
+      </DialogHeader>
+      {lines.length > 0 ? (
+        <div className="flex flex-col gap-1.5">
+          <p className="text-xs font-medium text-muted-foreground">
+            Translated with {plural(lines.length, "disclosure")} — text is never
+            lost, presentation may shift:
+          </p>
+          <ul
+            className="max-h-48 overflow-y-auto rounded-md border bg-muted/30 p-2 text-xs text-muted-foreground"
+            data-testid="opml-disclosures"
+          >
+            {lines.map((line) => (
+              <li key={line} className="py-0.5">
+                {line}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : (
+        <p className="text-xs text-muted-foreground">
+          Full fidelity: nothing changes in translation.
+        </p>
+      )}
+      <DialogFooter>
+        <Button variant="outline" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button onClick={onConfirm} data-testid="opml-confirm">
+          Import {report.nodesPost.toLocaleString()} bullets
+        </Button>
+      </DialogFooter>
+    </>
+  );
+}

--- a/src/components/opml-import-opener.ts
+++ b/src/components/opml-import-opener.ts
@@ -1,0 +1,15 @@
+let opener: (() => void) | null = null;
+
+export function setOpmlImportOpener(fn: typeof opener) {
+  opener = fn;
+}
+
+/**
+ * Kick off the OPML import flow (hidden file picker -> summary dialog) from
+ * anywhere — the header More menu and the Cmd+K command center both call this
+ * (ADR 0034: one action, several surfaces). The dialog itself is mounted once
+ * in `__root.tsx` (`OpmlImportDialog`), which registers the opener.
+ */
+export function openOpmlImport() {
+  opener?.();
+}

--- a/src/data/structural.ts
+++ b/src/data/structural.ts
@@ -34,11 +34,32 @@ import { chainDisagreements } from './sibling-chain'
  * one atomic frame, and the per-keystroke text path must not await an echo.
  */
 export function runStructural<T>(body: () => T): T {
+  const { result, persisted } = runStructuralTracked(body)
+  // Nobody consumes the outcome here — a failed batch already rolls the
+  // transaction back — so mark the derived promise handled to avoid an
+  // unhandled-rejection report for every offline structural write.
+  persisted.catch(() => {})
+  return result
+}
+
+/**
+ * `runStructural`, plus a `persisted` promise that settles when the batch's
+ * echo has landed (resolves) or the send failed and the optimistic overlay
+ * rolled back (rejects). For flows that must REPORT the outcome — the OPML
+ * import dialog awaits it to flip from "importing" to success/failure (ADR
+ * 0037: any fault means "nothing was imported"). Same single-batch guarantees
+ * as `runStructural`; this only exposes the transaction's own completion.
+ */
+export function runStructuralTracked<T>(body: () => T): {
+  result: T
+  persisted: Promise<void>
+} {
   // Nesting guard: a compound flow (e.g. the daily get-or-create, which creates
   // a container then a day) may call runStructural while already inside one.
   // Join the outer transaction so the whole flow is ONE frame; never open a
-  // second (which would re-tear the very thing we're fixing).
-  if (getActiveTransaction()) return body()
+  // second (which would re-tear the very thing we're fixing). The outer
+  // transaction owns persistence, so there is nothing separate to track.
+  if (getActiveTransaction()) return { result: body(), persisted: Promise.resolve() }
 
   let result!: T
   const tx = createTransaction({
@@ -50,7 +71,9 @@ export function runStructural<T>(body: () => T): T {
       // P1 (atomic, writeSem-serialized send) → P2 (hold optimistic until the
       // echo) as ONE Effect program, bridged once here at the async mutationFn
       // seam (ADR 0021). waitForSeqE never fails, so the only rejection — which
-      // rolls the transaction back — comes from the batch send.
+      // rolls the transaction back — comes from the batch send. A chunked
+      // >500-op batch replies with its FINAL seq (worker/outline-do.ts), so
+      // waiting on it spans the whole multi-frame echo.
       await runPromise(
         persistBatchE(ops).pipe(Effect.flatMap(({ seq }) => waitForSeqE(seq))),
       )
@@ -60,7 +83,7 @@ export function runStructural<T>(body: () => T): T {
     result = body()
   })
   if (import.meta.env.DEV) assertTouchedChainsClean(tx.mutations)
-  return result
+  return { result, persisted: tx.isPersisted.promise.then(() => undefined) }
 }
 
 /** A PendingMutation, narrowed to the fields the batch wire format needs. */

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -10,6 +10,7 @@ import { TextSizeProvider } from '../components/text-size-provider'
 import { ShowCompletedProvider } from '../components/show-completed-provider'
 import { NodeSwitcher } from '../components/node-switcher'
 import { MoveDialog } from '../components/move-dialog'
+import { OpmlImportDialog } from '../components/opml-import-dialog'
 import { MirrorPlaces } from '../components/mirror-places'
 import { TagColorStyles } from '../plugins/tags/tag-color-menu'
 import { SpotlightController } from '../components/spotlight-mode'
@@ -79,6 +80,7 @@ function RootComponent() {
               <Outlet />
               <NodeSwitcher />
               <MoveDialog />
+              <OpmlImportDialog />
               <MirrorPlaces />
               <TagColorStyles />
               <SpotlightController />

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,4 +1,0 @@
-{
-  "status": "passed",
-  "failedTests": []
-}


### PR DESCRIPTION
## Summary

Issue #126 — the app-UI half of OPML import (ADR 0037), consuming the shared core from #133 verbatim (no parse/map/plan logic reimplemented).

- **Entry (ADR 0034 bridge):** "Import OPML…" as a More-menu item **and** a Cmd+K global action — ONE action via a shared module opener (`opml-import-opener.ts`), clicking a hidden `<input type="file" accept=".opml,.xml,…">`. No drag-drop (deferred per issue).
- **One dialog, whole flow** (`opml-import-dialog.tsx`, mounted once in `__root.tsx`): client-side `parseOpml` → summary/confirm with the counts and **every** line of the core's degradation tally ("1 note became 2 child bullets", each `degraded`/`anomalies`/`unknownAttributes` entry) → modal progress (undismissable mid-commit, so editing is blocked) → success with "Go to imported" (zooms into the container) or an error stating plainly that **nothing was imported**. A malformed/truncated file errors cleanly at the summary step with the parser's line/column.
- **Commit:** history `capture` first (one Cmd+Z removes the whole import, `drop()` on failure), then ONE `runStructural` batch replaying `planOpmlImport`'s insert plan → `POST /api/nodes {ops}` → DO `applyBatch`, with `waitForSeq` on the **final** seq of the chunked changelog (#130). New additive export `runStructuralTracked` in `structural.ts` exposes the transaction's `persisted` promise so the dialog can await the echo; `runStructural` is now a thin shell over it — behavior unchanged for every existing caller.
- **Landing:** one fresh top-level container `Imported from Workflowy — {date}`, always-append, created `collapsed: true` (the client-tx perf guard — `buildVisibleRows` never descends into it mid-commit).
- **Ceiling:** 50,000 post-split nodes, friendly rejection in the dialog before any plan or write exists.

### Deferred (noted per issue scope)

- **Hard Worker-side ceiling enforcement** — would need a new wire-schema surface on the `/api/nodes` batch decode; the dialog-side rejection is the only gate for now.
- Cosmetic: the shared core's `OpmlParseError.message` getter can double the parser's own `(line X, column Y)` suffix; the dialog composes its detail defensively (`parseErrorDetail`). Worth a one-line core fix later (kept out to preserve probe byte-compat).

## Test evidence

New `e2e/opml-import.spec.ts` (via `seedOutline`, reading the crafted sample `docs/spec-assets/opml/workflowy-crafted-sample.opml` at test-definition time):

1. **Crafted sample import** — summary shows "23 bullets" + the exact disclosure lines (`1 note became 2 child bullets`, `2× nested <mark> dropped (outermost wins)`, `1× <mention> -> @mention(id) (name unrecoverable)`); "Go to imported" shows the mapped contents (folded bold, note-derived child bullets, 6-deep nesting); back home the container is top-level, collapsed (zero descendants render), and **survives a reload** (persisted to the mock store, not just the overlay).
2. **One Cmd+Z removes the whole import**; seeded tree intact; removal persists across reload.
3. **Truncated file** — parse error with `line N, column N`, "Nothing was imported", no confirm button ever, zero writes (node count unchanged after reload).
4. **Cmd+K bridge** — the "Import OPML…" action row fires the same file chooser.

Gates (all green):

```
bun run lint            ✓
bun run typecheck       ✓
bun run typecheck:test  ✓
bun run test            ✓ 434 pass / 0 fail
bunx playwright test e2e/opml-import.spec.ts   ✓ 4 passed (8.9s)
```

(The spec was run on a clean port — another checkout held :3210 — using the same config shape; only the new spec was run per the known pre-existing flakes in the full suite.)

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)