### PR TITLE
Fix nodes vanishing when indented under a mirror

### DIFF
--- a/docs/adr/0022-node-mirrors.md
+++ b/docs/adr/0022-node-mirrors.md
@@ -99,6 +99,13 @@ for instances (Notion's red/blue, revealed only when you're working in it) — *
   a "source not found" leaf, never throws.
 - **Reverse index** (`sourceId → instance ids`) maintained in the tree-store like `childrenByParent` — powers
   the count badge and the promote lookup without an O(n) scan per delete.
+- **Orphan rescue at snapshot load** (`healMirrorOrphans`, `collection.ts`, the `healSiblingChains` sibling).
+  Any node whose `parentId` points at a mirror **instance** (`parent.mirrorOf != null`) is by definition
+  orphaned — a mirror windows its source's children, so the instance-parented node is never rendered. This is
+  the data left behind by the pre-fix keyboard-indent bug (mirrors ship default-ON, so real outlines have it).
+  The heal repoints each such node at the true source, appended after the source's real children, and persists
+  it. **Gated on `isMirrorsEnabled()`**: with the flag OFF a `mirrorOf` node renders its own children, so that
+  child is legitimately placed and must NOT be moved. Early-returns on any flag-off / mirror-free outline.
 - **Single-DO safety.** Source and all instances live in the same per-user Durable Object
   ([ADR 0008](./0008-sync-via-a-per-user-durable-object.md)); a mirror is always intra-DO, so there's no
   cross-boundary consistency problem. (Cross-user mirrors would be a different decision — out of scope.)
@@ -128,6 +135,16 @@ Even though we chose A1, the build is sequenced so daily value arrives before th
   `flash`/drag/multi-select inside mirrored subtrees, and structural mutations redirecting at the mirror
   boundary (insert a child under a mirror → under the source). The caret-sensitive, regression-prone part;
   heavy e2e.
+  - **Boundary redirect covers EVERY structural entry point, not just drag.** The first cut resolved the
+    mirror boundary only in the drag `onMove` handler; keyboard **indent** (`Tab`), the **edge reparent**
+    (`Cmd+Shift+↑/↓` nudging into an uncle/aunt), and **multi-select `Tab`** (`indentManyNodes`) each derive
+    their new parent *inside* the mutation primitive, so a mirror prev-sibling/uncle sent the node under the
+    **instance** id — whose row windows the *source's* children and never the node, so it **vanished**. Fixed
+    by resolving `trueSourceOf` at each derivation site (`indent`, `reparentIntoParent{Prev,Next}Sibling`,
+    `indentManyNodes`). The flag is passed **as a `resolveMirror` param**, never a `flags.ts` read — `mutations.ts`
+    stays pure and OFF runs byte-identical old code (matching the drag call site, which gates on
+    `isMirrorsEnabled()`). Collapse-expand still targets the visible **instance** (a local field). `outdent` is
+    unaffected — its target is a grandparent, always a real content node. e2e: `mirror-editing.spec.ts`.
 - **Stage 3 — promote-on-delete** (direct + cascade-aware) and its undo/redo.
 
 ## Don't regress

--- a/e2e/mirror-editing.spec.ts
+++ b/e2e/mirror-editing.spec.ts
@@ -381,6 +381,47 @@ test.describe("node mirrors -- editing parity inside a mirror (ADR 0022, 2c)", (
     expect(chainErrors).toEqual([]);
   });
 
