### PR TITLE
Extract shared token-kit (reveal predicate + write-back + mdPunct + node-id)

### DIFF
--- a/src/data/highlight.ts
+++ b/src/data/highlight.ts
@@ -20,6 +20,8 @@
 // This module is DOM-free and side-effect-free; the decoration half lives in
 // src/plugins/highlight.
 
+import { spliceToken } from "../plugins/token-kit";
+
 export type HighlightColor =
   | "red"
   | "orange"
@@ -116,7 +118,6 @@ export function spliceHighlightRun(
   oldRun: string,
   newRun: string,
 ): string | null {
-  const at = text.indexOf(oldRun);
-  if (at < 0) return null;
-  return text.slice(0, at) + newRun + text.slice(at + oldRun.length);
+  // Delegates to the shared spliceToken (src/plugins/token-kit.ts).
+  return spliceToken(text, oldRun, newRun);
 }

--- a/src/data/links.ts
+++ b/src/data/links.ts
@@ -8,6 +8,8 @@
 // caret remap on reveal) lives in inline-code.ts; the link-aware paste cases in
 // the links plugin, over the core paste handler in paste.ts.
 
+import { spliceToken } from "../plugins/token-kit";
+
 // A link token: `[label](url)`. The label is "anything but `]`", the url is
 // "anything but `)`". Kept deliberately simple -- URLs that would break it (a
 // literal `)`, `(`, or space) are percent-encoded by encodeUrlForMarkdown when
