### PR TITLE
Header magnifier reads as engaged when the filter is open

### DIFF
--- a/.changeset/header-toggle-states.md
+++ b/.changeset/header-toggle-states.md
@@ -1,0 +1,5 @@
+---
+"dotflowy": patch
+---
+
+The header filter magnifier now shows a subtle "engaged" state the moment you open it (before you've typed a query), and turns solid only once a filter is actually applied. Its active look now tracks what's happening: muted while the search box is just open, solid when your view is genuinely filtered.

--- a/docs/adr/0050-header-toggle-button-states.md
+++ b/docs/adr/0050-header-toggle-button-states.md
@@ -1,0 +1,28 @@
+# Header toggle buttons: solid means the view is altered, muted means engaged
+
+The header's right cluster holds several icon toggles (spotlight, bookmark, the filter magnifier). They were drifting toward inconsistent "on" treatments, so we fixed the meaning rather than the pixels: **solid `--primary` = the view you're looking at is altered right now; muted `bg-muted` = a toggle is engaged but the view is still normal.** One rule decides every header toggle's active look.
+
+## The rule
+
+| Control                | "On" state               | View altered?          | Treatment                            |
+| ---------------------- | ------------------------ | ---------------------- | ------------------------------------ |
+| Spotlight (ADR 0033)   | mode on                  | yes — everything dims  | **solid** `variant="default"`        |
+| Filter magnifier       | a `?q=` query is applied | yes — nodes are hidden | **solid** `variant="default"`        |
+| Filter magnifier       | input open, no query yet | no                     | **muted** `bg-muted text-foreground` |
+| Bookmark star          | current view pinned      | no — it just saves     | **muted** `bg-muted` + filled icon   |
+| ⌘ command center, More | — (opens a dialog/menu)  | no                     | ghost only (no pressed state)        |
+
+Read it as: **solid answers "why does my outline look different?"** (dimmed, or pruned) — a surprising, persistent state you can scroll away from and forget. **Muted answers "is this tool engaged?"** — low-stakes, and usually corroborated by adjacent chrome (the open input, a filled star).
+
+## Why not the two obvious one-rule alternatives
+
+- **Grey everything** (the first instinct when solid-on-open feels too loud): demotes "your view is filtered" to the same weak signal as "the box is open." A filtered outline with the input scrolled out of sight is exactly the state that needs to shout. Rejected.
+- **Solid everything, tied to open:** opening an empty search box would shout as loudly as an applied filter, and two solid-black pills could sit in the header at once. Overweights transient, low-stakes states. Rejected.
+
+The magnifier therefore carries **three** states (ghost → muted → solid), which is the whole point: the emphasis tracks the stakes.
+
+## Consequences
+
+- The magnifier's "open" state must be observable outside `QueryFilterBar` (whose `summoned` flag is local `useState`). `query-filter-nav.ts` gains a `useSyncExternalStore`-backed open-signal (the `spotlight-mode` / `show-completed` pattern); `FilterButton` subscribes. `aria-pressed` now reflects "the input is open" (open ∨ applied), not just "a query is applied".
+- **The magnifier has no filled-icon variant** the way the bookmark/pin do, so `bg-muted` alone carries its muted state — and `bg-muted` is the same color as the ghost `hover:bg-muted`. Accepted because the muted state is transient (you're about to type) and the open input below disambiguates; if it ever reads as invisible, add a subtle inset ring rather than reaching for solid.
+- No shadcn `Toggle` primitive: the house `Button` + `data-state`/`aria-pressed` pattern (BookmarkStar) already expresses this; a second primitive would be redundant. Spotlight and bookmark already conformed and were left untouched — this ADR mostly _names_ an existing rule and fills the one gap (the magnifier's missing open state).

--- a/e2e/filter-input.spec.ts
+++ b/e2e/filter-input.spec.ts
@@ -77,26 +77,42 @@ test.describe("resident filter input (ADR 0047 §6)", () => {
     await expect(input(page)).toHaveCount(0);
   });
 
-  test("the magnifier lights (aria-pressed) while a filter is active", async ({
+  test("the magnifier's three states track the stakes (ADR 0050)", async ({
     page,
   }) => {
     await load(page);
     const magnifier = page.getByRole("button", { name: "Filter this view" });
+    // Match the STANDALONE fill token, not the ghost variant's `hover:bg-muted`
+    // / `aria-expanded:bg-muted` utilities (a bare `/bg-muted/` would).
+    const muted = /(?:^|\s)bg-muted(?:\s|$)/;
+    const solid = /(?:^|\s)bg-primary(?:\s|$)/;
 
-    // Idle: not pressed.
+    // Idle: ghost, not pressed -- neither the muted nor the solid fill.
     await expect(magnifier).toHaveAttribute("aria-pressed", "false");
+    await expect(magnifier).not.toHaveClass(muted);
+    await expect(magnifier).not.toHaveClass(solid);
 
-    // Active query lights it -- so the toggle-off press that WIPES the query
-    // only fires while the button visibly reads as "on".
+    // Open but empty: pressed + MUTED ("a tool is engaged, view still normal").
+    // This is the state the button previously lacked -- opening it now reads.
     await magnifier.click();
+    await expect(input(page)).toBeVisible();
+    await expect(magnifier).toHaveAttribute("aria-pressed", "true");
+    await expect(magnifier).toHaveClass(muted);
+
+    // Query applied: still pressed, now SOLID ("your view is altered") -- so the
+    // toggle-off press that WIPES the query only fires while it reads as "on".
     await input(page).fill("#work");
     await expect(page).toHaveURL(/q=%23work/);
     await expect(magnifier).toHaveAttribute("aria-pressed", "true");
+    await expect(magnifier).toHaveClass(solid);
+    await expect(magnifier).not.toHaveClass(muted);
 
-    // Toggle-off clears the query and drops the lit state.
+    // Toggle-off clears the query, collapses the row, and drops the lit state.
     await magnifier.click();
     await expect(page).not.toHaveURL(/q=/);
     await expect(magnifier).toHaveAttribute("aria-pressed", "false");
+    await expect(magnifier).not.toHaveClass(muted);
+    await expect(magnifier).not.toHaveClass(solid);
   });
 
   test("the ⌘ button opens the command center", async ({ page }) => {

--- a/src/components/query-filter-nav.ts
+++ b/src/components/query-filter-nav.ts
@@ -89,3 +89,34 @@ export function toggleFilterInput() {
   if (isOpenProbe?.()) closer?.();
   else opener?.();
 }
+
+// --- Reactive open-signal (ADR 0050) ----------------------------------------
+// `QueryFilterBar` owns whether the input is showing (`summoned || active`) in
+// local state, but `FilterButton` lives in the header and must LIGHT while the
+// input is open -- even before a query is typed. The `isOpenProbe` above is a
+// non-reactive read; this is its subscribable twin, mirroring the
+// `spotlight-mode` / `show-completed` store pattern. `QueryFilterBar` publishes
+// `showInput` here; `FilterButton` subscribes via `useSyncExternalStore`.
+
+let filterOpen = false;
+const openListeners = new Set<() => void>();
+
+/** Publish the input's open state (called by `QueryFilterBar` on change). */
+export function setFilterOpen(next: boolean) {
+  if (next === filterOpen) return;
+  filterOpen = next;
+  for (const l of openListeners) l();
+}
+
+/** Subscribe to open-state changes (for `useSyncExternalStore`). */
+export function subscribeFilterOpen(cb: () => void) {
+  openListeners.add(cb);
+  return () => {
+    openListeners.delete(cb);
+  };
+}
+
+/** Snapshot of the input's open state (for `useSyncExternalStore`). */
+export function getFilterOpen() {
+  return filterOpen;
+}

--- a/src/components/query-filter.tsx
+++ b/src/components/query-filter.tsx
@@ -6,6 +6,7 @@ import {
   useLayoutEffect,
   useRef,
   useState,
+  useSyncExternalStore,
 } from "react";
 import { createPortal } from "react-dom";
 
@@ -30,7 +31,10 @@ import { filterOperatorInfos } from "../plugins/registry";
 import {
   addTermToFilter,
   bindQueryFilterNav,
+  getFilterOpen,
   setFilterInputController,
+  setFilterOpen,
+  subscribeFilterOpen,
   toggleFilterInput,
   writeQuery,
 } from "./query-filter-nav";
@@ -99,23 +103,30 @@ export function useQueryFilter() {
  *  pointerdown keeps the input focused across the press so blur doesn't
  *  collapse-then-reopen before the click can close.
  *
- *  Lit (solid `--primary`, ADR 0033's grayscale "on" idiom -- same as
- *  SpotlightIndicator) whenever a `?q=` filter is applied, so the magnifier
- *  reads as a pressed toggle. This is intentional: the toggle-off press that
- *  WIPES the query only fires while the button visibly signals "on". Reads the
- *  search param directly rather than `useQueryFilter()`, whose Escape/nav side
- *  effects would double-bind if this button ran them too. */
+ *  Three states (ADR 0050's header-toggle rule): ghost when idle, **muted**
+ *  (`bg-muted`, "a tool is engaged but the view is normal") while the input is
+ *  open with no query yet, and **solid** (`--primary`, "your view is altered")
+ *  once a `?q=` filter is actually applied. The pressed look tracks the stakes,
+ *  and the toggle-off press that WIPES the query only fires while the button
+ *  visibly signals "on". "Open" comes from the reactive open-signal in
+ *  `query-filter-nav` (the header lives outside `QueryFilterBar`); the applied
+ *  state is read from the search param directly rather than via
+ *  `useQueryFilter()`, whose Escape/nav side effects would double-bind here. */
 export function FilterButton() {
   const search = useSearch({ strict: false }) as { q?: string };
   const active = (search.q ?? "").trim().length > 0;
+  const open = useSyncExternalStore(subscribeFilterOpen, getFilterOpen);
   return (
     <Button
       variant={active ? "default" : "ghost"}
       size="icon-sm"
+      // Muted "engaged" state in the open-but-empty window; the `default`
+      // variant above takes over (solid) the moment a query bites (ADR 0050).
+      className={cn(open && !active && "bg-muted text-foreground")}
       onMouseDown={(e) => e.preventDefault()}
       onClick={() => toggleFilterInput()}
       aria-label="Filter this view"
-      aria-pressed={active}
+      aria-pressed={open}
     >
       <Search />
       <span className="sr-only">Filter this view</span>
@@ -441,6 +452,14 @@ export function QueryFilterBar() {
   const isSaved = useIsQuerySaved(draft);
 
   const showInput = summoned || active;
+
+  // Publish the input's open state to the header FilterButton so it can light
+  // (muted) while the box is open with no query yet (ADR 0050). Reset on unmount
+  // so a torn-down editor doesn't leave the magnifier stuck "on".
+  useEffect(() => {
+    setFilterOpen(showInput);
+  }, [showInput]);
+  useEffect(() => () => setFilterOpen(false), []);
 
   // While NOT focused, mirror the input to `?q=` -- so an external write (a tag
   // chip click AND-ing `#tag`, a shared `?q=` URL) shows up in the resident

--- a/src/components/query-filter.tsx
+++ b/src/components/query-filter.tsx
@@ -115,7 +115,13 @@ export function useQueryFilter() {
 export function FilterButton() {
   const search = useSearch({ strict: false }) as { q?: string };
   const active = (search.q ?? "").trim().length > 0;
-  const open = useSyncExternalStore(subscribeFilterOpen, getFilterOpen);
+  // `() => false` server snapshot keeps the header prerender-safe (the repo
+  // prerenders `/`), matching every other store hook in the codebase.
+  const open = useSyncExternalStore(
+    subscribeFilterOpen,
+    getFilterOpen,
+    () => false,
+  );
   return (
     <Button
       variant={active ? "default" : "ghost"}

--- a/src/components/spotlight-indicator.tsx
+++ b/src/components/spotlight-indicator.tsx
@@ -23,7 +23,10 @@ import { Button } from "./ui/button";
  * is grayscale (`--primary` is chroma-0), so a 10%-opacity tint would read as an
  * ordinary ghost-button hover — invisible. A solid `--primary` pill (dark fill,
  * light glyph) is the grayscale system's "active" idiom (same emphasis the daily
- * "Today" badge uses) and is unmissable even at icon-only size. The chip is
+ * "Today" badge uses) and is unmissable even at icon-only size. Under the
+ * header-toggle rule (ADR 0050), solid is correct here for a second reason:
+ * spotlight ALTERS the view (everything dims), so it earns the loud treatment —
+ * where the filter magnifier's open-but-empty state stays muted. The chip is
  * icon-only on every breakpoint: the "Spotlight" label stays an SR-only span
  * (the `title` tooltip gives pointer users the text). A visible desktop label
  * distracted and crowded the breadcrumb + other header controls, and the solid


### PR DESCRIPTION
## Summary

The header filter magnifier now shows a muted "engaged" state the moment you open the filter (before typing a query) and turns solid only once a filter is actually applied, so opening the box finally reads as a toggle. Formalizes a header-toggle rule so future contributors stop reinventing the "on" look ([ADR 0050](docs/adr/0050-header-toggle-button-states.md)).

## Changes

1. Opening the filter now lights the magnifier muted; a bare click no longer looks inert.
2. The magnifier turns solid only when a `?q=` query is actually applied — muted = tool engaged, solid = your view is altered.
3. `aria-pressed` now reflects "the input is open" (open ∨ applied), not just "a query is applied".
4. The magnifier learns it's open via a reactive open-signal in `query-filter-nav` (the `useSyncExternalStore` house pattern) — it lives outside `QueryFilterBar`, which owns the `summoned` flag.
5. Recorded the cross-cutting rule as ADR 0050; cross-referenced the spotlight indicator, which already conformed (solid = view dimmed).

**Start here:** change 4 — the button is in the header, so the open state had to become observable outside `QueryFilterBar` rather than read from the route.

## Flow

```mermaid
flowchart LR
  QFB[QueryFilterBar: summoned/active] -->|setFilterOpen| S[open-signal store]
  S -->|useSyncExternalStore| FB[FilterButton]
  Route[?q= param] -->|useSearch| FB
  FB -->|ghost / muted / solid| UI[three states]
```

## Test plan

- `bun run typecheck`, `typecheck:test`, `lint` — clean
- `bun run test` — 640 unit tests pass
- `bun run build` — production build + `/` prerender succeed (the header stays prerender-safe)
- `filter-input.spec.ts` serial — 14/14 pass, incl. a new three-state guard (idle ghost → muted open-empty → solid applied, asserting `aria-pressed` + the standalone `bg-muted`/`bg-primary` fill tokens)
- Verified settled computed colors: idle transparent · open-empty `--muted` (0.97, light grey) · applied `--primary` (0.205, dark) — muted is the only filled button at rest, so it's distinguishable
- `/code-review` (high): one finding — `useSyncExternalStore` was missing the `getServerSnapshot` arg every sibling store passes; fixed in a follow-up commit
