### PR TITLE
fix(editor): align bullets, + button, and zoomed title to one axis

### DIFF
--- a/src/components/OutlineEditor.tsx
+++ b/src/components/OutlineEditor.tsx
@@ -822,11 +822,13 @@ export function OutlineEditor({ rootId }: OutlineEditorProps) {
                   </ul>
                 )}
                 {/* Click in the whitespace below the list adds a new top-level
-                bullet. Hidden while filtering -- there's no "add here" then. */}
+                bullet. Hidden while filtering -- there's no "add here" then.
+                `size="icon"` (32px) is what puts the glyph on the same vertical
+                axis as the bullets above and the breadcrumb Home button. */}
                 {!filter && (
                   <Button
                     type="button"
-                    size="icon-sm"
+                    size="icon"
                     variant="ghost"
                     onClick={() =>
                       runStructural(() => {

--- a/src/styles.css
+++ b/src/styles.css
@@ -207,12 +207,19 @@
   margin: 0;
 }
 
+/*
+ * The leading padding centers the 16px bullet on the breadcrumb Home button's
+ * axis (a 32px icon button flush with the same content column, so its icon
+ * centers 16px in): 8px padding + half the bullet = 16px. Coarse re-declares
+ * `padding` below and reaches 16px with a 4px pad + a 24px bullet, so it needs
+ * no change -- keep the two in step if either box size moves.
+ */
 .outline-row {
   position: relative;
   display: flex;
   align-items: flex-start;
   gap: 6px;
-  padding: 2px 4px;
+  padding: 2px 4px 2px 8px;
   border-radius: 4px;
 }
 
@@ -1175,8 +1182,11 @@ body.dragging-active * {
    positioned panel would be clipped by the breadcrumb's horizontal overflow. */
 
 .zoomed-title {
-  /* This inline start padding on mobile is meant to compensate for visual alignment*/
-  @apply max-sm:ps-1;
+  /* Start the title on the same axis as the icon column below and above it: the
+     bullet box, the new-bullet `+`, and the breadcrumb Home glyph all have their
+     left edge 8px into the content column (a 32px icon button, or `.outline-row`'s
+     8px lead padding, around a 16px glyph). Keep in step with that padding. */
+  padding-inline-start: 8px;
   font-weight: 600;
   /* Still flex, but the single item is now the .row-body cell (mirroring
      .outline-row): the leading decorations float inside it, so a long wrapped


### PR DESCRIPTION
Four things in the left column sat on four different x positions. Now all four share one.

Anchor is the breadcrumb **Home** button: a 16px glyph whose left edge is **8px** into the content column.

| | before | after |
|---|---|---|
| Home glyph left | 312 | 312 |
| Bullet box left | 308 | 312 |
| `+` glyph left | 310 | 312 |
| Zoomed title left | 304 | 312 |

### Changes

- **`.outline-row`** lead padding `4px → 8px`. The row *box* doesn't move, only its content, so hover and selection backgrounds are untouched.
- **`+` button** `size="icon-sm"` (28px) → `size="icon"` (32px), matching Home exactly.
- **`.zoomed-title`** gets `padding-inline-start: 8px`, replacing the old mobile-only `max-sm:ps-1` nudge (commented "to compensate for visual alignment"). 8px is right on both breakpoints.

### Touch is unaffected

The `(pointer: coarse)` block re-declares `padding` as a shorthand, so it fully overrides the new lead. It already hit the same axis via a 4px pad + a 24px bullet. Verified at 412px with touch emulation.

### Verification

Measured actual `getBoundingClientRect()` in a live render rather than eyeballing screenshots. `lint`, `typecheck`, and 45 e2e tests across windowing, enter-split, zoom, daily-notes (the title-slot badge path), move-flash, and mobile-actions-bar pass.

One optical note: the title is type, not a glyph box, so its "W" ink starts a hair right of 312 from the left side bearing. Normal when aligning text to icons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Adjusted outline and breadcrumb spacing for better visual alignment.
  * Improved the positioning and size of the “add new top-level bullet” button so it matches surrounding controls more consistently.
  * Refined padding in the zoomed view to keep titles aligned with bullets and breadcrumb icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->