@@ -103,9 +105,8 @@ export function replaceLinkToken(
   oldToken: string,
   newToken: string,
 ): string | null {
-  const at = text.indexOf(oldToken);
-  if (at < 0) return null;
-  return text.slice(0, at) + newToken + text.slice(at + oldToken.length);
+  // Delegates to the shared spliceToken (src/plugins/token-kit.ts).
+  return spliceToken(text, oldToken, newToken);
 }
 
 /** Verbatim-match-or-drop label swap (ADR 0016): replace the FIRST occurrence

--- a/src/plugins/code/index.ts
+++ b/src/plugins/code/index.ts
@@ -4,6 +4,8 @@
 // adjacent to the run -- the same reveal-on-proximity model emphasis and links
 // use (ADR 0025 / ADR 0005). Dogfoods Seam A's fold, no interaction.
 
+import { mdPunct } from "../../components/inline-code";
+import { isRevealed } from "../token-kit";
 import { definePlugin, type El } from "../types";
 
 // Single-line, non-empty, no nested backtick.
@@ -37,11 +39,7 @@ function foldedCodeEl(interior: string, tok: string): El {
 // carries `data-src`, so readSource and the caret math treat the whole thing as
 // ordinary text -- the caret walks through the backticks one step at a time.
 function revealedCodeEl(interior: string): El {
-  const tick: El = {
-    tag: "span",
-    attrs: { class: "md-punct" },
-    children: ["`"],
-  };
+  const tick = mdPunct("`");
   return {
     tag: "code",
     attrs: { class: CODE_CLASS, "data-code-reveal": true },
@@ -58,13 +56,13 @@ export default definePlugin({
       // Between links (0) and tags (20): a `#tag` inside a code run stays code.
       precedence: 10,
       folds: true,
-      render: (tok, { revealOffset, start, end }) => {
+      render: (tok, view) => {
         const interior = tok.slice(1, tok.length - 1);
         // Reveal iff the caret sits within or adjacent to the run (offset in
         // `[start, end]`, inclusive) -- mirrors the link/emphasis reveal rule.
-        const reveal =
-          revealOffset != null && revealOffset >= start && revealOffset <= end;
-        return reveal ? revealedCodeEl(interior) : foldedCodeEl(interior, tok);
+        return isRevealed(view)
+          ? revealedCodeEl(interior)
+          : foldedCodeEl(interior, tok);
       },
     },
   ],

--- a/src/plugins/emphasis/index.tsx
+++ b/src/plugins/emphasis/index.tsx
@@ -42,6 +42,7 @@ import {
 } from "../types";
 import { mdPunct } from "../../components/inline-code";
 import { type MarkerPair, toggleWrapSelection } from "../../components/wrap";
+import { isRevealed } from "../token-kit";
 
 /** The four marker pairs. Keys match the slash-command ids and the keymap
  *  wiring; the generic wrap mechanics live in components/wrap.ts (shared with
@@ -157,10 +158,7 @@ function partsOf(tok: string): { marker: string; interior: string } {
 // edge) -- mirrors the link reveal rule verbatim.
 function renderEmphasis(kind: EmphasisKind, tok: string, view: TokenView): El {
   const { marker, interior } = partsOf(tok);
-  const { revealOffset, start, end } = view;
-  const reveal =
-    revealOffset != null && revealOffset >= start && revealOffset <= end;
-  return reveal
+  return isRevealed(view)
     ? revealedEmphasisEl(kind, interior, marker)
     : foldedEmphasisEl(kind, interior, tok);
 }

--- a/src/plugins/highlight/highlight-color-menu.tsx
+++ b/src/plugins/highlight/highlight-color-menu.tsx
@@ -23,10 +23,9 @@ import {
   HIGHLIGHT_DEFAULT_COLOR,
   HIGHLIGHT_EMOJI,
   parseHighlight,
-  spliceHighlightRun,
   type HighlightColor,
 } from "../../data/highlight";
-import { getTreeIndex } from "../../data/tree-store";
+import { replaceTokenInNode } from "../token-kit";
 import type { NodeCommands } from "../../components/OutlineNode";
 import type { PluginContext } from "../types";
 
@@ -41,15 +40,7 @@ export function applyHighlightEdit(
 ): void {
   const { interior } = parseHighlight(oldRun);
   const newRun = color == null ? interior : buildHighlightRun(color, interior);
-  if (newRun === oldRun) return;
-  const index = getTreeIndex();
-  const clicked = index.byId.get(nodeId);
-  if (!clicked) return;
-  const targetId = clicked.mirrorOf ?? nodeId;
-  const current = index.byId.get(targetId)?.text;
-  if (current == null) return;
-  const next = spliceHighlightRun(current, oldRun, newRun);
-  if (next != null && next !== current) mutations.onTextChange(targetId, next);
+  replaceTokenInNode(nodeId, oldRun, newRun, mutations);
 }
 
 /** Mount the menu through the overlay host (the same thin `ctx.openOverlay`

--- a/src/plugins/highlight/index.tsx
+++ b/src/plugins/highlight/index.tsx
@@ -24,9 +24,9 @@ import {
   parseHighlight,
   type HighlightColor,
 } from "../../data/highlight";
-import { getViewRootId } from "../../data/view-state";
 import { mdPunct, readSource } from "../../components/inline-code";
 import { wrapSelectionOrInsert } from "../../components/wrap";
+import { isRevealed, resolveNodeId } from "../token-kit";
 import { definePlugin, type El, type PluginContext } from "../types";
 import { openHighlightColorMenu } from "./highlight-color-menu";
 
@@ -113,11 +113,8 @@ export default definePlugin({
       pattern: HIGHLIGHT_PATTERN,
       precedence: 35,
       folds: true,
-      render: (tok, { revealOffset, start, end }) => {
-        const reveal =
-          revealOffset != null && revealOffset >= start && revealOffset <= end;
-        return reveal ? revealedHighlightEl(tok) : foldedHighlightEl(tok);
-      },
+      render: (tok, view) =>
+        isRevealed(view) ? revealedHighlightEl(tok) : foldedHighlightEl(tok),
     },
   ],
 
@@ -141,10 +138,7 @@ export default definePlugin({
         if (!markEl || !token) return;
         e.preventDefault();
         e.stopPropagation();
-        const nodeId =
-          markEl
-            .closest<HTMLElement>("[data-node-id]")
-            ?.getAttribute("data-node-id") ?? getViewRootId();
+        const nodeId = resolveNodeId(markEl);
         if (!nodeId) return;
         const rect = markEl.getBoundingClientRect();
         openHighlightColorMenu(
@@ -165,10 +159,7 @@ export default definePlugin({
         e.preventDefault();
         e.stopPropagation();
         // Row id, or the zoom root when the run lives in the zoomed title.
-        const nodeId =
-          el
-            .closest<HTMLElement>("[data-node-id]")
-            ?.getAttribute("data-node-id") ?? getViewRootId();
+        const nodeId = resolveNodeId(el);
         if (!nodeId) return;
         openHighlightColorMenu(
           { nodeId, token, x: e.clientX, y: e.clientY },

--- a/src/plugins/links/index.ts
+++ b/src/plugins/links/index.ts
@@ -16,11 +16,15 @@ import {
   sanitizeLinkLabel,
   swapLinkLabel,
 } from "../../data/links";
-import { getSelectionRange, readSource } from "../../components/inline-code";
+import {
+  getSelectionRange,
+  mdPunct,
+  readSource,
+} from "../../components/inline-code";
 import { openUrlInFocusedTab } from "../../components/open-url";
 import { appRuntime } from "../../data/runtime";
 import { getTreeIndex } from "../../data/tree-store";
-import { getViewRootId } from "../../data/view-state";
+import { isRevealed, resolveNodeId } from "../token-kit";
 import { definePlugin, type El, type PluginContext } from "../types";
 import { openLinkCreatePopover, openLinkEditPopover } from "./link-edit-popover";
 
@@ -109,19 +113,14 @@ function foldedLinkEl(label: string, url: string, tok: string): El {
 // text. Clicking the chip opens the Edit Link popover. Everything except the
 // chip stays 1:1 with its slice of the source.
 function revealedLinkEl(label: string, url: string): El {
-  const punct = (s: string): El => ({
-    tag: "span",
-    attrs: { class: "md-punct" },
-    children: [s],
-  });
   return {
     tag: "span",
     attrs: { class: "link-reveal", "data-link-reveal": true },
     children: [
-      punct("["),
+      mdPunct("["),
       { tag: "span", attrs: { class: "link-label" }, children: [label] },
-      punct("]"),
-      punct("("),
+      mdPunct("]"),
+      mdPunct("("),
       {
         tag: "span",
         attrs: {
@@ -133,7 +132,7 @@ function revealedLinkEl(label: string, url: string): El {
         },
         children: [editIconEl()],
       },
-      punct(")"),
+      mdPunct(")"),
     ],
   };
 }
@@ -162,9 +161,7 @@ function openEditFor(el: HTMLElement, ctx: PluginContext): void {
   }
   const parts = LINK_PARTS.exec(token);
   if (!parts) return;
-  const nodeId =
-    el.closest<HTMLElement>("[data-node-id]")?.getAttribute("data-node-id") ??
-    getViewRootId();
+  const nodeId = resolveNodeId(el);
   if (!nodeId) return;
   const textEl = el.closest<HTMLElement>(".node-text");
   const rect = rectEl.getBoundingClientRect();
@@ -281,13 +278,11 @@ export default definePlugin({
       // `#tag` or `code` run inside a label/url never becomes its own chip.
       precedence: 0,
       folds: true,
-      render: (tok, { revealOffset, start, end }) => {
+      render: (tok, view) => {
         const parts = LINK_PARTS.exec(tok);
         const label = parts?.[1] ?? "";
         const url = parts?.[2] ?? "";
-        const reveal =
-          revealOffset != null && revealOffset >= start && revealOffset <= end;
-        return reveal
+        return isRevealed(view)
           ? revealedLinkEl(label, url)
           : foldedLinkEl(label, url, tok);
       },

--- a/src/plugins/links/link-edit-popover.tsx
+++ b/src/plugins/links/link-edit-popover.tsx
@@ -12,12 +12,9 @@ import { useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { useDismissable } from "../../components/use-dismissable";
 import { Button, Input } from "@/plugins/kit";
-import {
-  encodeUrlForMarkdown,
-  replaceLinkToken,
-  sanitizeLinkLabel,
-} from "../../data/links";
+import { encodeUrlForMarkdown, sanitizeLinkLabel } from "../../data/links";
 import { getTreeIndex } from "../../data/tree-store";
+import { replaceTokenInNode } from "../token-kit";
 import type { NodeCommands } from "../../components/OutlineNode";
 import type { PluginContext } from "../types";
 
@@ -37,15 +34,7 @@ export function submitLinkEdit(
   if (!trimmedUrl) return;
   const safeLabel = sanitizeLinkLabel(label) || trimmedUrl;
   const newToken = `[${safeLabel}](${encodeUrlForMarkdown(trimmedUrl)})`;
-  if (newToken === oldToken) return;
-  const index = getTreeIndex();
-  const clicked = index.byId.get(nodeId);
-  if (!clicked) return;
-  const targetId = clicked.mirrorOf ?? nodeId;
-  const current = index.byId.get(targetId)?.text;
-  if (current == null) return;
-  const next = replaceLinkToken(current, oldToken, newToken);
-  if (next != null && next !== current) mutations.onTextChange(targetId, next);
+  replaceTokenInNode(nodeId, oldToken, newToken, mutations);
 }
 
 /** Mount the popover through the overlay host (the same thin `ctx.openOverlay`

--- a/src/plugins/route-bible/bible.ts
+++ b/src/plugins/route-bible/bible.ts
@@ -18,6 +18,7 @@ import {
   type OsisBookCode,
 } from "grab-bcv";
 import { LINK_PATTERN, encodeUrlForMarkdown } from "../../data/links";
+import { spliceToken } from "../token-kit";
 
 // The Seam-A token fragment: detection PROPOSES, the parser DISPOSES. Mirrors
 // grab-bcv's own (internal, unexported) natural-text reference pattern, plus a
@@ -108,9 +109,8 @@ export function replaceBibleRefToken(
   oldToken: string,
   newToken: string,
 ): string | null {
-  const i = text.indexOf(oldToken);
-  if (i < 0) return null;
-  return text.slice(0, i) + newToken + text.slice(i + oldToken.length);
+  // Delegates to the shared spliceToken (src/plugins/token-kit.ts).
+  return spliceToken(text, oldToken, newToken);
 }
 
 const CODE_RUN_PATTERN = "`[^`\\n]+`";

--- a/src/plugins/route-bible/index.tsx
+++ b/src/plugins/route-bible/index.tsx
@@ -12,9 +12,9 @@
 
 import { BIBLE_REF_PATTERN, resolveBibleRef } from "./bible";
 import { BibleChip } from "./chip";
-import { getViewRootId } from "../../data/view-state";
 import { openBiblePassageEditPopover } from "./passage-edit-popover";
 import { openUrlInFocusedTab } from "../../components/open-url";
+import { resolveNodeId } from "../token-kit";
 import { definePlugin, type WidgetEl } from "../types";
 
 const LONG_PRESS_MS = 550;
@@ -60,9 +60,7 @@ function openEditForChip(
   ctx: Parameters<typeof openBiblePassageEditPopover>[1],
 ): void {
   const token = el.getAttribute("data-src") ?? "";
-  const nodeId =
-    el.closest<HTMLElement>("[data-node-id]")?.getAttribute("data-node-id") ??
-    getViewRootId();
+  const nodeId = resolveNodeId(el);
   if (!token || !nodeId) return;
   const focusTarget = el.closest<HTMLElement>(".node-text");
   const rect = el.getBoundingClientRect();

--- a/src/plugins/route-bible/passage-edit-popover.tsx
+++ b/src/plugins/route-bible/passage-edit-popover.tsx
@@ -9,15 +9,14 @@ import {
 import { ExternalLink } from "lucide-react";
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { getTreeIndex } from "../../data/tree-store";
 import type { NodeCommands } from "../../components/OutlineNode";
 import { placeCaretAtEnd } from "../../components/caret-place";
 import { Button, Input } from "../kit";
+import { replaceTokenInNode } from "../token-kit";
 import type { PluginContext } from "../types";
 import {
   formatStructuredBibleRef,
   normalizeBibleRef,
-  replaceBibleRefToken,
   suggestBibleRefs,
 } from "./bible";
 
@@ -64,15 +63,7 @@ export function submitBiblePassageEdit(
   const normalized = normalizeBibleRef(input);
   if (!normalized) return;
   const newToken = normalized.label;
-  if (newToken === oldToken) return;
-  const index = getTreeIndex();
-  const clicked = index.byId.get(nodeId);
-  if (!clicked) return;
-  const targetId = clicked.mirrorOf ?? nodeId;
-  const current = index.byId.get(targetId)?.text;
-  if (current == null) return;
-  const next = replaceBibleRefToken(current, oldToken, newToken);
-  if (next != null && next !== current) mutations.onTextChange(targetId, next);
+  replaceTokenInNode(nodeId, oldToken, newToken, mutations);
 }
 
 export function openBiblePassageEditPopover(

--- a/src/plugins/token-kit.test.ts
+++ b/src/plugins/token-kit.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import { isRevealed, spliceToken } from "./token-kit";
+
+describe("isRevealed", () => {
+  test("null caret is never revealed", () => {
+    expect(isRevealed({ revealOffset: null, start: 2, end: 5 })).toBe(false);
+  });
+
+  test("offset before start is not revealed", () => {
+    expect(isRevealed({ revealOffset: 1, start: 2, end: 5 })).toBe(false);
+  });
+
+  test("offset at start is revealed (inclusive boundary)", () => {
+    expect(isRevealed({ revealOffset: 2, start: 2, end: 5 })).toBe(true);
+  });
+
+  test("offset inside the span is revealed", () => {
+    expect(isRevealed({ revealOffset: 3, start: 2, end: 5 })).toBe(true);
+  });
+
+  test("offset at end is revealed (inclusive boundary)", () => {
+    expect(isRevealed({ revealOffset: 5, start: 2, end: 5 })).toBe(true);
+  });
+
+  test("offset past end is not revealed", () => {
+    expect(isRevealed({ revealOffset: 6, start: 2, end: 5 })).toBe(false);
+  });
+});
+
+describe("spliceToken", () => {
+  test("replaces the first occurrence", () => {
+    expect(spliceToken("a [x](y) b", "[x](y)", "[z](y)")).toBe("a [z](y) b");
+  });
+
+  test("returns null when the token is missing", () => {
+    expect(spliceToken("edited away", "[x](y)", "[z](y)")).toBeNull();
+  });
+
+  test("only the first occurrence is replaced when the token appears twice", () => {
+    expect(spliceToken("aa bb aa", "aa", "cc")).toBe("cc bb aa");
+  });
+});

--- a/src/plugins/token-kit.ts
+++ b/src/plugins/token-kit.ts
@@ -1,0 +1,60 @@
+// Shared helpers for token plugins (ADR 0001). One blessed home for the small
+// pieces the folding + editable tokens all need, so the rule lives in one place
+// instead of N copies. Pure/DOM helpers only — no UI barrel imports.
+
+import { getTreeIndex } from "../data/tree-store";
+import { getViewRootId } from "../data/view-state";
+import type { NodeCommands } from "../components/OutlineNode";
+import type { TokenView } from "./types";
+
+/** True iff the caret sits within or adjacent to a token's source span — the
+ *  fold/reveal rule every folding token shares (inclusive boundaries, so the
+ *  caret can arrive from either edge). Replaces the copy-pasted predicate. */
+export function isRevealed({ revealOffset, start, end }: TokenView): boolean {
+  return revealOffset != null && revealOffset >= start && revealOffset <= end;
+}
+
+/** Splice a verbatim token replacement into `text` at its first occurrence, or
+ *  null if the token is no longer present (it was edited/deleted since). The
+ *  pure core of every token write-back. */
+export function spliceToken(
+  text: string,
+  oldToken: string,
+  newToken: string,
+): string | null {
+  const at = text.indexOf(oldToken);
+  if (at < 0) return null;
+  return text.slice(0, at) + newToken + text.slice(at + oldToken.length);
+}
+
+/** Verbatim-match-or-drop write-back against a node's LIVE text: resolve a
+ *  mirror row to its source, read the current text, splice `oldToken`→`newToken`
+ *  at its first occurrence, and write back only if it still matches and actually
+ *  changed. A no-op if the node is gone or the token was edited away — the guard
+ *  that keeps a stale editor write from corrupting a since-changed bullet. */
+export function replaceTokenInNode(
+  nodeId: string,
+  oldToken: string,
+  newToken: string,
+  mutations: NodeCommands,
+): void {
+  if (newToken === oldToken) return;
+  const index = getTreeIndex();
+  const clicked = index.byId.get(nodeId);
+  if (!clicked) return;
+  const targetId = clicked.mirrorOf ?? nodeId;
+  const current = index.byId.get(targetId)?.text;
+  if (current == null) return;
+  const next = spliceToken(current, oldToken, newToken);
+  if (next != null && next !== current) mutations.onTextChange(targetId, next);
+}
+
+/** The node id owning `el` (nearest `[data-node-id]` ancestor), or the zoom root
+ *  when the element lives in the zoomed title (which has no row id), or null. The
+ *  single resolution used by every Seam-B interaction handler. */
+export function resolveNodeId(el: HTMLElement): string | null {
+  return (
+    el.closest<HTMLElement>("[data-node-id]")?.getAttribute("data-node-id") ??
+    getViewRootId()
+  );
+}


