### PR TITLE
fix(auth): reload at auth boundaries so a signed-out account can't leak into the next

### DIFF
--- a/.changeset/tame-planes-shout.md
+++ b/.changeset/tame-planes-shout.md
@@ -1,0 +1,5 @@
+---
+"dotflowy": patch
+---
+
+Signing out — or signing in on a tab someone else used — now fully reloads the app, so a previous account's outline can no longer appear in, or be written into, a newly signed-in account.

--- a/README.md
+++ b/README.md
@@ -185,11 +185,11 @@ src/
     index.tsx         # the outline at the top level (Home)
     $nodeId.tsx       # the same outline zoomed into one bullet
   lib/
-    auth-client.ts    # Better Auth browser client (useSession / signIn / signUp / signOut)
+    auth-client.ts    # Better Auth browser client (useSession / signIn / signUp / signOut / signOutAndReload)
     utils.ts          # cn() and small helpers
   components/
     auth-screen.tsx     # login / signup screen (shown by the root AuthGate when signed out)
-    sign-out-button.tsx # header sign-out control
+    # sign out lives in the header More menu (header-more-menu.tsx) and the Cmd+K command center (command-actions.tsx)
     OutlineEditor.tsx   # reads tree, focus + command dispatch, the zoom view
     OutlineNode.tsx     # one bullet + its subtree (memoized, per-node store subscription)
     inline-code.ts      # contentEditable decorate / caret engine (source-offset aware)

--- a/e2e/sign-out.spec.ts
+++ b/e2e/sign-out.spec.ts
@@ -1,0 +1,87 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { seedOutline, type SeedNode } from "./fixtures";
+
+// Sign-out must tear the page down with a FULL document navigation — the data
+// layer is module singletons and the /api/sync socket authenticates only at
+// upgrade, so an SPA-internal gate swap would leak the signed-out account's
+// outline into the next sign-in (see signOutAndReload in src/lib/auth-client).
+// These specs pin that contract: a marker stamped on `window` survives any
+// SPA-internal swap but not a real navigation.
+
+const TREE: SeedNode[] = [
+  { id: "alpha", parentId: null, prevSiblingId: null, text: "alphabravo" },
+];
+
+const text = (page: Page, id: string) =>
+  page.locator(`li[data-node-id="${id}"] > .outline-row .node-text`);
+
+async function load(page: Page) {
+  await seedOutline(page, TREE);
+  await page.goto("/");
+  await expect(text(page, "alpha")).toBeVisible();
+  await page.evaluate(() => {
+    (window as unknown as { __preNavMarker?: boolean }).__preNavMarker = true;
+  });
+}
+
+async function clickSignOut(page: Page) {
+  await page.getByRole("button", { name: /more/i }).click();
+  await page.getByRole("menuitem", { name: /sign out/i }).click();
+}
+
+const hasMarker = (page: Page) =>
+  page
+    .evaluate(
+      () =>
+        (window as unknown as { __preNavMarker?: boolean }).__preNavMarker ===
+        true,
+    )
+    // Mid-navigation the execution context is destroyed — that's the very
+    // reload under test, not a failure; report "unknown" and let poll retry.
+    .catch(() => null);
+
+test.describe("Sign out (header More menu)", () => {
+  test("a successful sign-out hard-navigates to / (new document, marker gone)", async ({
+    page,
+  }) => {
+    await page.route(
+      (url) => url.pathname === "/api/auth/sign-out",
+      (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ success: true }),
+        }),
+    );
+    await load(page);
+
+    await clickSignOut(page);
+
+    // The reload lands back on "/" and the fresh document has no marker — an
+    // SPA-only gate swap would have kept it.
+    await expect.poll(() => hasMarker(page)).toBe(false);
+    await expect(page).toHaveURL("/");
+    // The mocked get-session still answers, so the outline remounts fresh.
+    await expect(text(page, "alpha")).toBeVisible();
+  });
+
+  test("a failed sign-out stays put and says so (no silent no-op)", async ({
+    page,
+  }) => {
+    await page.route(
+      (url) => url.pathname === "/api/auth/sign-out",
+      (route) => route.fulfill({ status: 500, body: "nope" }),
+    );
+    await load(page);
+
+    await clickSignOut(page);
+
+    // No navigation: the session cookie is still valid and no teardown ran,
+    // so the editor stays (same document — marker intact) and the failure is
+    // surfaced instead of swallowed.
+    await expect(page.getByText(/sign out failed/i)).toBeVisible();
+    expect(await hasMarker(page)).toBe(true);
+    await expect(text(page, "alpha")).toBeVisible();
+  });
+});

