### PR TITLE
fix(observability): scrub note text from error-report URLs

### DIFF
--- a/.changeset/sentry-scrub-url.md
+++ b/.changeset/sentry-scrub-url.md
@@ -1,0 +1,5 @@
+---
+"dotflowy": patch
+---
+
+Error reports now strip the query string from URLs and navigation breadcrumbs, so an active outline filter (`?q=`) or a pasted link can't ride an error report — closing a gap in the note-text scrub.

--- a/src/data/sentry-scrub.test.ts
+++ b/src/data/sentry-scrub.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "bun:test";
+
+import { scrubSentryEvent } from "./sentry-scrub";
+
+describe("scrubSentryEvent", () => {
+  it("strips the query string from request.url but keeps origin + path", () => {
+    const event = {
+      request: { url: "https://app.dotflowy.com/abc?q=my%20secret%20note" },
+    };
+    scrubSentryEvent(event);
+    expect(event.request.url).toBe("https://app.dotflowy.com/abc");
+  });
+
+  it("leaves a url with no query string untouched", () => {
+    const event = { request: { url: "https://app.dotflowy.com/abc" } };
+    scrubSentryEvent(event);
+    expect(event.request.url).toBe("https://app.dotflowy.com/abc");
+  });
+
+  it("drops the request body, cookies, and query_string fields", () => {
+    const event = {
+      request: {
+        data: { text: "node text" },
+        cookies: "session=abc",
+        query_string: "q=secret",
+      },
+    };
+    scrubSentryEvent(event);
+    expect(event.request.data).toBeUndefined();
+    expect(event.request.cookies).toBeUndefined();
+    expect(event.request.query_string).toBeUndefined();
+  });
+
+  it("deletes auth, cookie, and referer headers (both casings), keeps others", () => {
+    const event = {
+      request: {
+        headers: {
+          authorization: "Bearer x",
+          Cookie: "session=abc",
+          Referer: "https://app.dotflowy.com/n?q=secret",
+          "user-agent": "test",
+        },
+      },
+    };
+    scrubSentryEvent(event);
+    expect(event.request.headers.authorization).toBeUndefined();
+    expect(event.request.headers.Cookie).toBeUndefined();
+    expect(event.request.headers.Referer).toBeUndefined();
+    expect(event.request.headers["user-agent"]).toBe("test");
+  });
+
+  it("strips query strings from navigation breadcrumb url fields", () => {
+    const event = {
+      breadcrumbs: [
+        {
+          data: {
+            from: "/a?q=old%20note",
+            to: "/b?q=new%20note",
+            url: "https://x/api/unfurl?url=https://private.example",
+          },
+        },
+        undefined,
+        { data: { method: "GET" } },
+      ],
+    };
+    scrubSentryEvent(event);
+    expect(event.breadcrumbs[0]!.data.from).toBe("/a");
+    expect(event.breadcrumbs[0]!.data.to).toBe("/b");
+    expect(event.breadcrumbs[0]!.data.url).toBe("https://x/api/unfurl");
+    // Non-url breadcrumb data and holes are left alone.
+    expect(event.breadcrumbs[2]!.data.method).toBe("GET");
+  });
+
+  it("no-ops on an event with no request or breadcrumbs, returning the same ref", () => {
+    const event = { request: undefined, breadcrumbs: undefined };
+    expect(scrubSentryEvent(event)).toBe(event);
+  });
+});