### PR DESCRIPTION
## What

Extracts a shared `src/plugins/token-kit.ts` and collapses the small pieces of logic the folding/editable token plugins each re-implemented.

## Why

Four folding plugins (links, code, emphasis, highlight) and three token editors (links, highlight, route-bible) duplicated:

1. The **reveal predicate** (`revealOffset != null && revealOffset >= start && revealOffset <= end`) — 4 verbatim copies.
2. The **verbatim-match-or-drop write-back** (resolve mirror → read live text → splice → guard → `onTextChange`) — 3 byte-identical helpers + 3 structurally-identical callers.
3. The **`md-punct` span** — a shared `mdPunct` existed, but links and code re-declared local copies.
4. **Node-id resolution** — 4 duplicated `el.closest("[data-node-id]") ?? getViewRootId()` sites.

## Change

New `token-kit.ts` exports `isRevealed`, `spliceToken`, `replaceTokenInNode`, `resolveNodeId`. The three pure splice fns (`replaceLinkToken`/`spliceHighlightRun`/`replaceBibleRefToken`) now delegate to `spliceToken` (names/signatures unchanged, so existing tests pass as-is); the three edit-popover callers delegate to `replaceTokenInNode`; the four token renders call `isRevealed`; links/code import `mdPunct`; four handlers use `resolveNodeId`. New `token-kit.test.ts` covers the pure helpers.