--- a/src/components/auth-screen.tsx
+++ b/src/components/auth-screen.tsx
@@ -1,6 +1,6 @@
 import { useState, type FormEvent } from "react";
 
-import { signIn, signUp } from "../lib/auth-client";
+import { hardResetToRoot, signIn, signUp } from "../lib/auth-client";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
 
@@ -66,9 +66,16 @@ export function AuthScreen() {
         password,
         inviteCode: inviteCode.trim(),
       };
+      // disableSignal: every success branch below leaves via a top-level
+      // navigation, but Better Auth otherwise fires its session signal ~10ms
+      // after resolve — the /get-session refetch can flip the AuthGate and
+      // mount the whole editor (collections, /api/sync socket) against the
+      // previous occupant's still-live singletons before the navigation
+      // commits. Errors never fire the signal, so that path is unaffected.
+      const fetchOptions = { disableSignal: true };
       const res = isSignup
-        ? await signUp.email(signupBody)
-        : await signIn.email({ email, password });
+        ? await signUp.email({ ...signupBody, fetchOptions })
+        : await signIn.email({ email, password, fetchOptions });
       // A real credential/validation failure (>= 400) shows the error; on an
       // OAuth hop anything else (success, or the mcp plugin's after-hook 302
       // that fetch couldn't follow cross-origin) means the session was set —
