### PR TITLE
docs: mandate snapshot PR descriptions via ft-create-concise-pr

### DIFF
--- a/.agents/skills/ft-create-concise-pr/SKILL.md
+++ b/.agents/skills/ft-create-concise-pr/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: ft-create-concise-pr
+description: Create or update a pull request with a concise, skimmable snapshot description. Use when opening a PR, writing or rewriting a PR description, or refreshing a PR description after review changes.
+metadata:
+  fruit: self-control
+---
+
+# Snapshot PR
+
+A PR description is a snapshot: one glance gives the reviewer the whole picture. A concise description is kindness to the people who review your work.
+
+## Gather
+
+Know the whole change before writing a word:
+
+1. Find where the branch forked: `git merge-base HEAD <default-branch>` (default branch via `gh repo view --json defaultBranchRef`).
+2. Read the full diff and commit messages since the merge base.
+3. If a PR already exists (`gh pr view`), read its current description and review comments. If the description is already a snapshot (matches the template below), jump to **Update** below. If it isn't, rewrite it with **Write**, keeping facts from the old description that are still true — and never dropping images or links you can't regenerate.
+
+Done when every changed file is accounted for in your understanding — not necessarily in the description.
+
+## Write
+
+Use exactly this template. Omit sections that don't apply. Never add sections.
+
+```md
+## Summary
+
+## Changes
+
+## Flow
+
+## Breaking / Migration
+
+## Test plan
+```
+
+Rules:
+
+- **Title**: imperative mood, under 70 characters.
+- **Summary**: max 2 sentences. What changed and why. No "This PR..." openers. If the PR closes an issue, add `Fixes #N` on its own line — GitHub auto-closes it on merge.
+- **Changes**: 1–7 bullets, one line each — as few as the change honestly needs. Order: behavior changes first, then logic changes, then refactors/chores. Lead with the outcome, trail the mechanism: "Highlights survive flaky networks (retry with backoff)", not "Added retry logic for highlights". The outcome names who benefits and how — a user keeping their moments, a developer getting faster builds. Never file names; the diff shows those.
+- **Flow**: only when the gate below passes.
+- **Breaking / Migration**: only when the change breaks consumers or requires a migration step.
+- **Test plan**: one line stating what was actually verified (commands run, flows exercised). If nothing was verified, write `Not tested`. Never invent verification.
+- No filler, no adjectives.
+
+### Flow diagram gate
+
+Include a Mermaid diagram (GitHub renders it natively) only when the change alters flow across 3 or more components, or reorders a sequence of operations. Max 8 nodes. Show the new flow only — no before/after pairs. Never diagram what one bullet already explains.
+
+## Apply
+
+Post it:
+
+- New PR: push the branch if it isn't pushed, then `gh pr create`. If HEAD is the default branch, stop and ask the user before branching.
+- Existing PR: `gh pr edit --body-file`, adding `--title` if the current title breaks the title rule.
+
+Done when the PR on GitHub shows the snapshot description.
+
+## Update
+
+When a PR that already has a snapshot description changes:
+
+- Keep the structure. Edit only the bullets affected by new commits.
+- Don't let the Summary grow.
+- If a change reverses an earlier bullet, replace the bullet rather than appending.
+- Refresh the Test plan if new verification happened. Refresh or delete the diagram if the flow changed.

--- a/.claude/skills/ft-create-concise-pr
+++ b/.claude/skills/ft-create-concise-pr
@@ -1,0 +1,1 @@
+../../.agents/skills/ft-create-concise-pr

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,10 @@ Repo reality is the source of truth. If `AGENTS.md` or `README.md` becomes false
 - If the code already makes the call obvious, the code is the doc — don't write it down.
 - When a decision changes, edit its ADR in place (or mark it superseded). History — including superseded decisions and their rejected alternatives — is in `git log`.
 
+## Pull requests
+
+**Opening or updating a PR? Run `/ft-create-concise-pr` — always, not just when asked.** Every PR description in this repo follows that skill's snapshot template (Summary / Changes / Flow / Breaking / Test plan), so reviewers get one consistent, skimmable shape regardless of who — human or agent — wrote the change. Don't hand-write a PR body in your own format, and don't let a description drift after review changes — re-run the skill's Update pass instead. If the skill can't be invoked in your harness, follow `.agents/skills/ft-create-concise-pr/SKILL.md` by hand.
+
 ## Commands
 
 ```sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,6 +120,9 @@ Rules of thumb, expanded in `AGENTS.md`:
 - If you change a documented fact (a command, a path, repo structure), fix the
   affected doc (`AGENTS.md` and/or `README.md`) in the same change. See
   _Documentation Freshness_ in `AGENTS.md`.
+- **PR descriptions follow the snapshot template** in
+  `.agents/skills/ft-create-concise-pr/SKILL.md` (agents: run
+  `/ft-create-concise-pr`) — one consistent, skimmable shape for every review.
 
 ## Conventions worth knowing
 

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -49,6 +49,12 @@
       "skillPath": "skills/errore/SKILL.md",
       "computedHash": "c8c58707dfee91f71d479431d3ab3d64d63f824c22760444e7ae08b6397fd378"
     },
+    "ft-create-concise-pr": {
+      "source": "cameronapak/jstack",
+      "sourceType": "github",
+      "skillPath": "skills/ft-create-concise-pr/SKILL.md",
+      "computedHash": "122e980e1374016860ad585caf3215662460f87d2f3320dd4bdf179822677832"
+    },
     "grill-with-docs": {
       "source": "mattpocock/skills",
       "sourceType": "github",


### PR DESCRIPTION
## Summary

Every PR now follows one snapshot description template, so reviewers get the same skimmable shape from every contributor, human or agent. The `ft-create-concise-pr` skill is locked into the repo and mandated in the agent and contributor docs — the same pattern as the grill-with-docs mandate.

## Changes

- Reviewers get consistent PR descriptions: AGENTS.md gains a "Pull requests" section requiring `/ft-create-concise-pr` on every PR create or update
- Human contributors see the same expectation in CONTRIBUTING.md's pre-PR checklist
- The skill is pinned and reproducible (locked from cameronapak/jstack via skills-lock.json, with the `.claude/skills` symlink for Claude Code)

## Test plan

Verified the skill loads by running `/ft-create-concise-pr` to produce this description. Docs-only otherwise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added standardized guidance for creating and updating concise pull request descriptions.
  * Introduced a reusable pull request documentation skill with a consistent snapshot template.
* **Documentation**
  * Updated contributor guidance and repository instructions to include the new pull request format and workflow.
  * Registered the new skill for repository tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->