### PR TITLE
Add ctx.run: an Effect-backed async seam for plugins (ADR 0039)

### DIFF
--- a/docs/adr/0039-plugin-async-effect-seam.md
+++ b/docs/adr/0039-plugin-async-effect-seam.md
@@ -1,0 +1,78 @@
+# 39. An Effect-backed async seam for plugins (`ctx.run`)
+
+## Status
+
+Accepted.
+
+## Context
+
+The plugin contract (ADR 0001) is synchronous. `InputSpec.afterPaste` may do
+async work but returns `void`; `PluginDef.preload` returns `void`. Every plugin
+doing async work therefore re-derives its own execution + error + lifecycle
+story. Two consumers exist today and they diverge:
+
+- The links title-unfurl forks a fiber on the shared `appRuntime` — tracked, but
+  app-scoped (never interrupted on editor teardown) and with no timeout.
+- The daily get-or-create hand-rolls `async/await` Promise chains that never
+  touch the shared runtime, and in one spot leaks an unhandled rejection.
+
+The Effect runtime, typed errors, retry, and timeout are already the house model
+for I/O (ADR 0012, `kv-client-effect.ts`). What is missing is a way for a plugin
+to run async work *through* that model without re-implementing forking, fiber
+tracking, interruption, and a failure sink each time.
+
+## Decision
+
+Add one capability to `PluginContext`:
+
+    run(effect: Effect.Effect<unknown, unknown>): void
+
+`run` forks the effect on the shared `appRuntime`, registers the fiber in an
+editor-scoped set, removes it from the set on completion, and interrupts every
+still-running fiber when the editor unmounts. Before forking it wraps the effect
+with a failure sink (`catchCause` → log) so a defect or unhandled failure is
+logged, never silently swallowed and never a floating unhandled rejection.
+
+The seam owns the *runtime, lifecycle, and failure logging* — not error
+*semantics*. A plugin still composes its own timeout/retry/typed-error recovery
+inside the effect it hands to `run` (the kv core is the pattern). The effect must
+be fully provided (`R = never`, satisfied by `appRuntime`'s layer) and should be
+`Effect<void>` at the point of `run` (self-handle the domain result).
+
+## Consequences
+
+- Plugin async work is robust by construction: one runtime, guaranteed failure
+  logging, guaranteed interruption on editor teardown.
+- `PluginContext` grows a versioned capability (as its doc-comment anticipates).
+  There is exactly one constructor of `PluginContext` (the editor's `pluginCtx`),
+  so the surface stays centrally owned.
+- **Scope is editor-lifetime, not node-lifetime.** Deleting a single node does
+  not interrupt a `run` in flight — the continuation's own guards (e.g. the
+  unfurl's `current == null` / verbatim-match checks) still handle a
+  since-deleted target. Node-scoped cancellation is deliberately not built (it
+  would require per-node fiber tracking for a rare case the guards already cover).
+- **A promise lifted with `Effect.promise` is not truly cancellable.**
+  Interrupting the fiber stops the continuation but cannot abort the underlying
+  JS promise (it has no signal). Effects built from `Effect.tryPromise` with the
+  runtime `signal` threaded to `fetch` (the unfurl) DO get real cancellation. The
+  daily migration uses the promise-lift form and therefore gets lifecycle
+  tracking + failure logging, but not fetch abortion — acceptable, and recorded
+  here so the difference is not mistaken for a bug.
+
+## Alternatives considered
+
+- **Let plugins call `appRuntime.runFork` themselves** (status quo for links):
+  rejected — every plugin then re-implements tracking, interruption, and a
+  failure sink, and most will skip them (daily did).
+- **A typed-error `run` (`Effect<void, never>`)** forcing the plugin to pre-handle
+  all errors: rejected as needlessly restrictive; the failure sink makes an
+  escaped error observable without forcing the plugin to prove `never`.
+- **Node-scoped fibers**: rejected — disproportionate for the one case
+  (unfurl-after-delete) the continuation guards already cover.
+
+## Implementation note (Effect v4)
+
+Effect v4 (vendored at `repos/effect-smol/`) renamed `Effect.catchAllCause` to
+`Effect.catchCause`; `Fiber.RuntimeFiber` no longer exists as a separate type —
+`ManagedRuntime.runFork` returns `Fiber.Fiber<A, E>`. The implementation follows
+the vendored source, not the v3-era names.

--- a/src/components/OutlineEditor.tsx
+++ b/src/components/OutlineEditor.tsx
@@ -12,6 +12,7 @@ import {
   type ReactNode,
   type RefObject,
 } from "react";
+import { Cause, Effect, Fiber } from "effect";
 import { useWindowVirtualizer } from "@tanstack/react-virtual";
 import {
   Link,
@@ -90,6 +91,7 @@ import {
 } from "../data/mutations";
 import { bootstrapOutline } from "../data/seed";
 import { runStructural } from "../data/structural";
+import { appRuntime } from "../data/runtime";
 import { setNodeActionBridge } from "../data/command-bridge";
 import { capture, drop } from "../data/history";
 import { runHistoryRestore } from "./history-restore";
@@ -432,6 +434,9 @@ export function OutlineEditor({ rootId }: OutlineEditorProps) {
     consumeClick,
   });
 
+  // Live plugin async fibers (ctx.run), interrupted on editor unmount (ADR 0039).
+  const runningFibers = useRef(new Set<Fiber.Fiber<void, never>>());
+
   // PluginContext factory (ADR 0001 D8): the promoted command set + tree reads +
   // a small nav surface, handed to plugin interaction handlers (Seam B). Reads
   // the live tree via getTreeIndex() at call time; stable identity.
@@ -444,9 +449,33 @@ export function OutlineEditor({ rootId }: OutlineEditorProps) {
       },
       openOverlay: (node) => setOverlayNode(node),
       openPanel: (node) => setPanelNode(node),
+      run: (effect) => {
+        const guarded = effect.pipe(
+          Effect.catchCause((cause) =>
+            Effect.sync(() =>
+              console.error("[plugin] async task failed:", Cause.pretty(cause)),
+            ),
+          ),
+          Effect.asVoid,
+        );
+        const set = runningFibers.current;
+        let fiber: Fiber.Fiber<void, never>;
+        fiber = appRuntime.runFork(
+          guarded.pipe(Effect.ensuring(Effect.sync(() => set.delete(fiber)))),
+        );
+        set.add(fiber);
+      },
     }),
     [commands, navigateZoom],
   );