--- a/src/data/sentry-scrub.ts
+++ b/src/data/sentry-scrub.ts
@@ -1,0 +1,75 @@
+/**
+ * The ONE place we strip user-authored text from an outbound Sentry event
+ * (#227). Shared by the client (`src/instrument.client.ts`, @sentry/react) and
+ * the Worker/DO (`worker/sentry.ts`, @sentry/cloudflare) so the two can't drift
+ * on the privacy guarantee the policy makes: "your note text never rides an
+ * error report".
+ *
+ * Pure and DOM-free (no `window`, no workers-types), structurally typed so both
+ * SDKs' `ErrorEvent` satisfy it — that's why it lives in `src/data` (the worker
+ * already imports from here, e.g. `redactSpoilers`) rather than in `worker/`.
+ *
+ * The leak this closes is NOT the obvious fields: both SDKs populate
+ * `event.request.url` with the FULL url (query string included), and the
+ * browser SDK adds navigation breadcrumbs with `?q=…` in them. Deleting only
+ * `query_string` (an earlier version's mistake) leaves the `?q=` outline filter
+ * and the `?url=` unfurl target — both user-authored — in `request.url`, the
+ * `Referer` header, and breadcrumb URLs. So we drop the query string wherever a
+ * url appears, keeping the path for debugging.
+ */
+
+interface ScrubbableEvent {
+  request?: {
+    url?: string;
+    data?: unknown;
+    cookies?: unknown;
+    query_string?: unknown;
+    headers?: Record<string, string>;
+  };
+  breadcrumbs?: Array<{ data?: Record<string, unknown> } | undefined>;
+}
+
+/** Drop everything after the first `?` (keep origin + path). */
+function stripQuery(url: string): string {
+  const q = url.indexOf("?");
+  return q === -1 ? url : url.slice(0, q);
+}
+
+export function scrubSentryEvent<E extends ScrubbableEvent>(event: E): E {
+  const request = event.request;
+  if (request) {
+    delete request.data;
+    delete request.cookies;
+    delete request.query_string;
+    if (typeof request.url === "string") {
+      request.url = stripQuery(request.url);
+    }
+    if (request.headers) {
+      for (const header of [
+        "authorization",
+        "Authorization",
+        "cookie",
+        "Cookie",
+        "referer",
+        "Referer",
+      ]) {
+        delete request.headers[header];
+      }
+    }
+  }
+
+  // Navigation/fetch breadcrumbs carry url-shaped fields (the browser SDK's
+  // history + fetch integrations), so a ?q= filter change rides `to`/`from`.
+  if (Array.isArray(event.breadcrumbs)) {
+    for (const crumb of event.breadcrumbs) {
+      const data = crumb?.data;
+      if (!data) continue;
+      for (const key of ["from", "to", "url"]) {
+        const value = data[key];
+        if (typeof value === "string") data[key] = stripQuery(value);
+      }
+    }
+  }
+
+  return event;
+}

--- a/src/instrument.client.ts
+++ b/src/instrument.client.ts
@@ -1,5 +1,7 @@
 import * as Sentry from "@sentry/react";
 
+import { scrubSentryEvent } from "./data/sentry-scrub";
+
 /**
  * Client-side error monitoring (ticket #227, decided in #156): Sentry,
  * errors-only. Omitting tracing/replay integrations keeps this to exception
@@ -20,27 +22,11 @@ if (import.meta.env.PROD && dsn && typeof window !== "undefined") {
   Sentry.init({
     dsn,
     sendDefaultPii: false,
-    beforeSend(event) {
-      // Outline node text must never ride an error payload (#227): drop the
-      // request body, query string (?q= filter / ?url= unfurl carry user
-      // text), cookies, and the auth header.
-      const request = event.request;
-      if (request) {
-        delete request.data;
-        delete request.cookies;
-        delete request.query_string;
-        if (request.headers) {
-          for (const header of [
-            "authorization",
-            "Authorization",
-            "cookie",
-            "Cookie",
-          ]) {
-            delete request.headers[header];
-          }
-        }
-      }
-      return event;
-    },
+    // Shared scrub (src/data/sentry-scrub.ts, same leaf the Worker uses):
+    // outline node text must never ride an error payload (#227). The leak isn't
+    // the obvious fields — the browser SDK puts the full href (incl. the ?q=
+    // filter) in request.url and navigation breadcrumbs, so the scrub strips
+    // the query string wherever a url appears.
+    beforeSend: (event) => scrubSentryEvent(event),
   });
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,8 +10,10 @@ import { changelogPlugin } from "./scripts/vite-plugin-changelog";
 
 // Upload client source maps to Sentry (#227), build-time only. Gated on the
 // build secret so a normal `bun run build` (no token — local, CI, a fork) stays
-// clean: no map emission, no upload. The plugin deletes the emitted maps after
-// upload, so they never reach the CDN.
+// clean: no map emission, no upload. `filesToDeleteAfterUpload` is REQUIRED for
+// the plugin to delete the maps post-upload — without it (we enable
+// build.sourcemap ourselves, so the plugin won't infer it) the .map files ship
+// to the public CDN and expose original source.
 const sentryAuthToken = process.env.SENTRY_AUTH_TOKEN;
 
 // SPA mode: no SSR. This sidesteps localStorage-on-server entirely,
@@ -64,6 +66,10 @@ export default defineConfig({
             org: "cameron-pak-sole-trader",
             project: "dotflowy",
             authToken: sentryAuthToken,
+            // Delete the emitted maps after upload so they never reach the CDN.
+            sourcemaps: {
+              filesToDeleteAfterUpload: ["./dist/client/**/*.map"],
+            },
           }),
         ]
       : []),