The folded-element `data-src`/`data-src-len`/`contenteditable` atom blocks are left **verbatim** (out of scope — they control the exact serialized innerHTML the decorate cache + e2e selectors depend on).

## Verification

- `bun run typecheck`, `bun run typecheck:test`, `bun run lint` → exit 0
- `bun run test` → 459 pass (incl. new `token-kit` blocks + the unchanged `links`/`highlight`/`bible` write-back tests)
- Folding e2e (`rich-links`, `emphasis`, `highlight`, `inline-code`, `route-bible`) → 65/65 pass
- Confirmed `mdPunct` returns byte-identical El shape to the removed local copies (render output preserved), and no atom block was modified.

## Reviewer notes

- **Merge order:** land this before #003 — both touch `src/plugins/links/index.ts` (this PR: reveal-predicate/mdPunct/resolveNodeId; #003: unfurl timeout + `ctx.run`). #003 will need a trivial import-line reconcile after this lands.
- Import direction: `src/data/links.ts` now imports `spliceToken` from `src/plugins/token-kit.ts` (leaf module — only tree-store/view-state/a type). No circular import (typecheck/lint clean).

Executed from advisor plan `002-shared-token-kit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Unified editing and rendering behavior for highlighted text, links, Bible passages, emphasis, and inline code.
  * Link, highlight, and passage edits now update more consistently across the editor.

* **Bug Fixes**
  * Improved handling when editing text that has moved or changed, reducing failed replacements.
  * Fixed reveal-state checks so folded and revealed content displays correctly at token boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->