+
+  // Interrupt any still-running plugin fibers when the editor unmounts (ADR 0039).
+  useEffect(() => {
+    const fibers = runningFibers.current;
+    return () => {
+      for (const f of fibers) appRuntime.runFork(Fiber.interrupt(f));
+    };
+  }, []);
 
   // Publish the node-action surface for the Cmd+K command center (ADR 0034). The
   // switcher is mounted in `__root`, OUTSIDE this editor, so it reads these live

--- a/src/plugins/daily/index.tsx
+++ b/src/plugins/daily/index.tsx
@@ -16,6 +16,7 @@
 // capture/pending-focus semantics are editor-edit concerns a get-or-create that
 // navigates away doesn't want.
 
+import { Effect } from "effect";
 import {
   CalendarArrowDownIcon,
   CalendarDaysIcon,
@@ -216,7 +217,10 @@ function TodayButton({ getCtx }: { getCtx: () => PluginContext }) {
       disabled={pending}
       aria-busy={pending}
       data-daily-nav-pending={pending ? "" : undefined}
-      onClick={() => void goToDate(localDateKey(), getCtx())}
+      onClick={() => {
+        const ctx = getCtx();
+        ctx.run(Effect.promise(() => goToDate(localDateKey(), ctx)));
+      }}
     >
       {pending ? (
         <Loader2Icon className="animate-spin" />
@@ -303,7 +307,7 @@ export default definePlugin({
         if (!key) return;
         e.preventDefault();
         e.stopPropagation();
-        void goToDate(key, ctx);
+        ctx.run(Effect.promise(() => goToDate(key, ctx)));
       },
     },
   ],
@@ -518,10 +522,12 @@ export default definePlugin({
         hint: "Creates today's daily note",
         icon: CalendarDaysIcon,
         run: () =>
-          void getOrCreateDay(key, ctx.index).then((id) => {
-            if (id) ctx.goTo(id);
-            else toast.error("Couldn't open today's daily note");
-          }),
+          void getOrCreateDay(key, ctx.index)
+            .then((id) => {
+              if (id) ctx.goTo(id);
+              else toast.error("Couldn't open today's daily note");
+            })
+            .catch(() => toast.error("Couldn't open today's daily note")),
       },
     ];
   },

--- a/src/plugins/links/index.ts
+++ b/src/plugins/links/index.ts
@@ -6,7 +6,7 @@
 // The pure link layer (parse/strip/encode) stays in src/data/links.ts; this is
 // just the decoration half expressed as El descriptors.
 
-import { Effect } from "effect";
+import { Duration, Effect } from "effect";
 import { LinkIcon } from "lucide-react";
 import {
   bareHttpUrl,
@@ -18,7 +18,6 @@ import {
 } from "../../data/links";
 import { getSelectionRange, readSource } from "../../components/inline-code";
 import { openUrlInFocusedTab } from "../../components/open-url";
-import { appRuntime } from "../../data/runtime";
 import { getTreeIndex } from "../../data/tree-store";
 import { getViewRootId } from "../../data/view-state";
 import { definePlugin, type El, type PluginContext } from "../types";
@@ -205,7 +204,13 @@ function fetchLinkTitleE(url: string): Effect.Effect<string | null> {
       return typeof data.title === "string" && data.title ? data.title : null;
     },
     catch: (cause) => cause,
-  }).pipe(Effect.orElseSucceed(() => null));
+  }).pipe(
+    Effect.timeoutOrElse({
+      duration: Duration.seconds(8),
+      orElse: () => Effect.succeed<string | null>(null),
+    }),
+    Effect.orElseSucceed(() => null),
+  );
 }
 
 // The just-folded <a> for `token` inside `el` (matched on its `data-src`, which
