### PR TITLE
DX: bun run seed:user + rewrite onboarding docs for the one-command flow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,18 +25,12 @@ change" guide. Two companion docs go deeper:
 
 ```sh
 bun install
-
-# Local Worker secrets (gitignored). Generate a signing secret:
-cp .dev.vars.example .dev.vars
-# then set BETTER_AUTH_SECRET in .dev.vars, e.g.:
-#   openssl rand -base64 32
-# The Worker fails closed without it.
-# Signup is invite-gated (alpha): the example file ships INVITE_CODES=dev-invite,
-# which is the code to use when creating a local account. No codes = signup closed.
-
-# Apply the local D1 schema (auth tables + the legacy import source). Once.
-bun run db:migrate:local
+bun run setup    # copies .dev.vars, generates BETTER_AUTH_SECRET, applies local D1 schema
 ```
+
+`setup` is idempotent — safe to re-run any time. Signup is invite-gated (alpha):
+the local invite code is **`dev-invite`**, the code to use when creating a
+local account by hand. No codes = signup closed.
 
 ## Running locally
 
@@ -44,15 +38,22 @@ Dotflowy is a static SPA that talks to a Cloudflare Worker over `/api/*`, so the
 real local setup runs both: Vite for the UI and Wrangler for the Worker + the
 per-user Durable Object it routes to.
 
-### Fast loop (two terminals) — the default
+### Fast loop — the default
 
 ```sh
-bun run dev:api   # terminal 1: wrangler dev (Worker + DO + local D1) on :8787
-bun run dev       # terminal 2: vite dev on :3000 (proxies /api -> :8787)
+bun run dev      # vite (:3000) + wrangler (:8787) together; HMR for the UI
 ```
 
 Open http://localhost:3000. Vite gives you HMR; the Worker reloads on its own
-edits. This is the loop for almost all work.
+edits. This is the loop for almost all work. `bun run dev:api` + `bun run dev:web`
+still exist if you want the two servers in separate terminals with isolated logs.
+
+### Sign in
+
+`bun run seed:user` creates a ready-to-use dev account
+(`dev@dotflowy.local` / `dotflowy-dev`) through the real sign-up endpoint —
+run it once the Worker is up and sign in with those credentials. Prefer your
+own account? Sign up by hand with invite code `dev-invite`.
 
 ### Production-like loop (one server)
 

--- a/README.md
+++ b/README.md
@@ -99,11 +99,10 @@ bun run test:e2e   # Playwright end-to-end tests (chromium)
 The repo deploys to **Cloudflare Workers**: one Worker (`worker/index.ts`) serves the static SPA *and* routes the `/api/nodes` + `/api/kv` sync APIs to a **per-user Durable Object**, behind **Better Auth** accounts ([the auth gate](docs/adr/0011-the-auth-gate.md)). Config is in `wrangler.jsonc`. Full design: [the sync design](docs/adr/0008-sync-via-a-per-user-durable-object.md).
 
 ```sh
-# local dev (two terminals): Vite HMR + a local Worker (DO + D1) it proxies /api to
-cp .dev.vars.example .dev.vars   # once: add a BETTER_AUTH_SECRET (openssl rand -base64 32)
-bun run db:migrate:local   # once: apply the local D1 schema (auth tables + the DO import source)
-bun run dev:api            # wrangler dev (Worker + DO + local D1) on :8787
-bun run dev                # vite dev (proxies /api -> :8787)
+bun install
+bun run setup        # generates BETTER_AUTH_SECRET + applies the local D1 schema
+bun run dev          # starts the app (vite :3000 + worker :8787) in one command
+bun run seed:user    # (optional) creates dev@dotflowy.local / dotflowy-dev to sign in with
 
 # or a production-like single-server preview
 bun run cf:dev             # build + wrangler dev
@@ -114,6 +113,8 @@ wrangler secret put INVITE_CODES         # comma-separated invite codes (unset =
 bun run db:migrate:remote  # before the first deploy
 bun run deploy             # build + wrangler deploy
 ```
