### PR TITLE
Speed up caret pickers: maintained tag corpus + flattenInline early-bails

### DIFF
--- a/src/data/emphasis.ts
+++ b/src/data/emphasis.ts
@@ -74,6 +74,15 @@ export function hasEmphasis(text: string): boolean {
  *  verbatim. A run with empty interior can't match (the patterns require a
  *  non-empty interior), so there's nothing to collapse. */
 export function stripEmphasis(text: string): string {
+  // Bail before constructing the (unicode-lookaround, per-call-built)
+  // alternation regex when none of the marker chars are present -- the
+  // dominant cost of `flattenInline` on marker-free text (measured ~1.5us/node
+  // from RegExp construction alone), which the `[[` node-link picker's scan
+  // pays per node while the menu is open. Mirrors `stripLinks`/
+  // `stripHighlights`'s parallel guards.
+  if (!text.includes("*") && !text.includes("_") && !text.includes("~")) {
+    return text;
+  }
   return text.replace(anyEmphasisRegex(), (run) => {
     // Every pattern uses the SAME marker char on both edges with equal length
     // (1 for italic/underline, 2 for bold/strike). Count the leading run of

--- a/src/data/highlight.ts
+++ b/src/data/highlight.ts
@@ -102,8 +102,11 @@ export function buildHighlightRun(
 }
 
 /** The interior text of every highlight run, fences + color emoji stripped --
- *  the search/display projection (the `stripEmphasis` sibling). */
+ *  the search/display projection (the `stripEmphasis` sibling). Bails before
+ *  building the regex when `text` has no `==` (see `stripLinks`'s parallel
+ *  guard -- `flattenInline` chains this on every scanned node text). */
 export function stripHighlights(text: string): string {
+  if (!text.includes("==")) return text;
   return text.replace(highlightRegex(), (run) => parseHighlight(run).interior);
 }
 

--- a/src/data/links.ts
+++ b/src/data/links.ts
@@ -30,8 +30,12 @@ export function hasLink(text: string): boolean {
 }
 
 /** Flatten links to their label text -- the projection used for fuzzy search
- *  and for clean display in result rows (ADR 0005). */
+ *  and for clean display in result rows (ADR 0005). Bails before building the
+ *  regex when `text` can't contain a link (no `[`) -- `flattenInline` chains
+ *  this on every node text in the `[[` node-link picker's scan while it's
+ *  open, so a link-free node should cost one `includes` check. */
 export function stripLinks(text: string): string {
+  if (!text.includes("[")) return text;
   return text.replace(LINK_RE(), (_full, label: string) => label);
 }
 

--- a/src/data/tags.test.ts
+++ b/src/data/tags.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, test } from 'bun:test'
 import {
   buildTagFilter,
   collectAllTags,
+  collectTagCorpus,
   normalizeTag,
   parseQuery,
+  parseTags,
   serializeQuery,
   validateOutlineSearch,
 } from './tags'
@@ -61,6 +63,41 @@ describe('collectAllTags', () => {
   test('excludeId drops one node’s contribution', () => {
     // dropping node 1 leaves only node 2's #Alpha (its own casing wins now)
     expect(collectAllTags(tree, '1')).toEqual(['#Alpha'])
+  })
+})
+
+describe('parseTags', () => {
+  test('bails without a #, matches the regex path for tagged text', () => {
+    expect(parseTags('plain text, no tags')).toEqual([])
+    expect(parseTags('')).toEqual([])
+    expect(parseTags('#alpha #beta #alpha')).toEqual(['#alpha', '#beta'])
+  })
+})
+
+describe('tagCorpus (buildTreeIndex)', () => {
+  test('matches collectAllTags for the same fixture (Plan 004 parity gate)', () => {
+    const tree = index([
+      makeNode({ id: '1', text: '#alpha #beta' }),
+      makeNode({ id: '2', text: '#Alpha' }), // case variant of #alpha
+      makeNode({ id: '3', text: 'plain text, no tags' }),
+      makeNode({ id: '4', text: '#gamma #gamma' }), // repeated tag, one node
+    ])
+    expect(collectTagCorpus(tree.tagCorpus)).toEqual(collectAllTags(tree))
+    expect(collectTagCorpus(tree.tagCorpus)).toEqual(['#alpha', '#beta', '#gamma'])
+  })
+
+  test('an empty tree has an empty corpus', () => {
+    const tree = index([])
+    expect(collectTagCorpus(tree.tagCorpus)).toEqual([])
+  })
+
+  test('counts occurrences, not just presence', () => {
+    const tree = index([
+      makeNode({ id: '1', text: '#work' }),
+      makeNode({ id: '2', text: '#work #home' }),
+    ])
+    expect(tree.tagCorpus.get('#work')?.count).toBe(2)
+    expect(tree.tagCorpus.get('#home')?.count).toBe(1)
   })
 })
 

--- a/src/data/tags.ts
+++ b/src/data/tags.ts
@@ -16,8 +16,16 @@ export const TAG_PATTERN = '(?<=^|\\s)#[\\p{L}\\p{N}_-]+'
 
 const TAG_RE = new RegExp(TAG_PATTERN, 'gu')
 
-/** The distinct tags in a string, with their leading `#`, in first-seen order. */
-function parseTags(text: string): string[] {
+const EMPTY_TAGS: string[] = []
+
+/**
+ * The distinct tags in a string, with their leading `#`, in first-seen order.
+ * Bails before any regex work when `text` can't contain a `#` (the tree-store's
+ * incremental corpus maintenance runs this on every text-changing keystroke, not
+ * just tag-bearing ones -- same early-out discipline as `parseNodeLinks`).
+ */
+export function parseTags(text: string): string[] {
+  if (!text.includes('#')) return EMPTY_TAGS
   const out: string[] = []
   const seen = new Set<string>()
   for (const m of text.matchAll(TAG_RE)) {
@@ -76,6 +84,28 @@ export function collectAllTags(index: TreeIndex, excludeId?: string): string[] {
     }
   }
   return [...seen.values()].sort((a, b) => a.localeCompare(b))
+}
+
+/**
+ * One entry in `TreeIndex.tagCorpus` (tree.ts): `tag` is the display casing
+ * (first registered, same first-seen-wins rule `collectAllTags` uses within a
+ * single build), `count` is how many nodes currently carry it -- so removing a
+ * node's occurrence is a decrement, not a rescan. Built once in `buildTreeIndex`
+ * and maintained incrementally in tree-store.ts's `applyChanges`, so the `#`
+ * picker's `entries` call is O(distinct tags) instead of O(all nodes) per
+ * keystroke while the menu is open.
+ */
+export interface TagEntry {
+  tag: string
+  count: number
+}
+
+/** The maintained corpus's sorted distinct tag list -- the `#` picker's
+ *  autocomplete source. O(distinct tags), never O(all nodes). */
+export function collectTagCorpus(corpus: Map<string, TagEntry>): string[] {
+  const out: string[] = []
+  for (const entry of corpus.values()) out.push(entry.tag)
+  return out.sort((a, b) => a.localeCompare(b))
 }
 
 /** True iff `text` carries every one of `activeTags` (per-node AND). */

--- a/src/data/tree-store.ts
+++ b/src/data/tree-store.ts
@@ -13,7 +13,7 @@ import {
 import { parseNodeLinks } from './node-links'
 import { buildVisibleRows, type VisibleRow } from './visible-order'
 import { isMirrorsEnabled } from './flags'
-import type { TagFilter } from './tags'
+import { parseTags, type TagFilter } from './tags'
 
 /**
  * A single, app-wide subscription to the nodes collection that derives one
@@ -49,6 +49,7 @@ let index: TreeIndex = {
   childrenByParent: new Map(),
   mirrorsBySource: new Map(),
   linksByTarget: new Map(),
+  tagCorpus: new Map(),
 }
 const listeners = new Set<() => void>()
 let started = false
@@ -115,6 +116,10 @@ function applyChanges(changes: ReadonlyArray<ChangeMessage<Node>>) {
   // refreshes on a bare field edit; parseNodeLinks bails on link-free text, so
   // the keystroke hot path pays two `includes` scans of the edited node's text.
   let linksChanged = false
+  // Tag-corpus transitions (the tags.ts split): a text edit that adds/removes a
+  // `#tag`. Tracked the same way as linksChanged; parseTags bails on tag-free
+  // text so a tag-free keystroke pays the same cheap `includes` scan.
+  let tagsChanged = false
   for (const change of changes) {
     if (change.type === 'delete') {
       const prev = index.byId.get(change.key as string)
@@ -130,6 +135,10 @@ function applyChanges(changes: ReadonlyArray<ChangeMessage<Node>>) {
       for (const target of parseNodeLinks(prev.text)) {
         removeLink(target, prev.id)
         linksChanged = true
+      }
+      for (const tag of parseTags(prev.text)) {
+        removeTagOccurrence(tag)
+        tagsChanged = true
       }
       continue
     }
@@ -150,6 +159,22 @@ function applyChanges(changes: ReadonlyArray<ChangeMessage<Node>>) {
           if (!before.includes(t)) {
             addLink(t, next.id)
             linksChanged = true
+          }
+        }
+      }
+      const tagsBefore = prev ? parseTags(prev.text) : []
+      const tagsAfter = parseTags(next.text)
+      if (tagsBefore.length > 0 || tagsAfter.length > 0) {
+        for (const t of tagsBefore) {
+          if (!tagsAfter.includes(t)) {
+            removeTagOccurrence(t)
+            tagsChanged = true
+          }
+        }
+        for (const t of tagsAfter) {
+          if (!tagsBefore.includes(t)) {
+            addTagOccurrence(t)
+            tagsChanged = true
           }
         }
       }
@@ -218,6 +243,9 @@ function applyChanges(changes: ReadonlyArray<ChangeMessage<Node>>) {
     // (link-free) keystroke keeps the reference.
     linksByTarget:
       structural || linksChanged ? new Map(index.linksByTarget) : index.linksByTarget,
+    // Same discipline for the tag corpus: fresh on a structural change or when a
+    // text edit added/removed a tag. A tag-free keystroke keeps the reference.
+    tagCorpus: structural || tagsChanged ? new Map(index.tagCorpus) : index.tagCorpus,
   }
   // Bump the flat-list signal on a structural change OR a visibility flip; a
   // pure text/isTask edit leaves it untouched (the typing hot path). See
@@ -286,6 +314,26 @@ function removeLink(targetId: string, referrerId: string) {
   const i = ids.indexOf(referrerId)
   if (i !== -1) ids.splice(i, 1)
   if (ids.length === 0) index.linksByTarget.delete(targetId)
+}
+
+/** Register one occurrence of `tag` in the maintained corpus (the tags.ts
+ *  split): first-seen casing wins the entry's display `tag`, same rule
+ *  `collectAllTags` applies in a full rebuild. */
+function addTagOccurrence(tag: string) {
+  const key = tag.toLowerCase()
+  const entry = index.tagCorpus.get(key)
+  if (entry) entry.count++
+  else index.tagCorpus.set(key, { tag, count: 1 })
+}
+
+/** Drop one occurrence; prune the entry once its count reaches zero (the tag no
+ *  longer appears anywhere in the outline). */
+function removeTagOccurrence(tag: string) {
+  const key = tag.toLowerCase()
+  const entry = index.tagCorpus.get(key)
+  if (!entry) return
+  entry.count--
+  if (entry.count <= 0) index.tagCorpus.delete(key)
 }
 
 /**

--- a/src/data/tree.ts
+++ b/src/data/tree.ts
@@ -1,6 +1,7 @@
 import type { Node } from './schema'
 import { parseNodeLinks } from './node-links'
 import { orderSiblings } from './sibling-chain'
+import { parseTags, type TagEntry } from './tags'
 
 export type { Node } from './schema'
 
@@ -37,6 +38,14 @@ export interface TreeIndex {
    * "{n} backlinks" chrome. Empty for a link-free outline.
    */
   linksByTarget: Map<string, string[]>
+  /**
+   * Maintained `#tag` corpus (the `src/data/tags.ts` split): a case-folded key
+   * -> {@link TagEntry}, built here and maintained incrementally in
+   * tree-store.ts alongside `linksByTarget`. Powers the `#` autocomplete picker
+   * via `collectTagCorpus` (tags.ts) so it reads O(distinct tags) instead of
+   * re-scanning every node's text per keystroke while the menu is open.
+   */
+  tagCorpus: Map<string, TagEntry>
 }
 
 /** Synthetic parent id for top-level nodes (those with parentId === null). */
@@ -90,7 +99,21 @@ export function buildTreeIndex(nodes: Node[]): TreeIndex {
     }
   }
 
-  return { childrenByParent, byId, mirrorsBySource, linksByTarget }
+  // Tag corpus (the tags.ts split): bucket each distinct tag under its
+  // case-folded key, first-seen casing wins -- the same dedupe rule
+  // `collectAllTags` applies in one pass, kept live instead of rebuilt.
+  // parseTags bails before any regex work on tag-free text.
+  const tagCorpus = new Map<string, TagEntry>()
+  for (const node of nodes) {
+    for (const tag of parseTags(node.text)) {
+      const key = tag.toLowerCase()
+      const entry = tagCorpus.get(key)
+      if (entry) entry.count++
+      else tagCorpus.set(key, { tag, count: 1 })
+    }
+  }
+
+  return { childrenByParent, byId, mirrorsBySource, linksByTarget, tagCorpus }
 }
 
 export function childrenOf(index: TreeIndex, parentId: string | null): Node[] {

--- a/src/plugins/tags/index.tsx
+++ b/src/plugins/tags/index.tsx
@@ -5,7 +5,7 @@
 // stays in src/data/tags.ts and the color side-collection in
 // src/data/tag-colors.ts (Seam E); this folder wires them.
 
-import { buildTagFilter, collectAllTags, parseQuery, TAG_PATTERN } from "../../data/tags";
+import { buildTagFilter, collectTagCorpus, parseQuery, TAG_PATTERN } from "../../data/tags";
 import {
   definePlugin,
   type El,
@@ -161,7 +161,9 @@ export default definePlugin({
         // already has a tag would never autocomplete a second one. Keep the
         // full corpus and filter out just the self-match token.
         const inProgress = ("#" + trigger.query).toLowerCase();
-        const all = collectAllTags(ctx.tree);
+        // Read the maintained corpus (tree-store.ts) instead of rescanning
+        // every node's text on each keystroke while the menu is open.
+        const all = collectTagCorpus(ctx.tree.tagCorpus);
         const matches = (q
           ? all.filter((t) => t.slice(1).toLowerCase().includes(q))
           : all


### PR DESCRIPTION
## What

Stops the two caret pickers (`#` tags, `[[` node-links) rebuilding a whole-tree corpus on every keystroke while open.

## Why (with measurements)

Both pickers ran an O(n·textlen) scan inside the menu's per-keystroke `entries(...)`. On a 10k-node outline (measured before this change): `collectAllTags` ~7.1ms/call and the `[[` scan+sort ~17.6ms/call — both well over a frame budget. (The plan gated the build on this measurement; it cleared the 4ms threshold, so it was built.)

## Change

1. **Maintained `tagCorpus`** on `TreeIndex` (`tree.ts` full build + `tree-store.ts` incremental maintenance), mirroring the existing `linksByTarget` discipline — including preserving the map reference on tag-free keystrokes so the ADR-0014 caches / typing hot path aren't churned. The `#` picker reads `collectTagCorpus(ctx.tree.tagCorpus)` (O(distinct tags)) instead of `collectAllTags` (O(all nodes)).
2. **Root-caused the `[[` picker cost** to the shared `flattenInline` primitives rebuilding unicode-lookaround regexes per node. Added `includes()` early-bail guards to `stripEmphasis`/`stripLinks`/`stripHighlights` (and `parseTags`), each bailing only when the regex's required trigger char is absent.

After: `collectTagCorpus` ~0.001ms; `flattenInline` 15.9ms → 0.98ms/10k-node pass.

## Verification

- `bun run typecheck`, `bun run typecheck:test`, `bun run lint` → exit 0
- `bun run test` → 454 pass (new `tagCorpus` parity + occurrence-count tests assert equality with `collectAllTags`)
- `tag-menu`, `tag-filter`, `node-links`, `emphasis`, `highlight`, `rich-links`, `command-center` e2e → green (`emphasis:245` passes 2/2 in isolation; a single batch-run flake was the known multi-spec dev-server contention, not this change)

## Reviewer notes — please read

- **Scope note (deliberate deviation from the plan's file list):** the plan named `src/plugins/node-links/index.tsx`, but the measured dominant cost lived in the shared `flattenInline` regex primitives, so this touches `src/data/emphasis.ts`, `src/data/links.ts`, `src/data/highlight.ts` instead and leaves `node-links/index.tsx` untouched. Each guard is **provably behavior-identical** (the regex cannot match without its trigger char present) and it speeds every `flattenInline` caller (Cmd+K corpus, breadcrumbs, mirror-places) for free — lower-risk than the plan's maintained-recency-index alternative, but wider than its literal file list. Worth your eyes on that diff.
- Minor: after edits, a tag's *display casing* in the picker can differ from a fresh rebuild (first-seen casing sticks). Harmless — tag matching is case-insensitive, and `collectAllTags` had the same looseness.
- **Merge order:** overlaps #002 in `links.ts`/`highlight.ts` (different functions); merge after #002 and reconcile if needed.

Executed from advisor plan `004-picker-corpus-perf`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