@@ -380,12 +385,13 @@ export default definePlugin({
       const anchor = findFoldedAnchor(el, token);
       anchor?.classList.add(UNFURLING_CLASS);
 
-      // Fork the unfurl on the app runtime (a tracked fiber, not a floating
-      // `void promise.then`). NOTE: it's app-scoped, not node-scoped -- nothing
-      // interrupts it when the bullet is deleted, so the continuation's own
-      // guards (current == null, verbatim swapLinkLabel match) are what keep a
-      // late title from writing into a deleted or since-edited bullet.
-      appRuntime.runFork(
+      // Run the unfurl through the plugin async seam (ctx.run, ADR 0039): a
+      // tracked fiber on the shared runtime, interrupted on editor unmount. It's
+      // editor-scoped, not node-scoped -- nothing interrupts it when just the
+      // bullet is deleted, so the continuation's own guards (current == null,
+      // verbatim swapLinkLabel match) are what keep a late title from writing
+      // into a deleted or since-edited bullet.
+      ctx.run(
         fetchLinkTitleE(label).pipe(
           Effect.flatMap((title) =>
             Effect.sync(() => {

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -7,6 +7,7 @@
 // token + decorator), B (delegated interaction), I (input/paste); later slices
 // add commands, keymap, slots, transforms, menus, and side-collections.
 
+import type { Effect } from "effect";
 import type { ComponentType, ReactNode } from "react";
 import type { Node, TreeIndex } from "../data/tree";
 // Type-only (erased at runtime) -- PluginContext.mutations IS the promoted
@@ -166,6 +167,16 @@ export interface PluginContext {
    *  Lane-B (untrusted MCP App) may render into. The node must supply its own
    *  `SheetHeader`/`SheetTitle`. */
   openPanel: (node: ReactNode | null) => void;
+  /** Run a fire-and-forget async task on the app's shared Effect runtime. The
+   *  fiber is tracked and INTERRUPTED when the editor unmounts; any failure or
+   *  defect is logged (never silently swallowed, never a floating unhandled
+   *  rejection). The effect must be fully provided (R = never) and self-handle
+   *  the domain result it cares about — the seam owns the runtime + lifecycle +
+   *  failure sink, not error semantics (compose timeout/retry inside the effect,
+   *  see kv-client-effect.ts). Editor-lifetime scoped, not node-scoped: deleting
+   *  one node does not interrupt an in-flight run (continuation guards cover
+   *  that). See ADR 0039. */
+  run(effect: Effect.Effect<unknown, unknown>): void;
 }
 
 // --- Seam B: delegated interaction ------------------------------------------


### PR DESCRIPTION
## What

Adds one capability to `PluginContext` — `run(effect)` — an Effect-backed async seam for plugins, plus ADR 0039. Migrates the two existing async consumers (links unfurl, daily get-or-create) onto it.

## Why

The plugin contract is synchronous; every plugin doing async work re-derives its own execution/error/lifecycle story, and they diverge: the links unfurl forks on the shared `appRuntime` (tracked, but app-scoped, never interrupted, no timeout), while daily hand-rolls `async/await` chains that never touch the shared runtime and in one spot leak an unhandled rejection.

## Change

- **`ctx.run(effect)`** (`OutlineEditor.tsx`): forks on the shared `appRuntime`, tracks the fiber in an editor-scoped `Set`, removes it on completion (`Effect.ensuring`), interrupts survivors on editor unmount, and wraps with a failure sink (`Effect.catchCause` → log) so nothing is silently swallowed. The seam owns runtime + lifecycle + failure logging, not error semantics.
- **Links unfurl**: `fetchLinkTitleE` gains an 8s `Effect.timeoutOrElse` (matching the kv core), and `afterPaste` forks through `ctx.run` instead of `appRuntime.runFork`.
- **Daily**: both `PluginContext` `goToDate` callers route through `ctx.run(Effect.promise(...))`; the `searchActions` floating promise gains a `.catch`.
- **ADR 0039** records the decision + rejected alternatives.

## Verification

- `bun run typecheck`, `bun run typecheck:test`, `bun run lint` → exit 0
- `bun run test` → 450 pass
- `bun run test:e2e e2e/rich-links.spec.ts` → 21/21; `e2e/daily-notes.spec.ts --workers=1` → 14 pass (2 pre-existing failures, see below)

## Reviewer notes

- **Effect v4 API deltas** (verified against the vendored `repos/effect-smol` source, recorded in ADR 0039): the plan's `Effect.catchAllCause` is `Effect.catchCause` in v4; `Fiber.RuntimeFiber` isn't a type → `Fiber.Fiber<void, never>`.
- **Merge order:** land #002 first — this PR and #002 both touch `src/plugins/links/index.ts` at different regions (this PR removes the `appRuntime` import + edits `fetchLinkTitleE`/`afterPaste`); expect a trivial import reconcile.
- **Pre-existing, unrelated:** `e2e/daily-notes.spec.ts:388`/`:409` (the two Cmd+K "today" tests) fail on clean `main` too (verified by reverting the whole tree to base — identical). Not caused by this change.

Executed from advisor plan `003-effect-plugin-async-seam`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