@@ -79,13 +86,12 @@ export function AuthScreen() {
         resumeAuthorize();
         return;
       } else {
-        // Hard-navigate on success — the SPA-internal gate swap would leave the
-        // previous occupant's outline singletons and /api/sync socket alive (see
-        // signOutAndReload in ../lib/auth-client). This covers what sign-out
-        // reload can't: a session that EXPIRES flips the gate here with no
-        // reload, and signing in as a different user would leak the prior
-        // account's data. Keeps `busy` true — the page is navigating away.
-        window.location.replace("/");
+        // Hard-navigate on success (hardResetToRoot's doc has the full why).
+        // This covers what the sign-out reload can't: a session that EXPIRES
+        // flips the gate here with no reload, and signing in as a different
+        // user would leak the prior account's data. Keeps `busy` true — the
+        // page is navigating away.
+        hardResetToRoot();
         return;
       }
     } catch {

--- a/src/components/auth-screen.tsx
+++ b/src/components/auth-screen.tsx
@@ -78,8 +78,16 @@ export function AuthScreen() {
       } else if (oauthQuery) {
         resumeAuthorize();
         return;
+      } else {
+        // Hard-navigate on success — the SPA-internal gate swap would leave the
+        // previous occupant's outline singletons and /api/sync socket alive (see
+        // signOutAndReload in ../lib/auth-client). This covers what sign-out
+        // reload can't: a session that EXPIRES flips the gate here with no
+        // reload, and signing in as a different user would leak the prior
+        // account's data. Keeps `busy` true — the page is navigating away.
+        window.location.replace("/");
+        return;
       }
-      // On success the session store updates and the gate swaps in the editor.
     } catch {
       if (oauthQuery) {
         // The after-hook redirect can throw inside fetch (mixed content /

--- a/src/components/auth-screen.tsx
+++ b/src/components/auth-screen.tsx
@@ -1,6 +1,6 @@
 import { useState, type FormEvent } from "react";
 
-import { hardResetToRoot, signIn, signUp } from "../lib/auth-client";
+import { hardReset, signIn, signUp } from "../lib/auth-client";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
 
@@ -86,12 +86,16 @@ export function AuthScreen() {
         resumeAuthorize();
         return;
       } else {
-        // Hard-navigate on success (hardResetToRoot's doc has the full why).
-        // This covers what the sign-out reload can't: a session that EXPIRES
-        // flips the gate here with no reload, and signing in as a different
-        // user would leak the prior account's data. Keeps `busy` true — the
-        // page is navigating away.
-        hardResetToRoot();
+        // Hard-navigate on success (hardReset's doc has the full why). This
+        // covers what the sign-out reload can't: a session that EXPIRES flips
+        // the gate here with no reload, and signing in as a different user
+        // would leak the prior account's data. Sign-IN keeps the current URL
+        // (a shared /$nodeId deep link, or your own spot after expiry — a
+        // foreign id degrades to the missing-node view); sign-UP resets to "/"
+        // (a brand-new outline has no nodes, the welcome seed beats a
+        // guaranteed-missing node). Keeps `busy` true — the page is navigating
+        // away.
+        hardReset(isSignup ? "/" : window.location.href);
         return;
       }
     } catch {

--- a/src/components/command-actions.tsx
+++ b/src/components/command-actions.tsx
@@ -26,7 +26,7 @@ import { openFeedbackReport } from "../data/feedback";
 import { capture } from "../data/history";
 import { toggleBookmark } from "../data/mutations";
 import { useTree } from "../data/useTree";
-import { signOut } from "../lib/auth-client";
+import { signOutAndReload } from "../lib/auth-client";
 import { openChangelog } from "./changelog-opener";
 import {
   copyOutlineAsMarkdown,
@@ -247,7 +247,7 @@ export function useGlobalActions(opts: {
         scope: "global",
         keywords: ["sign out", "logout", "log out", "exit"],
         run: () => {
-          void signOut();
+          signOutAndReload();
         },
       },
     );

--- a/src/components/header-more-menu.tsx
+++ b/src/components/header-more-menu.tsx
@@ -32,7 +32,7 @@ import { runStructural } from "../data/structural";
 import { childrenOf } from "../data/tree";
 import { getTreeIndex } from "../data/tree-store";
 import { getViewRootId } from "../data/view-state";
-import { signOut } from "../lib/auth-client";
+import { signOutAndReload } from "../lib/auth-client";
 import { openChangelog } from "./changelog-opener";
 import { McpConnectDialog } from "./mcp-connect-dialog";
 import { openOpmlImport } from "./opml-import-opener";
@@ -345,7 +345,10 @@ export function HeaderMoreMenu() {
 
           <DropdownMenuSeparator />
 
-          <DropdownMenuItem variant="destructive" onClick={() => signOut()}>
+          <DropdownMenuItem
+            variant="destructive"
+            onClick={() => signOutAndReload()}
+          >
             <LogOutIcon />
             Sign out
           </DropdownMenuItem>

--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -8,3 +8,20 @@ import { createAuthClient } from "better-auth/react";
 const authClient = createAuthClient();
 
 export const { signIn, signUp, signOut, useSession } = authClient;
+
+/**
+ * Sign out, then hard-navigate to "/". The data layer (nodesCollection, the kv
+ * side-collections, tree store, undo history) is a set of module singletons and
+ * the /api/sync WebSocket authenticates only at upgrade, so an SPA-internal auth
+ * swap keeps the previous account's outline in memory and its socket open —
+ * signing back in leaks that outline into the new account (cross-account
+ * contamination). A full navigation is the only honest teardown: it destroys
+ * every singleton and the socket. `replace` (not `assign`) keeps the dead auth
+ * state out of history; "/" (not reload) drops the previous account's /$nodeId
+ * URL. Better Auth's documented onSuccess pattern.
+ */
+export function signOutAndReload() {
+  void signOut({
+    fetchOptions: { onSuccess: () => window.location.replace("/") },
+  });
+}

--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -1,16 +1,20 @@
 import { createAuthClient } from "better-auth/react";
+import { toast } from "sonner";
 
 /**
  * Better Auth browser client. Same-origin: baseURL defaults to the current
  * origin and the default basePath (/api/auth) matches the Worker's route. The
  * app is a pure SPA, so this is only ever used in the browser.
+ *
+ * The bare `signOut` is deliberately NOT exported: a sign-out that skips the
+ * hard navigation reintroduces the cross-account leak. Use signOutAndReload.
  */
 const authClient = createAuthClient();
 
-export const { signIn, signUp, signOut, useSession } = authClient;
+export const { signIn, signUp, useSession } = authClient;
 
 /**
- * Sign out, then hard-navigate to "/". The data layer (nodesCollection, the kv
+ * Hard-navigate to "/". The data layer (nodesCollection, the kv
  * side-collections, tree store, undo history) is a set of module singletons and
  * the /api/sync WebSocket authenticates only at upgrade, so an SPA-internal auth
  * swap keeps the previous account's outline in memory and its socket open —
@@ -18,10 +22,26 @@ export const { signIn, signUp, signOut, useSession } = authClient;
  * contamination). A full navigation is the only honest teardown: it destroys
  * every singleton and the socket. `replace` (not `assign`) keeps the dead auth
  * state out of history; "/" (not reload) drops the previous account's /$nodeId
- * URL. Better Auth's documented onSuccess pattern.
+ * URL. Every auth boundary (sign-out here, sign-in/sign-up in auth-screen.tsx,
+ * the account-switch guard in __root.tsx's AuthGate) funnels through this.
+ */
+export function hardResetToRoot() {
+  window.location.replace("/");
+}
+
+/**
+ * Sign out, then hard-reset (Better Auth's documented onSuccess pattern). On
+ * failure (offline, 5xx) the session cookie is still valid and no teardown ran,
+ * so staying put is correct — but say so, or the user walks away from a shared
+ * machine believing they signed out.
  */
 export function signOutAndReload() {
-  void signOut({
-    fetchOptions: { onSuccess: () => window.location.replace("/") },
+  void authClient.signOut({
+    fetchOptions: {
+      onSuccess: hardResetToRoot,
+      onError: () => {
+        toast.error("Sign out failed. Check your connection and try again.");
+      },
+    },
   });
 }

--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -14,19 +14,21 @@ const authClient = createAuthClient();
 export const { signIn, signUp, useSession } = authClient;
 
 /**
- * Hard-navigate to "/". The data layer (nodesCollection, the kv
- * side-collections, tree store, undo history) is a set of module singletons and
- * the /api/sync WebSocket authenticates only at upgrade, so an SPA-internal auth
- * swap keeps the previous account's outline in memory and its socket open —
- * signing back in leaks that outline into the new account (cross-account
- * contamination). A full navigation is the only honest teardown: it destroys
- * every singleton and the socket. `replace` (not `assign`) keeps the dead auth
- * state out of history; "/" (not reload) drops the previous account's /$nodeId
- * URL. Every auth boundary (sign-out here, sign-in/sign-up in auth-screen.tsx,
- * the account-switch guard in __root.tsx's AuthGate) funnels through this.
+ * Hard-navigate. The data layer (nodesCollection, the kv side-collections,
+ * tree store, undo history) is a set of module singletons and the /api/sync
+ * WebSocket authenticates only at upgrade, so an SPA-internal auth swap keeps
+ * the previous account's outline in memory and its socket open — signing back
+ * in leaks that outline into the new account (cross-account contamination). A
+ * full navigation is the only honest teardown: it destroys every singleton and
+ * the socket. `replace` (not `assign`) keeps the dead auth state out of
+ * history. The default "/" target drops the previous account's /$nodeId URL —
+ * right whenever the NEXT occupant is a different account (sign-out, the
+ * account-switch guard in __root.tsx's AuthGate, sign-up); sign-in passes the
+ * current URL instead so deep links and expiry re-auth keep their place. Every
+ * auth boundary funnels through this.
  */
-export function hardResetToRoot() {
-  window.location.replace("/");
+export function hardReset(target: string = "/") {
+  window.location.replace(target);
 }
 
 /**
@@ -38,7 +40,7 @@ export function hardResetToRoot() {
 export function signOutAndReload() {
   void authClient.signOut({
     fetchOptions: {
-      onSuccess: hardResetToRoot,
+      onSuccess: () => hardReset(),
       onError: () => {
         toast.error("Sign out failed. Check your connection and try again.");
       },

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -21,7 +21,7 @@ import { TextSizeProvider } from "../components/text-size-provider";
 import { ThemeProvider } from "../components/theme-provider";
 import { Toaster } from "../components/ui/sonner";
 import { UpdateAvailableToast } from "../components/update-available";
-import { useSession } from "../lib/auth-client";
+import { hardResetToRoot, useSession } from "../lib/auth-client";
 import { FAVICON_DARK, FAVICON_LIGHT } from "../lib/favicon";
 import {
   LEGACY_THEME_KEY,
@@ -116,10 +116,30 @@ function RootComponent() {
  * data API it hits) require a session. While the session is still loading we
  * render nothing to avoid flashing the login screen at an authed user.
  */
+/**
+ * The user id this page's data-layer singletons first loaded under. A module
+ * value (not a ref): it must survive the gate unmounting/remounting and be
+ * remembered across an expiry (id → null → different id), where a previous-
+ * render comparison would misread the new id as a fresh sign-in.
+ */
+let firstUserId: string | null = null;
+
 function AuthGate({ children }: Readonly<{ children: ReactNode }>) {
   const { data: session, isPending } = useSession();
   if (isPending) return null;
   if (!session) return <AuthScreen />;
+  // Identity guard: the per-call-site reloads (signOutAndReload, AuthScreen)
+  // only fire in the tab where the auth action happened. If the account is
+  // switched in ANOTHER tab, this tab's session store revalidates to the new
+  // user while its singletons and /api/sync socket still belong to the old one
+  // — truthiness alone would keep the gate open and route writes to the wrong
+  // account. A different id here always means stale in-memory state: reload.
+  if (firstUserId === null) {
+    firstUserId = session.user.id;
+  } else if (session.user.id !== firstUserId) {
+    hardResetToRoot();
+    return null;
+  }
   return <>{children}</>;
 }
 

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -21,7 +21,7 @@ import { TextSizeProvider } from "../components/text-size-provider";
 import { ThemeProvider } from "../components/theme-provider";
 import { Toaster } from "../components/ui/sonner";
 import { UpdateAvailableToast } from "../components/update-available";
-import { hardResetToRoot, useSession } from "../lib/auth-client";
+import { hardReset, useSession } from "../lib/auth-client";
 import { FAVICON_DARK, FAVICON_LIGHT } from "../lib/favicon";
 import {
   LEGACY_THEME_KEY,
@@ -137,7 +137,7 @@ function AuthGate({ children }: Readonly<{ children: ReactNode }>) {
   if (firstUserId === null) {
     firstUserId = session.user.id;
   } else if (session.user.id !== firstUserId) {
-    hardResetToRoot();
+    hardReset();
     return null;
   }
   return <>{children}</>;


### PR DESCRIPTION
## Summary

Signing out then signing in (or signing up) in the same tab leaked the previous account's entire outline into the new account, and cross-wrote old node ids into the new account's Durable Object. A full page load at every auth boundary is the honest teardown for a singleton-based SPA. Fixes the cross-account contamination confirmed in a Jam network log.

## Changes

1. A signed-out or newly signed-in account no longer inherits the previous occupant's outline — every auth boundary is a full page load.
2. New `signOutAndReload()` + shared `hardReset(target = "/")` in `auth-client.ts`; the bare `signOut` is no longer exported, so no future call site can skip the teardown.
3. Both sign-out call sites (header More menu, Cmd+K command center) route through the helper instead of bare `signOut()`.
4. `auth-screen.tsx` hard-resets on non-OAuth success (covers session expiry, which sign-out reload can't reach); sign-in keeps the current URL so deep links and expiry re-auth keep their place, sign-up resets to `/`; OAuth `resumeAuthorize` branch untouched.
5. A failed sign-out (offline, 5xx) now surfaces an error toast instead of a silent no-op with the session still valid.
6. Switching accounts in another tab now hard-resets too: AuthGate reloads when the session's user id differs from the one the data layer first loaded under.
7. Sign-in/sign-up suppress Better Auth's post-resolve session signal (`disableSignal`), closing the pre-navigation window where a doomed editor could mount against stale singletons.

**Start here:** change 6 — the remembered id is a module value on purpose: an expiry sequence (id → null → different id) would read as a fresh sign-in to any previous-render comparison.

## Flow

Why a reload and not an in-tab swap: `nodesCollection`, the kv side-collections, tree store, and undo history are module singletons, and the `/api/sync` WebSocket authenticates only at upgrade. An SPA-internal auth swap leaves all of that alive, so the socket to the OLD user's DO stays open and the NEW account's empty snapshot never truncates it. Scope was held to the client: Worker/DO, `collection.ts`, and `realtime.ts` are untouched (server-side socket-expiry hardening is a separate follow-up).

## Test plan

- `bun run lint` — clean
- `bun run typecheck` — clean
- `bun run test` — 572 pass
- `bunx playwright test e2e/sign-out.spec.ts` — 2 pass (sign-out is a real document navigation; a failed sign-out stays put and toasts)
- `bunx playwright test e2e/collapse-expand-all.spec.ts e2e/enter-split.spec.ts` — 7 pass (smoke through the changed AuthGate)
- **Needs manual check:** on app.dotflowy.com sign in as user A, sign out, then sign up as new user B in the same tab — B must see the welcome seed, not A's outline. Also verify sign-out lands on the auth screen via a fresh page load (URL is `/`, not the prior `/$nodeId`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Signing out now fully reloads the app, preventing the previous account’s outline from appearing or being modified after another account signs in.
  * Successful sign-in now starts with a clean application state.
  * Sign-out behavior is consistent across available actions and menus.

* **Documentation**
  * Updated the project layout documentation to reflect the current sign-out implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