+  test("Tab on a node whose prev sibling is a mirror OF ITSELF is a safe no-op (cycle guard)", async ({
+    page,
+  }) => {
+    // Mirror resolution turns the prev-sibling id into its SOURCE. If that prev
+    // sibling is a mirror of the moving node itself (or a descendant), the source
+    // resolves back to the node -> parenting it under itself corrupts the tree.
+    // `indent` splices raw (not via moveNode), so it must guard the way moveNode
+    // does. This proves the guard: Tab is refused, X stays put, chain intact.
+    const chainErrors: string[] = [];
+    page.on("console", (msg) => {
+      if (
+        msg.type() === "error" &&
+        msg.text().includes("sibling-chain invariant broken")
+      )
+        chainErrors.push(msg.text());
+    });
+
+    // M mirrors X and sits directly before it, so X's prev sibling resolves to X.
+    const tree: SeedNode[] = [
+      { id: "A", parentId: null, prevSiblingId: null, text: "alphasource" },
+      { id: "P", parentId: null, prevSiblingId: "A", text: "project" },
+      { id: "M", parentId: "P", prevSiblingId: null, text: "ph", mirrorOf: "X" },
+      { id: "X", parentId: "P", prevSiblingId: "M", text: "targetnode" },
+    ];
+    await load(page, tree, true);
+    await expect(page.locator('li[data-node-id="X"]')).toHaveCount(1);
+
+    await spans(page, "X").click();
+    await expect(spans(page, "X")).toBeFocused();
+    await page.keyboard.press("Tab");
+
+    // No-op: X is still a single row under P, never self-parented, chain clean.
+    await expect(page.locator('li[data-node-id="X"]')).toHaveCount(1);
+    await expect(page.locator('li[data-node-id="X"]')).toHaveAttribute(
+      "data-parent-id",
+      "P",
+    );
+    await expect(focused(page)).toHaveText("targetnode");
+    expect(chainErrors).toEqual([]);
+  });
+
   test("deleting a mirror instance removes only that instance, not the source", async ({
     page,
   }) => {

--- a/e2e/mirror-editing.spec.ts
+++ b/e2e/mirror-editing.spec.ts
@@ -51,11 +51,12 @@ async function load(page: Page, tree: SeedNode[], mirrors: boolean) {
   await page.addInitScript(() => {
     localStorage.setItem("dotflowy:flag:virtualized", "on");
   });
-  if (mirrors) {
-    await page.addInitScript(() => {
-      localStorage.setItem("dotflowy:flag:mirrors", "on");
-    });
-  }
+  // Set the mirrors flag EXPLICITLY -- the compiled default is ON (flags.ts), so
+  // relying on "don't set it" for the off case actually leaves mirrors on and the
+  // parity tests run against the wrong path. Always write the concrete value.
+  await page.addInitScript((on) => {
+    localStorage.setItem("dotflowy:flag:mirrors", on ? "on" : "off");
+  }, mirrors);
   await seedOutline(page, tree);
   await page.goto("/");
   await expect(spans(page, "A")).toBeVisible();
@@ -182,6 +183,201 @@ test.describe("node mirrors -- editing parity inside a mirror (ADR 0022, 2c)", (
     );
     await expect(spans(page, "a2").nth(1)).toBeFocused();
 
+    expect(chainErrors).toEqual([]);
+  });
+
+  test("Tab on a node whose PREV SIBLING is a mirror parents it into the SOURCE, not the vanishing instance", async ({
+    page,
+  }) => {
+    // The reported bug: indenting under a mirror sent the node under the INSTANCE
+    // id, whose row windows the SOURCE's children and never the node -> it
+    // disappeared. The drag path resolved the mirror boundary; keyboard indent
+    // did not. Fix: `indent(index, id, resolveMirror)` parents into the source,
+    // so the node windows into every instance (matching drag). Guard the chain
+    // tripwire too -- a bad reparent could tear the sibling chain.
+    const chainErrors: string[] = [];
+    page.on("console", (msg) => {
+      if (
+        msg.type() === "error" &&
+        msg.text().includes("sibling-chain invariant broken")
+      )
+        chainErrors.push(msg.text());
+    });
+
+    // X sits directly after the mirror M under P, so X's prev sibling IS the
+    // mirror instance -- the exact trigger.
+    const tree: SeedNode[] = [
+      { id: "A", parentId: null, prevSiblingId: null, text: "alphasource" },
+      { id: "P", parentId: null, prevSiblingId: "A", text: "project" },
+      { id: "a1", parentId: "A", prevSiblingId: null, text: "childone" },
+      { id: "M", parentId: "P", prevSiblingId: null, text: "ph", mirrorOf: "A" },
+      { id: "X", parentId: "P", prevSiblingId: "M", text: "extranode" },
+    ];
+    await load(page, tree, true);
+    await expect(page.locator('li[data-node-id="X"]')).toHaveCount(1);
+
+    // Tab X. It must parent into A (M's source), NOT the instance id.
+    await spans(page, "X").click();
+    await expect(spans(page, "X")).toBeFocused();
+    await page.keyboard.press("Tab");
+
+    // X is still here (not vanished) and now windows into BOTH instances: the
+    // real copy under source A and the windowed copy under mirror M -- so it
+    // renders twice, both parented to the content node A.
+    await expect(page.locator('li[data-node-id="X"]')).toHaveCount(2);
+    await expect(page.locator('li[data-node-id="X"]').nth(0)).toHaveAttribute(
+      "data-parent-id",
+      "A",
+    );
+    await expect(page.locator('li[data-node-id="X"]').nth(1)).toHaveAttribute(
+      "data-parent-id",
+      "A",
+    );
+    // Focus survived on X (never dropped into the void).
+    await expect(focused(page)).toHaveText("extranode");
+    expect(chainErrors).toEqual([]);
+  });
+
+  test("flag OFF: Tab under a mirrorOf node indents normally (no source redirect)", async ({
+    page,
+  }) => {
+    // The escape hatch must run today's exact code: OFF, a `mirrorOf` node is a
+    // plain leaf, so X indents under IT (not the phantom source). Proves the fix
+    // is gated on the flag, not an unconditional `mirrorOf` read.
+    const tree: SeedNode[] = [
+      { id: "A", parentId: null, prevSiblingId: null, text: "alphasource" },
+      { id: "P", parentId: null, prevSiblingId: "A", text: "project" },
+      { id: "a1", parentId: "A", prevSiblingId: null, text: "childone" },
+      { id: "M", parentId: "P", prevSiblingId: null, text: "placeholder", mirrorOf: "A" },
+      { id: "X", parentId: "P", prevSiblingId: "M", text: "extranode" },
+    ];
+    await load(page, tree, false);
+    await expect(spans(page, "a1")).toHaveCount(1); // no windowing
+
+    await spans(page, "X").click();
+    await expect(spans(page, "X")).toBeFocused();
+    await page.keyboard.press("Tab");
+
+    // X indented under the plain M, rendering once. No redirect to A.
+    await expect(page.locator('li[data-node-id="X"]')).toHaveCount(1);
+    await expect(page.locator('li[data-node-id="X"]')).toHaveAttribute(
+      "data-parent-id",
+      "M",
+    );
+  });
+
+  test("edge reparent (Cmd+Shift+Up) into a mirror UNCLE lands in the source, not the vanishing instance", async ({
+    page,
+  }) => {
+    // moveUp at the first-child edge reparents into the parent's PREVIOUS sibling
+    // (the "uncle"). When that uncle is a mirror, the same boundary applies as Tab:
+    // land in the SOURCE so the node windows into every instance, never under the
+    // instance id (which would orphan it).
+    const chainErrors: string[] = [];
+    page.on("console", (msg) => {
+      if (
+        msg.type() === "error" &&
+        msg.text().includes("sibling-chain invariant broken")
+      )
+        chainErrors.push(msg.text());
+    });
+
+    // Q's prev sibling is the mirror M; X is Q's FIRST child, so Cmd+Shift+Up on X
+    // hits the edge and reparents into the uncle M -> its source A.
+    const tree: SeedNode[] = [
+      { id: "A", parentId: null, prevSiblingId: null, text: "alphasource" },
+      { id: "P", parentId: null, prevSiblingId: "A", text: "project" },
+      { id: "a1", parentId: "A", prevSiblingId: null, text: "childone" },
+      { id: "M", parentId: "P", prevSiblingId: null, text: "ph", mirrorOf: "A" },
+      { id: "Q", parentId: "P", prevSiblingId: "M", text: "queue" },
+      { id: "X", parentId: "Q", prevSiblingId: null, text: "extranode" },
+    ];
+    await load(page, tree, true);
+    await expect(page.locator('li[data-node-id="X"]')).toHaveCount(1);
+
+    await spans(page, "X").click();
+    await expect(spans(page, "X")).toBeFocused();
+    await page.keyboard.press(`${modifier()}+Shift+ArrowUp`);
+
+    // X windows into both instances now (child of source A, appended after a1).
+    await expect(page.locator('li[data-node-id="X"]')).toHaveCount(2);
+    await expect(page.locator('li[data-node-id="X"]').nth(0)).toHaveAttribute(
+      "data-parent-id",
+      "A",
+    );
+    await expect(page.locator('li[data-node-id="X"]').nth(1)).toHaveAttribute(
+      "data-parent-id",
+      "A",
+    );
+    await expect(focused(page)).toHaveText("extranode");
+    expect(chainErrors).toEqual([]);
+  });
+
+  test("multi-select Tab under a mirror indents the whole run into the source (indentManyNodes)", async ({
+    page,
+  }) => {
+    // The selection-mode Tab path (indentManyNodes) derives its target the same
+    // way single indent does -- the run's prev sibling. A mirror there must
+    // redirect the entire run to the source, not strand it under the instance.
+    const chainErrors: string[] = [];
+    page.on("console", (msg) => {
+      if (
+        msg.type() === "error" &&
+        msg.text().includes("sibling-chain invariant broken")
+      )
+        chainErrors.push(msg.text());
+    });
+
+    // X, Y are a contiguous run under P whose prev sibling (the node before the
+    // run) is the mirror M.
+    const tree: SeedNode[] = [
+      { id: "A", parentId: null, prevSiblingId: null, text: "alphasource" },
+      { id: "P", parentId: null, prevSiblingId: "A", text: "project" },
+      { id: "a1", parentId: "A", prevSiblingId: null, text: "childone" },
+      { id: "M", parentId: "P", prevSiblingId: null, text: "ph", mirrorOf: "A" },
+      { id: "X", parentId: "P", prevSiblingId: "M", text: "extraone" },
+      { id: "Y", parentId: "P", prevSiblingId: "X", text: "extratwo" },
+    ];
+    await load(page, tree, true);
+    await expect(page.locator('li[data-node-id="X"]')).toHaveCount(1);
+    await expect(page.locator('li[data-node-id="Y"]')).toHaveCount(1);
+
+    // Select the run X..Y: focus X, first Shift+Down selects X, second extends to
+    // Y. Both roots now carry the selection edge (top/bottom) -- proves the
+    // MULTI-node path (indentManyNodes), not single indent.
+    await caretIn(spans(page, "X"), 99);
+    await page.keyboard.press("Shift+ArrowDown");
+    await page.keyboard.press("Shift+ArrowDown");
+    await expect(page.locator('li[data-node-id="X"]')).toHaveAttribute(
+      "data-selected",
+      "top",
+    );
+    await expect(page.locator('li[data-node-id="Y"]')).toHaveAttribute(
+      "data-selected",
+      "bottom",
+    );
+
+    await page.keyboard.press("Tab");
+
+    // The whole run landed under the source A and windows into both instances.
+    await expect(page.locator('li[data-node-id="X"]')).toHaveCount(2);
+    await expect(page.locator('li[data-node-id="Y"]')).toHaveCount(2);
+    await expect(page.locator('li[data-node-id="X"]').nth(0)).toHaveAttribute(
+      "data-parent-id",
+      "A",
+    );
+    await expect(page.locator('li[data-node-id="Y"]').nth(0)).toHaveAttribute(
+      "data-parent-id",
+      "A",
+    );
+    await expect(page.locator('li[data-node-id="X"]').nth(1)).toHaveAttribute(
+      "data-parent-id",
+      "A",
+    );
+    await expect(page.locator('li[data-node-id="Y"]').nth(1)).toHaveAttribute(
+      "data-parent-id",
+      "A",
+    );
     expect(chainErrors).toEqual([]);
   });
 

--- a/e2e/mirrors.spec.ts
+++ b/e2e/mirrors.spec.ts
@@ -30,11 +30,12 @@ async function load(page: Page, tree: SeedNode[], mirrors: boolean) {
   await page.addInitScript(() => {
     localStorage.setItem("dotflowy:flag:virtualized", "on");
   });
-  if (mirrors) {
-    await page.addInitScript(() => {
-      localStorage.setItem("dotflowy:flag:mirrors", "on");
-    });
-  }
+  // Set the flag EXPLICITLY -- the compiled default is ON (flags.ts), so the
+  // "off" parity cases must write "off", not rely on leaving it unset (which
+  // leaves mirrors on and runs the wrong path).
+  await page.addInitScript((on) => {
+    localStorage.setItem("dotflowy:flag:mirrors", on ? "on" : "off");
+  }, mirrors);
   await seedOutline(page, tree);
   await page.goto("/");
   await expect(text(page, "A")).toBeVisible();

--- a/src/components/OutlineEditor.tsx
+++ b/src/components/OutlineEditor.tsx
@@ -1458,7 +1458,7 @@ function useNodeCommands({
               const instanceId = instanceIdForKey(activeKey);
               // Moving the node reparents it, which drops focus. Re-focus after render.
               capture(getTreeIndex(), activeKey);
-              if (indent(getTreeIndex(), instanceId))
+              if (indent(getTreeIndex(), instanceId, isMirrorsEnabled()))
                 return { instanceId, activeKey };
               drop(); // no move happened; discard the redundant undo point
               return null;
@@ -1507,6 +1507,7 @@ function useNodeCommands({
               const moved = moveUp(getTreeIndex(), instanceId, {
                 isVisible: (n) => !getViewIsHidden()(n),
                 rootId: getViewRootId(),
+                resolveMirror: isMirrorsEnabled(),
               });
               if (moved) return { instanceId, activeKey };
               drop();
@@ -1529,6 +1530,7 @@ function useNodeCommands({
               const moved = moveDown(getTreeIndex(), instanceId, {
                 isVisible: (n) => !getViewIsHidden()(n),
                 rootId: getViewRootId(),
+                resolveMirror: isMirrorsEnabled(),
               });
               if (moved) return { instanceId, activeKey };
               drop();

--- a/src/components/selection-mode.tsx
+++ b/src/components/selection-mode.tsx
@@ -224,7 +224,7 @@ function makeSelectionOps({
     if (ids.length === 0) return;
     runStructural(() => {
       capture(getTreeIndex(), ids[0]!);
-      if (indentManyNodes(ids)) refreshSelection();
+      if (indentManyNodes(ids, isMirrorsEnabled())) refreshSelection();
       else drop();
     });
   };

--- a/src/data/collection.ts
+++ b/src/data/collection.ts
@@ -316,7 +316,11 @@ function healMirrorOrphans(nodes: Node[]): void {
   for (const n of nodes) {
     if (n.parentId == null) continue
     const source = byId.get(n.parentId)?.mirrorOf
-    if (!source) continue
+    // A broken mirror (source deleted) renders as a leaf, not a window -- repointing
+    // the child at a missing id would persist a dangling parentId AND stop the node
+    // matching this heal on the next snapshot. Leave it and heal once the source
+    // (if ever) returns.
+    if (!source || !byId.has(source)) continue
     const list = orphansBySource.get(source)
     if (list) list.push(n.id)
     else orphansBySource.set(source, [n.id])
@@ -340,17 +344,17 @@ function healMirrorOrphans(nodes: Node[]): void {
   }
 
   queueMicrotask(() => {
-    try {
-      for (const fix of fixes) {
+    for (const fix of fixes) {
+      try {
         nodesCollection.update(fix.id, (draft) => {
           draft.parentId = fix.parentId
           draft.prevSiblingId = fix.prevSiblingId
           draft.updatedAt = now()
         })
+      } catch {
+        // A node may have been deleted between snapshot and microtask; harmless --
+        // isolate per fix so one stale id doesn't abort the rest. Next snapshot retries.
       }
-    } catch {
-      // A node may have been deleted between snapshot and microtask; harmless --
-      // the next snapshot retries.
     }
   })
 }

--- a/src/data/collection.ts
+++ b/src/data/collection.ts
@@ -7,8 +7,9 @@ import { runPromise } from './nodes-client-effect'
 import { makeSyncStream } from './realtime'
 import type { ChangeOp, ServerMessage, SyncEvent } from './realtime'
 import { appRuntime } from './runtime'
-import { buildTreeIndex, now } from './tree'
+import { buildTreeIndex, childrenOf, now } from './tree'
 import { chainDisagreements } from './sibling-chain'
+import { isMirrorsEnabled } from './flags'
 
 /**
  * Single source of truth for all outline nodes.
@@ -289,6 +290,72 @@ function healSiblingChains(nodes: Node[]): void {
 }
 
 /**
+ * Rescue nodes stranded UNDER a mirror instance (ADR 0022). A mirror windows its
+ * SOURCE's children, so a node whose `parentId` points at a mirror instance
+ * (`parent.mirrorOf != null`) is orphaned -- the render walk reads the source's
+ * children, never the instance's, so the node is invisible (the "disappears on
+ * Tab" bug, before keyboard indent learned to resolve the mirror boundary the
+ * drag path already did). Repoint each such node at the true source, appended
+ * after the source's current real children, so it reappears in every instance;
+ * runs alongside `healSiblingChains` at snapshot load and persists the same way.
+ *
+ * Gated on the mirrors flag ON PURPOSE: with mirrors OFF, a node carrying
+ * `mirrorOf` renders as a plain node with its OWN children, so a child parented
+ * to it is legitimately placed and must NOT be moved. Early-returns on any
+ * flag-off / mirror-free / orphan-free outline (the mirrorOf lookups all miss).
+ */
+function healMirrorOrphans(nodes: Node[]): void {
+  if (!isMirrorsEnabled()) return
+  const byId = new Map<string, Node>()
+  for (const n of nodes) byId.set(n.id, n)
+
+  // Group orphans by their true source. `parent.mirrorOf` is already the true
+  // source (mirror-of-mirror is flattened at creation -- ADR 0022), so there's
+  // no chain to resolve here.
+  const orphansBySource = new Map<string, string[]>()
+  for (const n of nodes) {
+    if (n.parentId == null) continue
+    const source = byId.get(n.parentId)?.mirrorOf
+    if (!source) continue
+    const list = orphansBySource.get(source)
+    if (list) list.push(n.id)
+    else orphansBySource.set(source, [n.id])
+  }
+  if (orphansBySource.size === 0) return
+
+  // Thread each rescued run after the source's current LAST real child (its own
+  // children hang off the source id, so the orphans -- bucketed under the mirror
+  // instance id -- are excluded from this read). Keeps the orphans' snapshot
+  // order among themselves.
+  const index = buildTreeIndex(nodes)
+  const fixes: { id: string; parentId: string; prevSiblingId: string | null }[] = []
+  for (const [source, orphanIds] of orphansBySource) {
+    const existing = childrenOf(index, source)
+    let prev: string | null =
+      existing.length > 0 ? existing[existing.length - 1]!.id : null
+    for (const id of orphanIds) {
+      fixes.push({ id, parentId: source, prevSiblingId: prev })
+      prev = id
+    }
+  }
+
+  queueMicrotask(() => {
+    try {
+      for (const fix of fixes) {
+        nodesCollection.update(fix.id, (draft) => {
+          draft.parentId = fix.parentId
+          draft.prevSiblingId = fix.prevSiblingId
+          draft.updatedAt = now()
+        })
+      }
+    } catch {
+      // A node may have been deleted between snapshot and microtask; harmless --
+      // the next snapshot retries.
+    }
+  })
+}
+
+/**
  * Backfill nullable-required fields added after some rows were persisted (ADR
  * 0022's `mirrorOf`, and node `origin`). The per-user DO adds each column with a
  * NULL default in its migrator, so a healthy DO always sends them; this guards
@@ -378,6 +445,10 @@ export const nodesCollection = createCollection({
           // outline is in hand (deferred so it writes outside this commit).
           // Copy: msg.nodes is a readonly wire array; the heal path wants Node[].
           healSiblingChains(msg.nodes.slice())
+          // Rescue any node stranded under a mirror instance (ADR 0022 boundary
+          // gap). Queued AFTER the chain heal so its parentId+prevSiblingId write
+          // wins on the rescued node if both touch it.
+          healMirrorOrphans(msg.nodes.slice())
         } else if (msg.type === 'resume') {
           // The gap since our cursor. Empty = already current; the cursor is
           // unchanged so there's nothing to write.

--- a/src/data/mutations.ts
+++ b/src/data/mutations.ts
@@ -217,6 +217,21 @@ export function indent(
     ? trueSourceOf(index, newParent.id)
     : newParent.id
 
+  // Cycle guard (ADR 0022 + ADR 0010): mirror resolution can point
+  // `newParentContentId` at `nodeId` itself (a mirror of `nodeId` sitting as its
+  // prev sibling) or at a descendant of `nodeId`, which would self-parent the
+  // node and corrupt the tree. `indent` splices raw (not via `moveNode`), so it
+  // must guard the way `moveNode` does. A no-op off-flag (the prev sibling can
+  // never be `nodeId` or its descendant), so flag-OFF stays byte-identical.
+  if (resolveMirror) {
+    let cursor: Node | undefined = index.byId.get(newParentContentId)
+    let guard = index.byId.size + 1
+    while (cursor && guard-- > 0) {
+      if (cursor.id === nodeId) return false
+      cursor = cursor.parentId ? index.byId.get(cursor.parentId) : undefined
+    }
+  }
+
   const oldParent = node.parentId
   const oldSiblings = childrenOf(index, oldParent)
   const i = oldSiblings.findIndex((n) => n.id === nodeId)
@@ -616,6 +631,19 @@ export function indentManyNodes(
   // `indent`). Off-flag it's the id itself; the collapse-expand above still
   // targets the visible instance.
   const target = resolveMirror ? trueSourceOf(index, targetId) : targetId
+  // If the mirror target resolves INTO the selected run (its prev sibling is a
+  // mirror of a selected root or one of their descendants), `moveManyNodes` would
+  // skip the cyclic node via `moveNode`'s guard and silently split the run. Abort
+  // the whole indent instead (a no-op). Only reachable under mirror resolution.
+  if (resolveMirror && target !== targetId) {
+    const selected = new Set(rootIds)
+    let cursor: string | null = target
+    let guard = index.byId.size + 1
+    while (cursor && guard-- > 0) {
+      if (selected.has(cursor)) return 0
+      cursor = index.byId.get(cursor)?.parentId ?? null
+    }
+  }
   return moveManyNodes(target, rootIds)
 }
 

--- a/src/data/mutations.ts
+++ b/src/data/mutations.ts
@@ -190,13 +190,32 @@ export function mirrorManyNodes(
  * Effect on siblings:
  *  - node's old next sibling's prevSiblingId becomes node's old prevSiblingId
  *  - node's prevSiblingId becomes the previous sibling's id (now its parent)
+ *
+ * `resolveMirror` (ADR 0022): when the previous sibling is a MIRROR, parent into
+ * its SOURCE instead of the instance id, so the node windows into every instance
+ * -- matching the drag path. The caller passes `isMirrorsEnabled()`; it's a param
+ * (not a `flags.ts` read) so this module stays pure, and OFF it runs today's exact
+ * code (byte-identical: no mirror boundary crossed).
  */
-export function indent(index: TreeIndex, nodeId: string): boolean {
+export function indent(
+  index: TreeIndex,
+  nodeId: string,
+  resolveMirror = false,
+): boolean {
   const node = index.byId.get(nodeId)
   if (!node || !node.prevSiblingId) return false
 
   const newParent = index.byId.get(node.prevSiblingId)
   if (!newParent) return false
+
+  // Resolve BEFORE the child read and parentId write below, or a mirror prev
+  // sibling parents the node under the INSTANCE id, whose row renders the
+  // source's children and never the node -> it vanishes. Off-flag this is the id
+  // itself. Collapse-expand still targets the VISIBLE instance (`newParent.id`)
+  // -- collapse is a local field.
+  const newParentContentId = resolveMirror
+    ? trueSourceOf(index, newParent.id)
+    : newParent.id
 
   const oldParent = node.parentId
   const oldSiblings = childrenOf(index, oldParent)
@@ -211,7 +230,7 @@ export function indent(index: TreeIndex, nodeId: string): boolean {
   // AFTER the move can already include the node itself -- it would then point its
   // own prevSiblingId at itself (a self-referencing chain). node is a sibling of
   // newParent here, never already its child, so the pre-move read excludes it.
-  const newSiblings = childrenOf(index, newParent.id)
+  const newSiblings = childrenOf(index, newParentContentId)
   const lastExisting = newSiblings.length > 0
     ? newSiblings[newSiblings.length - 1]!
     : null
@@ -219,7 +238,7 @@ export function indent(index: TreeIndex, nodeId: string): boolean {
   // Node becomes last child of newParent. If that parent was collapsed, the
   // node would be indented out of sight, so expand it to keep the node visible.
   update(nodeId, {
-    parentId: newParent.id,
+    parentId: newParentContentId,
     prevSiblingId: lastExisting ? lastExisting.id : null,
   })
   if (newParent.collapsed) update(newParent.id, { collapsed: false })
@@ -299,6 +318,14 @@ interface MoveOpts {
    * the visible subtree, so an edge move there is a no-op. See ADR 0009.
    */
   rootId?: string | null
+  /**
+   * Resolve a mirror uncle/aunt to its SOURCE at an edge reparent (ADR 0022), so
+   * the moved node windows into every instance instead of vanishing under the
+   * instance id. The caller passes `isMirrorsEnabled()`; OFF (default) it's
+   * today's exact behavior. Kept a param, not a `flags.ts` read, to keep this
+   * module pure (matches the drag call site).
+   */
+  resolveMirror?: boolean
 }
 
 /**
@@ -309,20 +336,25 @@ function reparentIntoParentPrevSibling(
   index: TreeIndex,
   node: Node,
   rootId: string | null,
+  resolveMirror: boolean,
 ): boolean {
   if (node.parentId === null || node.parentId === rootId) return false
   const parent = index.byId.get(node.parentId)
   if (!parent?.prevSiblingId) return false
 
   const uncleId = parent.prevSiblingId
-  const uncleChildren = childrenOf(index, uncleId)
+  // ADR 0022: a mirror uncle windows its SOURCE's children, so land there (both
+  // the last-child read and the move target). Off-flag it's the id itself;
+  // collapse-expand stays on the visible instance.
+  const uncleContentId = resolveMirror ? trueSourceOf(index, uncleId) : uncleId
+  const uncleChildren = childrenOf(index, uncleContentId)
   const afterSiblingId =
     uncleChildren.length > 0 ? uncleChildren[uncleChildren.length - 1]!.id : null
 
   const uncle = index.byId.get(uncleId)
   if (uncle?.collapsed) update(uncle.id, { collapsed: false })
 
-  return moveNode(index, node.id, uncleId, afterSiblingId)
+  return moveNode(index, node.id, uncleContentId, afterSiblingId)
 }
 
 /**
@@ -333,6 +365,7 @@ function reparentIntoParentNextSibling(
   index: TreeIndex,
   node: Node,
   rootId: string | null,
+  resolveMirror: boolean,
 ): boolean {
   if (node.parentId === null || node.parentId === rootId) return false
   const parent = index.byId.get(node.parentId)
@@ -346,7 +379,10 @@ function reparentIntoParentNextSibling(
 
   if (aunt.collapsed) update(aunt.id, { collapsed: false })
 
-  return moveNode(index, node.id, aunt.id, null)
+  // ADR 0022: a mirror aunt windows its SOURCE's children; parent into the
+  // source (off-flag it's the id itself). Collapse stays on the instance.
+  const auntContentId = resolveMirror ? trueSourceOf(index, aunt.id) : aunt.id
+  return moveNode(index, node.id, auntContentId, null)
 }
 
 /**
@@ -379,7 +415,13 @@ export function moveUp(
     }
   }
 
-  if (!vp) return reparentIntoParentPrevSibling(index, node, opts.rootId ?? null)
+  if (!vp)
+    return reparentIntoParentPrevSibling(
+      index,
+      node,
+      opts.rootId ?? null,
+      opts.resolveMirror ?? false,
+    )
 
   // Swap: detach node, then re-insert it immediately before vp. A hidden
   // sibling between them stays put (rides along below vp).
@@ -420,7 +462,12 @@ export function moveDown(
   }
 
   if (k === -1) {
-    return reparentIntoParentNextSibling(index, node, opts.rootId ?? null)
+    return reparentIntoParentNextSibling(
+      index,
+      node,
+      opts.rootId ?? null,
+      opts.resolveMirror ?? false,
+    )
   }
 
   // Swap: detach node, then re-insert it immediately after vn.
@@ -554,7 +601,10 @@ export function moveManyNodes(
  * Reuses `moveManyNodes`, so it's the same rebuild-between-moves batch; wrap the
  * whole call in `runStructural` so it lands as ONE atomic frame (ADR 0009).
  */
-export function indentManyNodes(rootIds: string[]): number {
+export function indentManyNodes(
+  rootIds: string[],
+  resolveMirror = false,
+): number {
   if (rootIds.length === 0) return 0
   const index = buildTreeIndex(nodesCollection.toArray)
   // The run is contiguous, so the first root's prev sibling sits OUTSIDE it --
@@ -562,7 +612,11 @@ export function indentManyNodes(rootIds: string[]): number {
   const targetId = index.byId.get(rootIds[0]!)?.prevSiblingId
   if (!targetId) return 0
   if (index.byId.get(targetId)?.collapsed) update(targetId, { collapsed: false })
-  return moveManyNodes(targetId, rootIds)
+  // ADR 0022: a mirror target parents the run into its SOURCE (matches single
+  // `indent`). Off-flag it's the id itself; the collapse-expand above still
+  // targets the visible instance.
+  const target = resolveMirror ? trueSourceOf(index, targetId) : targetId
+  return moveManyNodes(target, rootIds)
 }
 
 /**


### PR DESCRIPTION
## The bug

Tab a node under a **mirror** → it vanishes. (Also fires on `Cmd+Shift+↑/↓` into a mirror uncle, and multi-select Tab.)

Not deleted — **orphaned**. Indent parented the node to the mirror *instance* id, but a mirror's row renders the *source's* children ([ADR 0022](docs/adr/0022-node-mirrors.md)), so the node rendered nowhere. The **drag** path already resolved this; the keyboard paths didn't.

## The fix

Resolve the derived parent through `trueSourceOf` (`mirrorOf ?? id`) at every structural op that computes its own target:

| Op | Trigger |
|---|---|
| `indent` | Tab |
| `reparentIntoParentPrev/NextSibling` | `Cmd+Shift+↑/↓` edge |
| `indentManyNodes` | multi-select Tab |

- Flag rides in as a **`resolveMirror` param**, not a `flags.ts` read → `mutations.ts` stays pure; **flag-OFF is byte-identical to old code** (matches the drag call site).
- Collapse-expand still targets the visible **instance**. `outdent` untouched (its target is always real).

## Rescue for already-orphaned data

Mirrors ship **default-ON**, so real outlines already have invisible orphans. `healMirrorOrphans` (collection.ts, sibling to `healSiblingChains`) repoints any node parented to a mirror instance back onto the true source at snapshot load. Gated on `isMirrorsEnabled()`.

## Tests

- **4 new e2e** (`mirror-editing.spec.ts`): Tab / edge-reparent / multi-select Tab under a mirror + a flag-OFF gate test. All guard the sibling-chain tripwire.
- **Harness fix:** the e2e `load()` helpers only ever wrote the flag `"on"`, relying on unset for off — but the default is ON, so parity tests ran the wrong path. Writing the concrete value both ways **repairs 3 stale-red "flag OFF" tests on main.**
- Green: 26/26 mirror e2e (serial), typecheck + oxlint clean, 450 unit tests.

Designed via `/grill-with-docs`; completes ADR 0022's Stage-2 boundary redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mirror-aware editing now keeps items visible when indenting or moving with keyboard shortcuts.
  * Multi-select indenting and edge reparenting now behave consistently with mirrored content.

* **Bug Fixes**
  * Fixed cases where items could disappear after being moved under mirrored rows.
  * Improved snapshot recovery so mirror-related outline gaps are repaired automatically.
  * Ensured mirror behavior stays off when the feature is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->