### PR TITLE
DX: bun run setup bootstraps a fresh clone in one command

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "description": "A local-first outline editor built with TanStack Start and TanStack DB.",
   "license": "O'Saasy",
   "scripts": {
+    "setup": "bun scripts/setup.ts",
     "dev": "vite dev",
     "dev:api": "wrangler dev --port 8787",
     "build": "vite build",

--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -1,0 +1,70 @@
+/**
+ * `bun run setup` bootstraps a fresh clone into a working local dev config.
+ *
+ * Three steps, each idempotent:
+ *   1. Copy `.dev.vars.example` -> `.dev.vars` if it doesn't exist yet.
+ *   2. Generate a `BETTER_AUTH_SECRET` if it's still the template placeholder
+ *      (or empty) - never rotate an already-set secret.
+ *   3. Apply the local D1 schema via the existing `db:migrate:local` script
+ *      (wrangler's migration apply is itself idempotent - re-running is a
+ *      no-op).
+ *
+ * Safe to re-run any time; never prints the generated secret.
+ */
+import { randomBytes } from "node:crypto";
+import {
+  copyFileSync,
+  existsSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { resolve } from "node:path";
+
+const ROOT = resolve(import.meta.dir, "..");
+const DEV_VARS = resolve(ROOT, ".dev.vars");
+const DEV_VARS_EXAMPLE = resolve(ROOT, ".dev.vars.example");
+const NODE_MODULES = resolve(ROOT, "node_modules");
+
+const log = (msg: string) => console.log(`\x1b[36m[setup]\x1b[0m ${msg}`);
+
+if (!existsSync(NODE_MODULES)) {
+  log("node_modules missing - run `bun install` first");
+  process.exit(1);
+}
+
+// 1. Ensure .dev.vars exists.
+if (!existsSync(DEV_VARS)) {
+  copyFileSync(DEV_VARS_EXAMPLE, DEV_VARS);
+  log("created .dev.vars from .dev.vars.example");
+} else {
+  log(".dev.vars already present - leaving it");
+}
+
+// 2. Ensure BETTER_AUTH_SECRET is set (line-oriented rewrite so commented
+// optional keys stay untouched).
+const lines = readFileSync(DEV_VARS, "utf8").split("\n");
+const idx = lines.findIndex((l) => l.startsWith("BETTER_AUTH_SECRET="));
+const current = idx >= 0 ? lines[idx].slice("BETTER_AUTH_SECRET=".length) : "";
+if (idx >= 0 && (current === "replace-me" || current.trim() === "")) {
+  lines[idx] = `BETTER_AUTH_SECRET=${randomBytes(32).toString("base64")}`;
+  writeFileSync(DEV_VARS, lines.join("\n"));
+  log("generated BETTER_AUTH_SECRET (32 bytes)");
+} else {
+  log("BETTER_AUTH_SECRET already set - leaving it");
+}
+
+// 3. Apply local D1 schema.
+log("applying local D1 schema (db:migrate:local)...");
+const migrate = Bun.spawn(["bun", "run", "db:migrate:local"], {
+  cwd: ROOT,
+  stdio: ["inherit", "inherit", "inherit"],
+});
+const code = await migrate.exited;
+if (code !== 0) {
+  log(`db:migrate:local failed (exit ${code})`);
+  process.exit(1);
+}
+
+log("Setup complete. Next:");
+log("  bun run dev          # start the app (http://localhost:3000)");
+log("  Sign up with invite code: dev-invite");


### PR DESCRIPTION
Part 2 of 3 in a local-dev onboarding cleanup.

## What
`bun run setup` (`scripts/setup.ts`) replaces the three manual first-run steps. Idempotent:
1. Copies `.dev.vars.example` → `.dev.vars` if absent.
2. Generates `BETTER_AUTH_SECRET` via `node:crypto` if it's still the placeholder — **never rotates an existing secret**, and the value is never logged.
3. Applies the local D1 schema (`bun run db:migrate:local`).

The local invite code ships as `dev-invite` in `.dev.vars.example`, so signup works out of the box after setup.

## Verification
- `bun run typecheck` → clean, oxlint clean.
- Fresh run generates a 44-char secret + applies all migrations; re-run leaves the secret unchanged and is a no-op.
- `.dev.vars` stays gitignored (never tracked).

## Merge order
Part of a 4-PR set. Merge **001 → 002 → 003 → 004**. Independent of 001. Expect a small `package.json` scripts-block conflict — trivial to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)