+
+The local invite code is **`dev-invite`** if you'd rather sign up your own account; `bun run seed:user` skips that by creating a ready-to-use account.
 
 `build:cf` copies the TanStack Start shell (`_shell.html`) to `index.html` so the root and client routes (e.g. `/<nodeId>` zoom views) resolve through the SPA fallback.
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build:cf": "vite build && cp dist/client/_shell.html dist/client/index.html",
     "preview": "vite preview",
     "cf:dev": "bun scripts/cf-dev.ts",
+    "seed:user": "bun scripts/seed-user.ts",
     "deploy": "bun run build:cf && wrangler deploy",
     "db:migrate:local": "wrangler d1 migrations apply dotflowy-db --local",
     "db:migrate:remote": "wrangler d1 migrations apply dotflowy-db --remote",

--- a/scripts/seed-user.ts
+++ b/scripts/seed-user.ts
@@ -1,0 +1,64 @@
+/**
+ * Seeds a ready-to-use dev account against a running local Worker, through
+ * the REAL Better Auth sign-up endpoint (`POST /api/auth/sign-up/email`) —
+ * not a direct D1 insert. Better Auth hashes passwords with its own scrypt
+ * scheme; reproducing that hash to write a row by hand is fragile and breaks
+ * on any Better Auth upgrade. Going through the live endpoint uses the real
+ * code path, so this script carries zero hash logic. The cost: the Worker
+ * must already be running (`bun run dev` / `bun run dev:api`).
+ *
+ * Idempotent: re-running after the account exists is a no-op that exits 0.
+ *
+ * These are well-known dev credentials for a LOCAL, invite-gated instance
+ * (documented in README/CONTRIBUTING so testers can sign in immediately).
+ * Not a production secret — API is hardcoded to localhost on purpose; never
+ * point this at a non-local origin.
+ */
+const API = "http://localhost:8787";
+const EMAIL = "dev@dotflowy.local";
+const PASSWORD = "dotflowy-dev";
+const INVITE = "dev-invite";
+
+async function main(): Promise<void> {
+  // Preflight: make sure the Worker is actually up before attempting the
+  // real sign-up POST, so a connection-refused doesn't read as an auth error.
+  try {
+    await fetch(`${API}/api/auth/ok`);
+  } catch {
+    console.error(
+      `Worker not reachable at ${API}. Run \`bun run dev\` first.`,
+    );
+    process.exit(1);
+  }
+
+  const res = await fetch(`${API}/api/auth/sign-up/email`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      name: "Dev",
+      email: EMAIL,
+      password: PASSWORD,
+      inviteCode: INVITE,
+    }),
+  });
+
+  if (res.ok) {
+    console.log(`created ${EMAIL} (password: ${PASSWORD})`);
+  } else {
+    const text = await res.text();
+
+    if (res.status >= 400 && res.status < 500 && /exist/i.test(text)) {
+      console.log(`${EMAIL} already exists - sign in with password: ${PASSWORD}`);
+    } else if (res.status === 403 || /FORBIDDEN/i.test(text)) {
+      console.error(`sign-up rejected (status ${res.status}): ${text}`);
+      process.exit(1);
+    } else {
+      console.error(`sign-up failed (status ${res.status}): ${text}`);
+      process.exit(1);
+    }
+  }
+
+  console.log(`Sign in at http://localhost:3000 with ${EMAIL} / ${PASSWORD}`);
+}
+
+await main();


### PR DESCRIPTION
Part 3 of 3 in a local-dev onboarding cleanup. This is the direct fix for a tester who couldn't sign in.

## What
- `bun run seed:user` (`scripts/seed-user.ts`) creates a ready-to-use dev account (`dev@dotflowy.local` / `dotflowy-dev`) through the **real Better Auth sign-up endpoint** — no hand-forged password hash, so it can't drift on a Better Auth upgrade. Idempotent; `API` hardcoded to localhost.
- `README.md` + `CONTRIBUTING.md` quick-starts rewritten around `bun install && bun run setup && bun run dev && bun run seed:user`, with the local invite code (`dev-invite`) surfaced clearly.

## Verification
- `bun run typecheck` → clean, oxlint clean.
- Live: first run creates the account, second run exits 0 ("already exists").

## Depends on / merge order
Part of a 4-PR set. Merge **001 → 002 → 003 → 004**. **Depends on 001 + 002** — the docs describe `bun run setup` and the combined `bun run dev`, which land in those PRs. Expect a small `package.json` scripts-block conflict — trivial to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)