### PR TITLE
DX: bun run dev starts the whole local stack in one command

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "description": "A local-first outline editor built with TanStack Start and TanStack DB.",
   "license": "O'Saasy",
   "scripts": {
-    "dev": "vite dev",
+    "dev": "bun scripts/dev.ts",
+    "dev:web": "vite dev",
     "dev:api": "wrangler dev --port 8787",
     "build": "vite build",
     "build:cf": "vite build && cp dist/client/_shell.html dist/client/index.html",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,9 +20,9 @@ export default defineConfig({
     { name: "chromium", use: { ...devices["Desktop Chrome"] } },
   ],
   // Boot the Vite dev server for the run; reuse one already running locally so
-  // an open `bun run dev` makes the suite start instantly.
+  // an open `bun run dev:web` (or `bun run dev`) makes the suite start instantly.
   webServer: {
-    command: `bun run dev --port ${PORT}`,
+    command: `bun run dev:web --port ${PORT}`,
     url: `http://localhost:${PORT}`,
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,

--- a/scripts/cf-dev.ts
+++ b/scripts/cf-dev.ts
@@ -22,7 +22,7 @@
  *
  * Tradeoff: a full build runs per save (~1-2s), slower than `bun run dev`'s HMR.
  * That is the cost of exercising the real Worker + per-user DO path. For pure UI
- * work, `bun run dev` (+ `bun run dev:api`) is still the faster loop.
+ * work, `bun run dev` (both servers, HMR) is still the faster loop.
  */
 import { watch as fsWatch, copyFileSync, existsSync } from "node:fs";
 import { resolve } from "node:path";

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -1,0 +1,48 @@
+/**
+ * `bun run dev` orchestrator: starts BOTH local servers with one command.
+ *
+ * Dotflowy's dev loop is two servers: `wrangler dev` (Worker + per-user DO +
+ * local D1) on :8787, and Vite (the SPA) on :3000, which proxies `/api` to
+ * :8787 (see vite.config.ts). Previously `bun run dev` only started Vite, so
+ * a new contributor running just that command got a UI where every `/api`
+ * call 502s with no explanation. This spawns both, prefixes their output,
+ * and tears both down together on exit.
+ *
+ * This is the HMR loop (fast, no rebuild-per-save) - not `cf:dev`
+ * (scripts/cf-dev.ts), which is a slower production-like single-server
+ * preview that exercises the real built assets through wrangler.
+ */
+import { resolve } from "node:path";
+
+const ROOT = resolve(import.meta.dir, "..");
+
+const log = (msg: string) => console.log(`\x1b[36m[dev]\x1b[0m ${msg}`);
+
+log("starting wrangler dev on :8787 + vite dev on :3000 ...");
+
+const wrangler = Bun.spawn(["bunx", "wrangler", "dev", "--port", "8787"], {
+  cwd: ROOT,
+  stdio: ["inherit", "inherit", "inherit"],
+});
+
+// Forward any extra CLI args (e.g. `bun run dev --port 3005`) to vite.
+const vite = Bun.spawn(["bunx", "vite", "dev", ...process.argv.slice(2)], {
+  cwd: ROOT,
+  stdio: ["inherit", "inherit", "inherit"],
+});
+
+log("Worker: http://localhost:8787  |  App: http://localhost:3000");
+
+function teardownAndExit(): void {
+  wrangler.kill();
+  vite.kill();
+  process.exit(0);
+}
+
+process.on("SIGINT", teardownAndExit);
+process.on("SIGTERM", teardownAndExit);
+
+// If either child dies on its own, tear down the other so the script never
+// hangs with an orphaned process.
+void wrangler.exited.then(teardownAndExit);
+void vite.exited.then(teardownAndExit);


### PR DESCRIPTION
Part 1 of 3 in a local-dev onboarding cleanup (fixes "ran `bun run dev`, every /api call 502s because the Worker isn't running").

## What
- `bun run dev` now starts **both** servers via `scripts/dev.ts` — vite (:3000) + `wrangler dev` (:8787) — with prefixed output and a shared teardown (Ctrl+C or either child exiting stops both).
- Old vite-only script preserved as `bun run dev:web`; `bun run dev:api` unchanged. Both still available for split-terminal use.
- Playwright's `webServer` repointed to `bun run dev:web` (the e2e suite mocks `/api`, so it needs vite only — not a Worker).

## Verification
- `bun run typecheck` → clean.
- e2e re-run: repointed webServer runs `vite dev --port 3210` only, 5/5 pass on `enter-split.spec.ts`.
- No new dependency (matches the hand-rolled `scripts/cf-dev.ts` precedent).

## Merge order
Part of a 4-PR set. Merge **001 → 002 → 003 → 004**. Independent of 002; must land before 003 (003's docs describe the combined `bun run dev`). Expect a small `package.json` scripts-block conflict with 002/003 — trivial to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the local development experience to start both the app and backend services together from one command.
  * Added clearer dev server handling so the browser app and API are launched in a coordinated way.
* **Bug Fixes**
  * Improved process cleanup during development to avoid leftover background servers if one stops unexpectedly.
  * E2E test setup now starts the intended web development server consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->