### PR TITLE
feat(dx): provision Claude Code worktrees on create

### DIFF
--- a/.claude/hooks/create-worktree.sh
+++ b/.claude/hooks/create-worktree.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+# WorktreeCreate hook. Replaces Claude Code's default `git worktree add` so a
+# new worktree lands dev-ready: deps installed and the local D1 schema applied.
+#
+# Contract (https://code.claude.com/docs/en/hooks#worktreecreate):
+#   - stdin  = JSON with `base_worktree` and `worktree_name`
+#   - stdout = the created worktree's path, and NOTHING else
+#   - exit 0 = success; any non-zero aborts worktree creation
+#
+# Everything chatty is redirected to stderr, because stdout IS the return value.
+set -euo pipefail
+
+input=$(cat)
+base=$(jq -r '.base_worktree' <<<"$input")
+name=$(jq -r '.worktree_name' <<<"$input")
+path="$base/.claude/worktrees/$name"
+
+{
+  # `claude/` prefix matches Claude Code's default branch naming.
+  git -C "$base" worktree add -b "claude/$name" "$path" \
+    || git -C "$base" worktree add "$path" "claude/$name"
+
+  # .dev.vars is gitignored, so a fresh checkout has no Worker secrets. Copying
+  # it before `setup` also preserves BETTER_AUTH_SECRET and INVITE_CODES rather
+  # than regenerating them from the template.
+  [ -f "$base/.dev.vars" ] && cp "$base/.dev.vars" "$path/.dev.vars"
+
+  cd "$path"
+
+  bun install --frozen-lockfile
+
+  # `bun run setup` requires node_modules, so it must follow the install. It is
+  # idempotent, and its wrangler migration prompts on a TTY -- CI=1 plus a
+  # closed stdin keep it from blocking forever inside the hook.
+  CI=1 bun run setup </dev/null
+} >&2
+
+echo "$path"

--- a/.claude/hooks/remove-worktree.sh
+++ b/.claude/hooks/remove-worktree.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# WorktreeRemove hook. Fires when Claude Code tears a worktree down (session
+# exit, or a subagent finishing). It has no decision control -- exit codes and
+# output are ignored, and removal proceeds regardless -- so this is purely for
+# side effects.
+#
+# It runs BEFORE the directory is gone, so it cannot prune the worktree that
+# triggered it. What it can do is clear the stale .git/worktrees metadata left
+# by *previous* removals, which is what keeps `git worktree list` honest.
+set -euo pipefail
+
+input=$(cat)
+base=$(jq -r '.base_worktree' <<<"$input")
+
+git -C "$base" worktree prune >&2 || true
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,19 @@
+{
+  "hooks": {
+    "WorktreeCreate": [
+      {
+        "type": "command",
+        "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/create-worktree.sh",
+        "timeout": 600,
+        "statusMessage": "Installing deps and applying the local D1 schema..."
+      }
+    ],
+    "WorktreeRemove": [
+      {
+        "type": "command",
+        "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/remove-worktree.sh",
+        "timeout": 30
+      }
+    ]
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,8 @@ bun run dev        # vite (:3000) + wrangler (Worker + DO + local D1, :8787) in 
 bun run seed:user  # optional: creates dev@dotflowy.local / dotflowy-dev to sign in with
 ```
 
+In a **Claude Code worktree** you can skip `bun install` + `bun run setup`: the `WorktreeCreate` hook (`.claude/hooks/create-worktree.sh`) already ran both and copied `.dev.vars` from the base repo, so `typecheck`/`lint`/`test` work immediately. `bun run seed:user` still doesn't — it signs up through a live Worker.
+
 The app is a static SPA that talks to the Worker over `/api/*`, so both servers must run. Testing the OAuth-gated `/mcp` endpoint locally needs `BETTER_AUTH_URL` + `BETTER_AUTH_TRUSTED_ORIGINS` in `.dev.vars` (the `wrangler dev` custom-domain simulation rewrites both the issuer and the request `Origin` to the prod domain) — see `.dev.vars.example` and [ADR 0026](./docs/adr/0026-agent-native-mcp-server.md).
 
 ## Error Handling

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,18 @@ bun run setup    # copies .dev.vars, generates BETTER_AUTH_SECRET, applies local
 the local invite code is **`dev-invite`**, the code to use when creating a
 local account by hand. No codes = signup closed.
 
+### Worktrees provision themselves
+
+Worktrees created by Claude Code (`claude --worktree`, or an agent running with
+`isolation: "worktree"`) skip the two commands above — a `WorktreeCreate` hook
+(`.claude/hooks/create-worktree.sh`, wired up in `.claude/settings.json`) runs
+them for you, plus copies the gitignored `.dev.vars` over from the base repo. A
+fresh worktree can run `typecheck`, `lint`, and `test` immediately.
+
+The one thing it can't do is `bun run seed:user`, which signs up through the
+live Worker and so needs `bun run dev` already running. Seed the worktree's D1
+by hand the first time you want to sign in there.
+
 ## Running locally
 
 Dotflowy is a static SPA that talks to a Cloudflare Worker over `/api/*`, so the


### PR DESCRIPTION
Claude Code worktrees start without `node_modules` or a local D1, so agents can't run the gates. Two hooks fix that.

### What

- **`WorktreeCreate`** replaces the default `git worktree add`: copy `.dev.vars` → `bun install` → `bun run setup` (local D1 migrations).
- **`WorktreeRemove`** prunes stale worktree metadata.

### Verified

Ran the hook against a real worktree: 5 D1 migrations applied, `typecheck` clean, `bun test` 484 pass / 0 fail. stdout was exactly the worktree path (the hook's return value).

### Notes

- `seed:user` is deliberately excluded — it signs up through a live Worker, which isn't running at create time.
- `wrangler d1 migrations apply` prompts on a TTY, so it runs with `CI=1` and stdin closed.
- `.claude/settings.json` is new and checked in — first shared settings file in the repo.
- Fires for every `isolation: "worktree"` subagent too. Each pays a ~36 MB `.wrangler/` that only `bun run dev` uses. Gate `bun run setup` behind an env var if that adds up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