--- a/worker/sentry.ts
+++ b/worker/sentry.ts
@@ -1,6 +1,8 @@
 /// <reference types="@cloudflare/workers-types" />
 import type { CloudflareOptions } from "@sentry/cloudflare";
 
+import { scrubSentryEvent } from "../src/data/sentry-scrub";
+
 /**
  * Error monitoring for the Worker + Durable Object (ticket #227, decided in
  * #156): Sentry, errors-only, layered on the Workers Logs already enabled.
@@ -18,49 +20,18 @@ export interface SentryEnv {
   SENTRY_DSN?: string;
 }
 
-/** The user-authored fields we strip from every outbound event. */
-interface ScrubbableRequest {
-  data?: unknown;
-  cookies?: unknown;
-  query_string?: unknown;
-  headers?: Record<string, string>;
-}
-
-/**
- * Strip anything user-authored from an outbound event before it leaves the
- * isolate. Outline node text must NEVER ride an error payload (#227): we drop
- * the request body, the query string (the `?q=` filter and `?url=` unfurl carry
- * user text), cookies, and the auth header.
- */
-export function scrubRequest(request: ScrubbableRequest | undefined): void {
-  if (!request) return;
-  delete request.data;
-  delete request.cookies;
-  delete request.query_string;
-  if (request.headers) {
-    for (const header of [
-      "authorization",
-      "Authorization",
-      "cookie",
-      "Cookie",
-    ]) {
-      delete request.headers[header];
-    }
-  }
-}
-
 /**
  * Errors-only Sentry options for the Worker handler and the Durable Object.
  * Both `withSentry` and `instrumentDurableObjectWithSentry` take an
  * `(env) => options` callback, so the DSN is read from env at request time.
+ * `beforeSend` runs the shared scrub — the Worker and the client share ONE leaf
+ * (src/data/sentry-scrub.ts) so the "node text never rides an error report"
+ * guarantee can't drift between them.
  */
 export function workerSentryOptions(env: SentryEnv): CloudflareOptions {
   return {
     dsn: env.SENTRY_DSN,
     sendDefaultPii: false,
-    beforeSend(event) {
-      scrubRequest(event.request);
-      return event;
-    },
+    beforeSend: (event) => scrubSentryEvent(event),
   };
 }


### PR DESCRIPTION
## Summary

The `/code-review` pass on #238 found the Sentry `beforeSend` scrub deleted `request.query_string` but not `request.url` — and both SDKs put the full URL (query string included) in `event.request.url`, so an active `?q=` outline filter (which can hold note text) and a pasted `?url=` unfurl target still shipped to Sentry, breaking the "note text never rides an error report" promise in `docs/legal/privacy.md`. Follow-up to #238.

## Changes

1. Error reports now strip the query string from `request.url`, the `Referer` header, and navigation-breadcrumb URL fields, so `?q=` filter text and pasted links no longer leave the isolate (path kept for debugging).
2. The scrub is now one shared pure leaf (`src/data/sentry-scrub.ts`), used by both the client and the Worker/DO, so the security-critical logic can't drift between two copies.
3. Vite sets `sourcemaps.filesToDeleteAfterUpload`, so client source maps are deleted after upload instead of shipping to the public CDN (latent — fires once `SENTRY_AUTH_TOKEN` is set, #237).
4. Added a unit test locking the scrub's behavior (pure logic).

**Start here:** change 1 — verified against the installed `@sentry/browser` (`httpContextIntegration` sets `request.url` to the full href) and `@sentry/core` (`winterCGRequestToRequestData` sets `url: req.url`).

## Test plan

- `bun test src/data/sentry-scrub.test.ts` (6 pass) + full suite green; `typecheck`, `typecheck:worker`, `typecheck:test`, `lint`, `fmt` all green.
- `bun run build`: DSN still inlines, 0 `.map` files emitted on a tokenless build, scrub logic present in the client bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Privacy & Security**
  * Error reports now exclude URL query strings, request payloads, cookies, sensitive headers, and query parameters from navigation breadcrumbs.
  * Active filters and pasted-link details are no longer included in captured error data.

* **Bug Fixes**
  * Applied consistent sensitive-data removal across client and worker error reporting.

* **Chores**
  * Uploaded source maps are automatically removed after Sentry upload to prevent them from reaching the CDN.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->