### PR TITLE
Scrollable menus fade at their edges and stay on screen

### DIFF
--- a/.changeset/scroll-fade-menus.md
+++ b/.changeset/scroll-fade-menus.md
@@ -1,0 +1,5 @@
+---
+"dotflowy": patch
+---
+
+Scrollable menus, command palettes, and dialog lists now fade softly at their edges when there's more to scroll, so it's clearer when a list runs past what's visible. The breadcrumb trail and mobile action bar get the same left/right hint. The fade dissolves content into the menu's own surface, and the `/` command menu and the `#`/`[[` caret menus now always stay fully on screen instead of clipping off the right or bottom edge. It's pure CSS with no runtime cost, and falls back cleanly to plain scrolling in browsers that don't support scroll-driven animations.

--- a/src/components/MobileActionsBar.tsx
+++ b/src/components/MobileActionsBar.tsx
@@ -172,7 +172,7 @@ export function MobileActionsBar({
           // instead of clipping. Buttons are shrink-0, so they keep their 44px
           // targets and the strip scrolls rather than squashing; justify-start (the
           // flex default) keeps the leftmost button reachable when it does scroll.
-          "flex max-w-full items-center gap-1 overflow-x-auto rounded-full px-1.5 py-1",
+          "flex max-w-full scroll-fade-x items-center gap-1 overflow-x-auto rounded-full px-1.5 py-1",
           // Frosted-glass material: translucent, blurred, hairline edge + soft
           // shadow (depth from shadow, not a hard border) — the iOS accessory
           // pill's grammar, resolved through our own theme tokens so it adapts to

--- a/src/components/OutlineEditor.tsx
+++ b/src/components/OutlineEditor.tsx
@@ -2091,7 +2091,7 @@ function BreadcrumbTrail({
   return (
     <nav
       ref={navRef}
-      className="breadcrumb"
+      className="breadcrumb scroll-fade-x"
       aria-label="Breadcrumb"
       data-compact={isMobile ? "" : undefined}
     >

--- a/src/components/backlinks.tsx
+++ b/src/components/backlinks.tsx
@@ -104,7 +104,7 @@ function BacklinksDialog({
             Nodes whose text links here.
           </DialogDescription>
         </DialogHeader>
-        <ul className="max-h-[60vh] min-w-0 overflow-y-auto overscroll-contain px-2 pb-2">
+        <ul className="max-h-[60vh] min-w-0 scroll-fade overflow-y-auto overscroll-contain px-2 pb-2">
           {referrers.map((referrer) => (
             <li key={referrer.id}>
               <button

--- a/src/components/changelog-dialog.tsx
+++ b/src/components/changelog-dialog.tsx
@@ -141,7 +141,7 @@ export function ChangelogDialog() {
           </div>
         )}
 
-        <div className="flex max-h-[50vh] flex-col gap-5 overflow-y-auto pr-1">
+        <div className="flex max-h-[50vh] scroll-fade flex-col gap-5 overflow-y-auto pr-1">
           {releases.map((release) => (
             <ReleaseSection key={release.version} release={release} />
           ))}

--- a/src/components/mcp-connect-dialog.tsx
+++ b/src/components/mcp-connect-dialog.tsx
@@ -392,7 +392,7 @@ export function McpConnectDialog({
             ))}
           </TabsList>
 
-          <div className="min-w-0 flex-1 overflow-y-auto">
+          <div className="min-w-0 flex-1 scroll-fade overflow-y-auto">
             <AnimateHeight className="p-5">
               {CLIENTS.map((c) => (
                 <TabsContent

--- a/src/components/menu-engine.tsx
+++ b/src/components/menu-engine.tsx
@@ -13,6 +13,7 @@ import { menuSpecs } from "../plugins/registry";
 import { caretOffset, caretPosition, wrap } from "./caret-menu-utils";
 import { decorate, readSource, setCaretOffset } from "./inline-code";
 import { MenuList } from "./menu-list";
+import { useClampedMenuPosition } from "./use-menu-position";
 
 /**
  * The generic caret-menu engine (ADR 0001 Seam H). One per focused bullet --
@@ -77,6 +78,14 @@ export function useMenus({
   // "Open" only counts when there's something to show (or the spec opts into an
   // empty state), so a brand-new `#tag`'s Enter is never swallowed.
   const isOpen = open !== null && (entries.length > 0 || !!spec?.openWhenEmpty);
+
+  // Keep the menu on screen: clamp the caret coords to the viewport (shift left
+  // near the right edge, flip above near the bottom). Re-measures on entry count.
+  const menuPosition = useClampedMenuPosition(
+    open?.x ?? 0,
+    open?.y ?? 0,
+    entries.length,
+  );
 
   const close = () => setOpen(null);
 
@@ -174,8 +183,8 @@ export function useMenus({
             entries={entries}
             activeIndex={open.activeIndex}
             emptyLabel={spec?.emptyLabel}
-            x={open.x}
-            y={open.y}
+            ref={menuPosition.ref}
+            style={menuPosition.style}
             onHover={(i) => setOpen((s) => (s ? { ...s, activeIndex: i } : s))}
             onSelect={pick}
           />,

--- a/src/components/menu-list.tsx
+++ b/src/components/menu-list.tsx
@@ -1,3 +1,5 @@
+import type { CSSProperties, Ref } from "react";
+
 import { cn } from "@/lib/utils";
 
 import type { MenuEntry } from "../plugins/types";
@@ -6,51 +8,59 @@ export function MenuList({
   entries,
   activeIndex,
   emptyLabel,
-  x,
-  y,
   onHover,
   onSelect,
+  style,
+  ref,
 }: {
   entries: MenuEntry[];
   activeIndex: number;
   emptyLabel?: string;
-  x: number;
-  y: number;
   onHover: (index: number) => void;
   onSelect: (index: number) => void;
+  /** Position the listbox. The caller owns it (clamped-to-viewport fixed coords
+   *  via `useClampedMenuPosition`). */
+  style?: CSSProperties;
+  ref?: Ref<HTMLDivElement>;
 }) {
   return (
     <div
+      ref={ref}
       role="listbox"
-      className="fixed z-50 max-h-72 w-64 overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md"
-      style={{ left: x, top: y + 6 }}
+      className="z-50 w-64 overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md"
+      style={style}
     >
-      {entries.length === 0 ? (
-        <div className="px-2 py-1.5 text-sm text-muted-foreground">
-          {emptyLabel ?? "No results"}
-        </div>
-      ) : (
-        entries.map((entry, i) => (
-          <button
-            key={entry.key}
-            type="button"
-            role="option"
-            aria-selected={i === activeIndex}
-            className={cn(
-              "flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm",
-              i === activeIndex && "bg-accent text-accent-foreground",
-            )}
-            // mousedown (not click) so the contentEditable keeps focus.
-            onMouseDown={(e) => {
-              e.preventDefault();
-              onSelect(i);
-            }}
-            onMouseEnter={() => onHover(i)}
-          >
-            {entry.render(i === activeIndex)}
-          </button>
-        ))
-      )}
+      {/* Scroll + fade live on an inner div with NO background, so the mask
+          dissolves content into the card's bg-popover (matching the Cmd+K
+          list), not into the darker editor background behind the card. */}
+      <div className="max-h-72 scroll-fade overflow-y-auto p-1">
+        {entries.length === 0 ? (
+          <div className="px-2 py-1.5 text-sm text-muted-foreground">
+            {emptyLabel ?? "No results"}
+          </div>
+        ) : (
+          entries.map((entry, i) => (
+            <button
+              key={entry.key}
+              type="button"
+              role="option"
+              aria-selected={i === activeIndex}
+              className={cn(
+                "flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm",
+                i === activeIndex && "bg-accent text-accent-foreground",
+              )}
+              // mousedown (not click) so the contentEditable keeps focus.
+              onMouseDown={(e) => {
+                e.preventDefault();
+                onSelect(i);
+              }}
+              onMouseEnter={() => onHover(i)}
+            >
+              {entry.render(i === activeIndex)}
+            </button>
+          ))
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/mirror-places.tsx
+++ b/src/components/mirror-places.tsx
@@ -136,7 +136,7 @@ function MirrorPlacesInner({
             {title}
           </DialogDescription>
         </DialogHeader>
-        <ul className="max-h-[60vh] min-w-0 overflow-y-auto overscroll-contain px-2 pb-2">
+        <ul className="max-h-[60vh] min-w-0 scroll-fade overflow-y-auto overscroll-contain px-2 pb-2">
           {places.map((place) => (
             <PlaceRow
               key={place.node.id}

--- a/src/components/opml-import-dialog.tsx
+++ b/src/components/opml-import-dialog.tsx
@@ -418,7 +418,7 @@ function SummaryStage({
             lost, presentation may shift:
           </p>
           <ul
-            className="max-h-48 overflow-y-auto rounded-md border bg-muted/30 p-2 text-xs text-muted-foreground"
+            className="max-h-48 scroll-fade overflow-y-auto rounded-md border bg-muted/30 p-2 text-xs text-muted-foreground"
             data-testid="opml-disclosures"
           >
             {lines.map((line) => (

--- a/src/components/query-filter.tsx
+++ b/src/components/query-filter.tsx
@@ -376,32 +376,37 @@ function SuggestionPopover({
   return createPortal(
     <div
       data-filter-popover
-      className="fixed z-50 max-h-80 origin-top overflow-y-auto rounded-lg border bg-popover text-popover-foreground shadow-md"
+      className="fixed z-50 origin-top overflow-hidden rounded-lg border bg-popover text-popover-foreground shadow-md"
       style={{ left: rect.left, top: rect.bottom + 4, width: rect.width }}
       // A press anywhere in the popover must not blur the input (the rename input
       // stops its own mousedown so it can still take focus).
       onMouseDown={(e) => e.preventDefault()}
     >
-      {showSaved ? (
-        <SavedQueriesSection anchorRef={anchorRef} onPick={onPickSaved} />
-      ) : null}
-      <ul
-        id={LISTBOX_ID}
-        role="listbox"
-        aria-label="Filter suggestions"
-        data-filter-suggestions
-        className="p-1"
-      >
-        {suggestions.map((s, i) => (
-          <SuggestionRow
-            key={s.id}
-            suggestion={s}
-            id={optionId(i)}
-            active={i === activeIndex}
-            onPick={onPick}
-          />
-        ))}
-      </ul>
+      {/* Scroll + fade live on an inner div with NO background, so the mask
+          dissolves content into the card's bg-popover (matching the Cmd+K
+          list), not into the darker background behind the card. */}
+      <div className="max-h-80 scroll-fade overflow-y-auto">
+        {showSaved ? (
+          <SavedQueriesSection anchorRef={anchorRef} onPick={onPickSaved} />
+        ) : null}
+        <ul
+          id={LISTBOX_ID}
+          role="listbox"
+          aria-label="Filter suggestions"
+          data-filter-suggestions
+          className="p-1"
+        >
+          {suggestions.map((s, i) => (
+            <SuggestionRow
+              key={s.id}
+              suggestion={s}
+              id={optionId(i)}
+              active={i === activeIndex}
+              onPick={onPick}
+            />
+          ))}
+        </ul>
+      </div>
     </div>,
     document.body,
   );

--- a/src/components/quick-add.tsx
+++ b/src/components/quick-add.tsx
@@ -1063,7 +1063,7 @@ function QuickAddOverlay({ onClose }: { onClose: () => void }) {
           </div>
 
           {captures.length > 0 && (
-            <div className="min-h-0 flex-1 overflow-y-auto border-t px-1 py-1">
+            <div className="min-h-0 flex-1 scroll-fade overflow-y-auto border-t px-1 py-1">
               <div className="px-2 py-1.5 text-xs font-medium text-muted-foreground">
                 Captured this session
               </div>

--- a/src/components/slash-menu-list.tsx
+++ b/src/components/slash-menu-list.tsx
@@ -42,44 +42,49 @@ export function SlashMenuList({
     <div
       ref={ref}
       role="listbox"
-      className="fixed z-50 max-h-72 w-64 overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md"
+      className="fixed z-50 w-64 overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md"
       style={style}
     >
-      {items.length === 0 ? (
-        <div className="px-2 py-1.5 text-sm text-muted-foreground">
-          No commands
-        </div>
-      ) : (
-        items.map((item, i) => {
-          const Icon = item.icon;
-          return (
-            <button
-              key={item.id}
-              type="button"
-              role="option"
-              aria-selected={i === activeIndex}
-              className={cn(
-                "flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm",
-                i === activeIndex && "bg-accent text-accent-foreground",
-              )}
-              // mousedown (not click) so the contentEditable keeps focus.
-              onMouseDown={(e) => {
-                e.preventDefault();
-                onSelect(i);
-              }}
-              onMouseEnter={() => onHover(i)}
-            >
-              <Icon className="size-4 shrink-0 opacity-70" />
-              <span className="flex flex-col">
-                <span className="font-medium">{item.label}</span>
-                <span className="text-xs text-muted-foreground">
-                  {item.description}
+      {/* Scroll + fade live on an inner div with NO background, so the mask
+          dissolves content into the card's bg-popover (matching the Cmd+K
+          list), not into the darker editor background behind the card. */}
+      <div className="max-h-72 scroll-fade overflow-y-auto p-1">
+        {items.length === 0 ? (
+          <div className="px-2 py-1.5 text-sm text-muted-foreground">
+            No commands
+          </div>
+        ) : (
+          items.map((item, i) => {
+            const Icon = item.icon;
+            return (
+              <button
+                key={item.id}
+                type="button"
+                role="option"
+                aria-selected={i === activeIndex}
+                className={cn(
+                  "flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm",
+                  i === activeIndex && "bg-accent text-accent-foreground",
+                )}
+                // mousedown (not click) so the contentEditable keeps focus.
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  onSelect(i);
+                }}
+                onMouseEnter={() => onHover(i)}
+              >
+                <Icon className="size-4 shrink-0 opacity-70" />
+                <span className="flex flex-col">
+                  <span className="font-medium">{item.label}</span>
+                  <span className="text-xs text-muted-foreground">
+                    {item.description}
+                  </span>
                 </span>
-              </span>
-            </button>
-          );
-        })
-      )}
+              </button>
+            );
+          })
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/slash-menu.tsx
+++ b/src/components/slash-menu.tsx
@@ -9,6 +9,7 @@ import { commandSpecs } from "../plugins/registry";
 import { caretOffset, caretPosition, wrap } from "./caret-menu-utils";
 import { decorate, readSource, setCaretOffset } from "./inline-code";
 import { SlashMenuList } from "./slash-menu-list";
+import { useClampedMenuPosition } from "./use-menu-position";
 
 /** The composed command list driving the `/` palette: plugin commands (Seam C,
  *  array order), then the core's (`data/core-commands.ts`) -- so the contextual
@@ -70,6 +71,14 @@ export function useSlashMenu({
   const [state, setState] = useState<SlashState | null>(null);
 
   const items = state ? filterCommands(node, state.query, commandFilter) : [];
+
+  // Keep the menu on screen: clamp the caret coords to the viewport (shift left
+  // near the right edge, flip above near the bottom). Re-measures on item count.
+  const menuPosition = useClampedMenuPosition(
+    state?.x ?? 0,
+    state?.y ?? 0,
+    items.length,
+  );
 
   const close = () => setState(null);
 
@@ -151,7 +160,8 @@ export function useSlashMenu({
         <SlashMenuList
           items={items}
           activeIndex={state.activeIndex}
-          style={{ position: "fixed", left: state.x, top: state.y + 6 }}
+          ref={menuPosition.ref}
+          style={menuPosition.style}
           onHover={(i) => setState((s) => (s ? { ...s, activeIndex: i } : s))}
           onSelect={select}
         />,

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -95,7 +95,7 @@ function CommandList({
     <CommandPrimitive.List
       data-slot="command-list"
       className={cn(
-        "no-scrollbar max-h-72 scroll-py-1 overflow-x-hidden overflow-y-auto outline-none",
+        "no-scrollbar max-h-72 scroll-fade scroll-py-1 overflow-x-hidden overflow-y-auto outline-none",
         className,
       )}
       {...props}

--- a/src/components/use-menu-position.ts
+++ b/src/components/use-menu-position.ts
@@ -1,0 +1,68 @@
+import { useLayoutEffect, useRef, useState, type CSSProperties } from "react";
+
+/** Gap (px) between the caret and the menu, and the minimum breathing room kept
+ *  from every viewport edge. */
+const CARET_GAP = 6;
+const VIEWPORT_MARGIN = 8;
+
+/**
+ * Position a caret-anchored menu (the `/` palette, the `#`/`[[` caret menus) so
+ * it always stays fully on screen. The menus are `position: fixed` at the caret;
+ * near the right or bottom edge the raw caret coords would clip them off the
+ * viewport. This measures the rendered menu and clamps: it shifts left when it
+ * would overflow the right edge and flips ABOVE the caret when it would overflow
+ * the bottom (falling back to a bottom-clamp when there's no room either way).
+ *
+ * `revalidateKey` re-runs the measurement when the menu's height can change
+ * without the caret moving -- pass the item count, since filtering the list as
+ * you type grows/shrinks it.
+ *
+ * `useLayoutEffect` runs before paint, so the clamp lands with no visible jump.
+ */
+export function useClampedMenuPosition(
+  x: number,
+  y: number,
+  revalidateKey: number,
+): { ref: (el: HTMLDivElement | null) => void; style: CSSProperties } {
+  const elRef = useRef<HTMLDivElement | null>(null);
+  const [pos, setPos] = useState<{ left: number; top: number }>({
+    left: x,
+    top: y + CARET_GAP,
+  });
+
+  useLayoutEffect(() => {
+    const el = elRef.current;
+    if (!el) return;
+    const { width, height } = el.getBoundingClientRect();
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+
+    // Horizontal: prefer the caret x; shift left to fit, never past the margin.
+    let left = x;
+    if (left + width > vw - VIEWPORT_MARGIN)
+      left = vw - VIEWPORT_MARGIN - width;
+    if (left < VIEWPORT_MARGIN) left = VIEWPORT_MARGIN;
+
+    // Vertical: prefer just below the caret; flip above if the bottom overflows
+    // and there's room above, else clamp to the bottom margin.
+    let top = y + CARET_GAP;
+    if (top + height > vh - VIEWPORT_MARGIN) {
+      const above = y - CARET_GAP - height;
+      top =
+        above >= VIEWPORT_MARGIN
+          ? above
+          : Math.max(VIEWPORT_MARGIN, vh - VIEWPORT_MARGIN - height);
+    }
+
+    setPos((prev) =>
+      prev.left === left && prev.top === top ? prev : { left, top },
+    );
+  }, [x, y, revalidateKey]);
+
+  return {
+    ref: (el) => {
+      elRef.current = el;
+    },
+    style: { position: "fixed", left: pos.left, top: pos.top },
+  };
+}

--- a/src/plugins/route-bible/passage-edit-popover.tsx
+++ b/src/plugins/route-bible/passage-edit-popover.tsx
@@ -270,7 +270,7 @@ export function BiblePassageEditPopover({
         <div
           id={suggestionsId}
           role="listbox"
-          className="flex max-h-36 flex-col gap-0.5 overflow-auto rounded-md border border-border/70 bg-muted/30 p-1"
+          className="flex max-h-36 scroll-fade flex-col gap-0.5 overflow-auto rounded-md border border-border/70 bg-muted/30 p-1"
           data-bible-passage-suggestions
         >
           {suggestions.map((suggestion, index) => (

--- a/src/styles.css
+++ b/src/styles.css
@@ -243,6 +243,23 @@
   );
   mask-image: linear-gradient(to right, #000 calc(100% - 22px), transparent);
 }
+/* scroll-fade fallback suppression.
+   shadcn's `scroll-fade` utility (in shadcn/tailwind.css) is scroll-aware in
+   browsers with CSS scroll-driven animations. Where those are unsupported
+   (older Safari, Firefox by default) it falls back to a STATIC fade on both
+   edges — which would dim the top/bottom of a short, non-overflowing menu for
+   no reason. We treat the fade as pure progressive enhancement, so null the
+   mask entirely in the fallback path: unsupported browsers get exactly today's
+   plain-scroll behavior, no visual regression. */
+@supports not (animation-timeline: scroll()) {
+  .scroll-fade,
+  .scroll-fade-x,
+  .scroll-fade-y {
+    -webkit-mask-image: none;
+    mask-image: none;
+  }
+}
+
 .node-deco-track {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary

Scrollable menus, command palettes, and dialog lists now fade at their edges to signal more content, and the `/` and `#`/`[[` caret menus no longer clip off the side of the screen.

## Changes

1. Menus, command palettes, and scrollable dialog lists (Cmd+K, slash menu, caret menus, backlinks, mirror places, changelog, filter suggestions, OPML preview, MCP body, bible popover) fade at their top/bottom edge when there's more to scroll.
2. The breadcrumb trail and the mobile action bar get the matching left/right edge fade.
3. The `/` command menu and the `#`/`[[` caret menus stay fully on screen near a window edge — shifting left, or flipping above the caret — instead of clipping off the right or bottom.
4. The fade dissolves content into each menu's own surface, not the darker background behind it (a scroll-faded inner element over a solid card).
5. Browsers without CSS scroll-driven animations (older Safari, Firefox) fall back to plain scrolling via one global `@supports` guard, so nothing shows a permanent static fade.

**Start here:** change 3 — a new `useLayoutEffect` positioning hook (`use-menu-position.ts`) measures the rendered menu and clamps it; `MenuList` changed from `x`/`y` props to `ref`+`style`.

## Test plan

- `typecheck` (TypeScript 7), `lint`, `fmt` — all green.
- Drove the app (`cf:dev`): Cmd+K list fades at scrolled edges; confirmed the live `mask-image` + `animation-timeline: scroll(self y)` and `supportsScrollTimeline: true`.
- Slash menu near the right edge (566px viewport): was overflowing to ~802px → clamped to `left:302, right:558`, fully on screen.
- Slash menu in a 300px-tall viewport with a low caret: clamped to `top:8, bottom:298`, fully on screen.
- `[[` caret menu and the filter suggestion popover: measured solid card (unmasked) + transparent masked inner, and within-viewport.
- **Needs manual check:** the mobile action bar's left/right fade on a real coarse-pointer device — `scroll-fade-x` masks the frosted-glass capsule's own edges, which can't be verified from the desktop preview.
