### PR TITLE
Disable pinch-zoom on mobile

### DIFF
--- a/.changeset/mobile-zoom-disable.md
+++ b/.changeset/mobile-zoom-disable.md
@@ -1,0 +1,5 @@
+---
+"dotflowy": patch
+---
+
+Disable pinch-zoom on mobile.

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -84,7 +84,11 @@ export const Route = createRootRoute({
   head: () => ({
     meta: [
       { charSet: "utf-8" },
-      { name: "viewport", content: "width=device-width, initial-scale=1" },
+      {
+        name: "viewport",
+        content:
+          "width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no",
+      },
       { title: APP_TITLE },
       { name: "description", content: APP_DESCRIPTION },
       { name: "application-name", content: APP_TITLE },


### PR DESCRIPTION
## Summary

Mobile viewport now locks zoom so the installed PWA reads as a real app, not a pinch-and-zoom web toy.

## Changes

1. Mobile users can no longer pinch-zoom or trigger the input-focus lurch (`maximum-scale=1, user-scalable=no` on the viewport meta).

## Breaking / Migration

Note: iOS Safari overrides `user-scalable=no` in a normal browser tab — the lock only takes effect in add-to-home-screen / standalone PWA mode. Accessibility trade-off is intentional (WCAG 1.4.4).

## Test plan

- `bun run typecheck` — green
- **Needs manual check:** on an iPhone, add to home screen and launch from the icon — pinch is dead and tapping a bullet doesn't lurch the viewport. (Not reproducible in a headless browser or a plain Safari tab.)
