### PR TITLE
Tear down drag-reorder on unmount (fix leaked listeners/rAF/DOM)

### DIFF
--- a/src/components/use-drag-reorder.ts
+++ b/src/components/use-drag-reorder.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, type PointerEvent as ReactPointerEvent } from "react";
+import { useCallback, useEffect, useRef, type PointerEvent as ReactPointerEvent } from "react";
 import { type Node, type TreeIndex } from "../data/tree";
 import {
   buildVisibleRows,
@@ -467,6 +467,15 @@ export function useDragReorder(deps: DragDeps) {
     }
     return false;
   }, []);
+
+  // Unmount teardown. `cleanup` is otherwise only reached via `onUp`
+  // (pointerup/cancel); if this component unmounts mid-drag (the windowed source
+  // row scrolls out, a zoom/route change, a big sync re-render), the document
+  // pointer listeners + rAF loop + injected pill/indicator + `dragging-active`
+  // body class would all leak. An empty-dep effect whose cleanup runs only on
+  // unmount removes exactly that. cleanup() self-guards on a null drag, so this
+  // is a no-op when nothing is in flight. cleanup is stable ([] deps).
+  useEffect(() => cleanup, [cleanup]);
 
   return { startDrag, consumeClick };
 }


### PR DESCRIPTION
## What

Adds an unmount-only teardown effect to `useDragReorder` so the bullet drag can't leak listeners/rAF/DOM on mid-drag unmount.

## Why

`useDragReorder` registers three `document` pointer listeners on `startDrag`, runs a `requestAnimationFrame` auto-scroll loop, appends a floating `.drag-pill` + `.drag-indicator`, and adds a `dragging-active` body class. All of that is torn down by `cleanup()` — but `cleanup()` was only ever reached from `onUp` (pointerup/cancel). If the component unmounts mid-drag (a windowed source row scrolls out, a zoom/route change, a big sync re-render), the listeners, rAF loop, injected DOM, and body class all leak, and the orphaned `pointermove` listener keeps firing against stale rows for the rest of the session.

## Change

```ts
useEffect(() => cleanup, [cleanup]);
```

`cleanup` is a `useCallback` with `[]` deps (referentially stable), so the effect never re-fires after mount — the returned function runs only on unmount. `cleanup()` self-guards on a null drag, so it's a no-op when nothing is in flight. One file changed.

## Verification

- `bun run typecheck` → exit 0
- `bun run lint` → exit 0
- `bun run test:e2e e2e/move-flash.spec.ts` → 2/2 pass (proves the `onUp` → `onMove` commit path is untouched)

## Reviewer notes

- No React state added to the drag hot path; `startDrag` still has `[]` deps (both deliberate — the path is perf-tuned and stays imperative).
- **Pre-existing, unrelated:** `e2e/drag-reorder.spec.ts` fails 2/2 on clean `main` (verified by reverting this file to base — identical failures). Not caused by this change; flagged for separate triage.

Executed from advisor plan `001-drag-reorder-unmount-cleanup`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
