### PR TITLE
Selecting a to-do's text no longer completes it

### DIFF
--- a/.changeset/tidy-checkbox-hitbox.md
+++ b/.changeset/tidy-checkbox-hitbox.md
@@ -1,0 +1,5 @@
+---
+"dotflowy": patch
+---
+
+Clicking or drag-selecting the first characters of a to-do's text no longer completes it by accident. The checkbox had an invisible hit area reaching 12px past itself on every side — far enough to sit on top of the text beside it — so a click meant to place a caret landed on the checkbox instead. Its target is now the checkbox itself, and on touch it stays a comfortable 24px wide without growing the box or crowding the text.

--- a/docs/adr/0029-reading-size-and-touch-targets.md
+++ b/docs/adr/0029-reading-size-and-touch-targets.md
@@ -76,9 +76,17 @@ that would fatten the glyph, drop the check's fill ratio from 87% to 58%, shift 
 (it floats), and pull in the K 4.25 → 8.25 change with its specificity trap. Inflating the ::before
 costs no layout and no pixels, and **K stays 4.25 on coarse** precisely because the box never moves.
 4px per side is the ceiling — it leaves 2px of daylight on both sides, so the boxes still cannot
-overlap and refight for taps. Applies to both render paths (the zoomed title's checkbox floats in the
-same `.row-body` with the same 6px gap). Guarded in `e2e/todos.spec.ts` (fine pointer: the text's
-first character hit-tests to the text) and `e2e/mobile-touch-rows.spec.ts` (coarse: the 24px target).
+overlap and refight for taps.
+
+The rule is **deliberately unscoped**, because a task checkbox renders in **three** surfaces, not two:
+the list row, the zoomed title, and quick-add's mini-editor (ADR 0049, which renders the same
+`title:before-text` slots). Each earns its 6px of clearance from a **different declaration** —
+`.row-body > :not(.node-text)`'s `margin-right` for the first two, `.quick-add-editor`'s
+`gap: 0.375rem` for the third — so **all three are load-bearing for the 4px arm**: drop any one below
+4px and that surface re-creates this bug locally. That coupling is the price of one unscoped rule; the
+alternative (three scoped rules) trades it for three places to forget. Guarded in `e2e/todos.spec.ts`
+(fine pointer: the text's first character hit-tests to the text) and `e2e/mobile-touch-rows.spec.ts`
+(coarse: the 24px target) — **both on the row only**; the title and quick-add ride the shared selector.
 
 **Why the chevron goes right on touch (increment 4), and how.** Two reasons it belongs on the right,
 both Workflowy-mobile-proven: (a) it frees the left gutter to a single, unambiguous thumb target —

--- a/docs/adr/0029-reading-size-and-touch-targets.md
+++ b/docs/adr/0029-reading-size-and-touch-targets.md
@@ -19,7 +19,9 @@ status: accepted
 
 3. **Touch targets (global).** On coarse pointers the bullet's tappable box grows (it was 16px wide;
    the `touch-hitbox` only ever expanded it _vertically_ to 44px) and rows gain vertical padding, so
-   zoom taps and caret taps stop missing on mobile.
+   zoom taps and caret taps stop missing on mobile. **The task checkbox reaches the same ~24px on
+   coarse (amended later),** but by widening its `touch-hitbox` `::before` 4px per side rather than
+   growing the box — see _Why the checkbox widens its hitbox instead of its box_ below.
 
 4. **Right-edge chevron + tap-to-edit (coarse pointer, added later).** A second increment, modelled on
    Workflowy mobile: on coarse pointers the collapse chevron moves from the left gutter to the row's
@@ -56,6 +58,27 @@ and the text caret (right), 6px away on each side; a 44px-_wide_ target overlaps
 them for taps (the existing CSS comment documents exactly this). Phase 1 grows the bullet to a
 pragmatic ~24px on coarse pointers — a large improvement over 16px with zero overlap risk — and
 leaves full-width tap routing (e.g. a coarse-pointer row-left hit region) to a later pass.
+
+**Why the checkbox widens its hitbox instead of its box (amended).** The original increment grew the
+bullet only; the task checkbox was left at 16px on coarse, and the omission went unnoticed because
+shadcn's vendored `ui/checkbox.tsx` shipped an undocumented `after:-inset-x-3 after:-inset-y-2` that
+silently inflated it to 40×32. That ::after was **the bug**: the checkbox has exactly 6px of
+clearance to the text on its right and 6px to the bullet on its left, so a 12px-per-side arm
+overshot by 6px and sat on the first characters of the text — a fine-pointer drag-select starting
+there toggled the task instead of placing a caret. It is deleted, and the primitive carries a
+comment so a re-sync can't restore it.
+
+The checkbox then reaches 24px the way the chevron does: the width opt-in the `touch-hitbox` comment
+already permits, `left/right: -4px` on its `::before`, coarse-only. It does **not** copy the bullet's
+`width: 24px`, because the two controls are not alike — the bullet's box is invisible (only a 9px dot
+draws inside it), so growing it is free, whereas the checkbox's box **is** the drawn control. Growing
+that would fatten the glyph, drop the check's fill ratio from 87% to 58%, shift the text 8px right
+(it floats), and pull in the K 4.25 → 8.25 change with its specificity trap. Inflating the ::before
+costs no layout and no pixels, and **K stays 4.25 on coarse** precisely because the box never moves.
+4px per side is the ceiling — it leaves 2px of daylight on both sides, so the boxes still cannot
+overlap and refight for taps. Applies to both render paths (the zoomed title's checkbox floats in the
+same `.row-body` with the same 6px gap). Guarded in `e2e/todos.spec.ts` (fine pointer: the text's
+first character hit-tests to the text) and `e2e/mobile-touch-rows.spec.ts` (coarse: the 24px target).
 
 **Why the chevron goes right on touch (increment 4), and how.** Two reasons it belongs on the right,
 both Workflowy-mobile-proven: (a) it frees the left gutter to a single, unambiguous thumb target —

--- a/e2e/mobile-touch-rows.spec.ts
+++ b/e2e/mobile-touch-rows.spec.ts
@@ -203,8 +203,10 @@ test.describe("coarse-pointer rows: right chevron + tap-to-edit", () => {
     // ...but the target is 16 + 4 + 4 = 24px.
     expect(m.left).toBeCloseTo(-4, 1);
     expect(m.right).toBeCloseTo(-4, 1);
-    // The 4px arm must stay inside the 6px gap to the text, or it re-creates the
-    // very overlap the vendored ::after caused. 2px of daylight is the margin.
-    expect(m.gapToText).toBeGreaterThanOrEqual(6);
+    // The arm must stay inside the gap to the text, or it re-creates the overlap
+    // the vendored ::after caused. Asserted against the measured arm rather than
+    // a hardcoded 6, so it states the actual invariant (and a subpixel gap can't
+    // flake it): whatever the arm is, the gap must clear it.
+    expect(m.gapToText).toBeGreaterThan(Math.abs(m.right));
   });
 });

--- a/e2e/mobile-touch-rows.spec.ts
+++ b/e2e/mobile-touch-rows.spec.ts
@@ -159,4 +159,52 @@ test.describe("coarse-pointer rows: right chevron + tap-to-edit", () => {
     });
     expect(inSpan).toBe(true);
   });
+
+  test("the task checkbox reaches a ~24px target without overlapping neighbours", async ({
+    page,
+  }) => {
+    // ADR 0029 (amended): the checkbox reaches the bullet's ~24px coarse target
+    // by widening its touch-hitbox ::before 4px per side, NOT by growing the box
+    // -- its box is the drawn control, unlike the bullet's invisible one. So the
+    // guard is two-sided: the TARGET grew, the BOX did not.
+    await seedOutline(page, [
+      ...STANDARD_TREE,
+      {
+        id: "task",
+        parentId: null,
+        prevSiblingId: "charlie",
+        text: "buy milk",
+        isTask: true,
+      },
+    ]);
+    await page.goto("/");
+    await expect(text(page, "task")).toBeVisible();
+
+    const m = await page.evaluate(() => {
+      const li = document.querySelector('li[data-node-id="task"]')!;
+      const box = li.querySelector(".checkbox")! as HTMLElement;
+      const before = getComputedStyle(box, "::before");
+      const r = box.getBoundingClientRect();
+      const span = li.querySelector(".node-text")! as HTMLElement;
+      const range = document.createRange();
+      range.setStart(span.firstChild!, 0);
+      range.setEnd(span.firstChild!, 1);
+      return {
+        boxWidth: r.width,
+        left: parseFloat(before.left),
+        right: parseFloat(before.right),
+        gapToText: range.getBoundingClientRect().left - r.right,
+      };
+    });
+
+    // The drawn control is untouched at 16px (growing it would drop the check's
+    // fill ratio and shove the floated text right).
+    expect(m.boxWidth).toBeCloseTo(16, 0);
+    // ...but the target is 16 + 4 + 4 = 24px.
+    expect(m.left).toBeCloseTo(-4, 1);
+    expect(m.right).toBeCloseTo(-4, 1);
+    // The 4px arm must stay inside the 6px gap to the text, or it re-creates the
+    // very overlap the vendored ::after caused. 2px of daylight is the margin.
+    expect(m.gapToText).toBeGreaterThanOrEqual(6);
+  });
 });

--- a/e2e/todos.spec.ts
+++ b/e2e/todos.spec.ts
@@ -128,8 +128,8 @@ test.describe("todos plugin", () => {
     // only has 6px of clearance to the text, so that arm overshoots by 6px and
     // hit-tests ABOVE the static text span (it's positioned, the span isn't) --
     // clicking the first character toggled the task instead of placing a caret.
-    // Asserts the countable invariant, not a wall clock: what does the browser
-    // say is under the text's first character?
+    // Asserted by asking the browser what it would actually hit, rather than by
+    // reading back the CSS we just wrote.
     await load(page);
     // The first character's own rect. NOT `.node-text`'s box: the checkbox
     // `float: left`s inside `.row-body`, so it's out of flow and the span's box

--- a/e2e/todos.spec.ts
+++ b/e2e/todos.spec.ts
@@ -119,4 +119,49 @@ test.describe("todos plugin", () => {
     await page.keyboard.press("Enter");
     await expect(checkbox(page, "b")).toHaveCount(0);
   });
+
+  test("the checkbox hitbox does not reach into the text (ADR 0029)", async ({
+    page,
+  }) => {
+    // Regression guard: shadcn's vendored ui/checkbox.tsx ships an invisible
+    // `after:-inset-x-3` that inflates the 16px box to 40px wide. The checkbox
+    // only has 6px of clearance to the text, so that arm overshoots by 6px and
+    // hit-tests ABOVE the static text span (it's positioned, the span isn't) --
+    // clicking the first character toggled the task instead of placing a caret.
+    // Asserts the countable invariant, not a wall clock: what does the browser
+    // say is under the text's first character?
+    await load(page);
+    // The first character's own rect. NOT `.node-text`'s box: the checkbox
+    // `float: left`s inside `.row-body`, so it's out of flow and the span's box
+    // starts UNDERNEATH it -- only the text visually flows around it. A click at
+    // the span's own x=0 legitimately hits the checkbox and proves nothing.
+    const hit = await page.evaluate(() => {
+      const li = document.querySelector('li[data-node-id="c"]')!;
+      const span = li.querySelector(".node-text")! as HTMLElement;
+      const range = document.createRange();
+      range.setStart(span.firstChild!, 0);
+      range.setEnd(span.firstChild!, 1);
+      const r = range.getBoundingClientRect();
+      const x = r.left + 1;
+      const y = r.top + r.height / 2;
+      const el = document.elementFromPoint(x, y);
+      return {
+        x,
+        y,
+        insideText: !!el?.closest(".node-text"),
+        onCheckbox: !!el?.closest(".checkbox"),
+      };
+    });
+    expect(hit.onCheckbox).toBe(false);
+    expect(hit.insideText).toBe(true);
+
+    // And the click that follows from it places a caret rather than completing.
+    await page.mouse.click(hit.x, hit.y);
+    await expect(text(page, "c")).not.toHaveAttribute("data-completed", "true");
+    const caretInText = await text(page, "c").evaluate((el) => {
+      const sel = window.getSelection();
+      return !!sel && sel.rangeCount > 0 && el.contains(sel.anchorNode);
+    });
+    expect(caretInText).toBe(true);
+  });
 });

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -3,12 +3,27 @@ import { CheckIcon } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 
+/*
+ * NOTE: shadcn ships this with `after:absolute after:-inset-x-3 after:-inset-y-2`
+ * -- an invisible ::after that inflates the 16px box to 40x32 for touch. It is
+ * deliberately REMOVED here, and a re-sync from upstream must not bring it back.
+ *
+ * In the outline, the checkbox is a gutter control with only 6px of clearance to
+ * the text on its right (`.row-body > :not(.node-text)`'s margin) and 6px to the
+ * bullet on its left (`.outline-row`'s gap). A 12px-per-side ::after overshoots
+ * both by 6px; the right arm lands on the first characters of the text and eats
+ * clicks meant to place a caret or start a selection, toggling the task instead.
+ *
+ * Touch sizing is `touch-hitbox`'s job instead (see styles.css): it expands the
+ * target vertically only, and widens by an explicit opt-in per control that has
+ * room -- which is what keeps neighbouring controls from refighting for taps.
+ */
 function Checkbox({ className, ...props }: CheckboxPrimitive.Root.Props) {
   return (
     <CheckboxPrimitive.Root
       data-slot="checkbox"
       className={cn(
-        "peer relative flex size-4 shrink-0 items-center justify-center rounded-[4px] border border-input transition-colors outline-none group-has-disabled/field:opacity-50 after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary",
+        "peer relative flex size-4 shrink-0 items-center justify-center rounded-[4px] border border-input transition-colors outline-none group-has-disabled/field:opacity-50 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary",
         className,
       )}
       {...props}

--- a/src/styles.css
+++ b/src/styles.css
@@ -682,6 +682,33 @@ h2 span.protected-lock {
   }
 
   /*
+   * Checkbox: the same ~24px coarse target as the bullet, but bought with the
+   * touch-hitbox width opt-in rather than by growing the box (ADR 0029). The
+   * bullet's box is invisible -- only the 9px dot shows -- so growing it 16->24
+   * is free. The checkbox's box IS the drawn control, so growing it would fatten
+   * the glyph, shrink the check's fill ratio, shove the text over (it floats),
+   * and drag in the K 4.25->8.25 specificity trap. Inflating the ::before
+   * instead costs no layout and no pixels, and K stays 4.25 because the box
+   * never moves.
+   *
+   * 4px per side is the ceiling: the checkbox has exactly 6px of clearance to
+   * the text (`.row-body > :not(.node-text)`'s margin-right) and 6px to the
+   * bullet (`.outline-row`'s gap), so this keeps 2px of daylight on both sides
+   * and the boxes still can't overlap. Coarse-only on purpose -- on a fine
+   * pointer this arm would sit under a drag-select starting at the text's first
+   * character, which is the bug that removed the vendored ::after (checkbox.tsx).
+   *
+   * Deliberately NOT scoped to `.outline-row`: a task renders in both paths, and
+   * the zoomed title's checkbox sits in the same `.row-body` float with the same
+   * 6px gap, so it wants the same target. Only the ::before moves, so the title's
+   * own `size-5` + `mt-2` are untouched.
+   */
+  .checkbox.touch-hitbox::before {
+    left: -4px;
+    right: -4px;
+  }
+
+  /*
    * Right-edge chevron (ADR 0029, Workflowy-mobile parity). CSS-only relocation:
    * the same absolutely-positioned .collapse-toggle flips from the left gutter
    * (left:-15px) to the row's right edge. Because <li> is width:100% with depth
@@ -770,9 +797,10 @@ h2 span.protected-lock {
 
 /* The list row is `align-items: flex-start`, so the checkbox needs a nudge onto
    the first text line. It rides the shared 16px-glyph rule above (bullet /
-   checkbox / provenance, K=6.75px) so it scales with the reading size; the
+   checkbox / provenance, K=4.25px) so it scales with the reading size; the
    zoomed title is flex-centered and keeps its own `h2.zoomed-title .checkbox`
-   rule. */
+   rule. Unlike the bullet, K does NOT change on coarse -- the checkbox's box
+   stays 16px there and only its touch-hitbox ::before widens. */
 
 /* The mirror badge is a 20px (`h-5`) bordered pill; K=5.25px aligns it to the
    text optical center while scaling with the reading size (ADR 0029). */

--- a/src/styles.css
+++ b/src/styles.css
@@ -691,17 +691,23 @@ h2 span.protected-lock {
    * instead costs no layout and no pixels, and K stays 4.25 because the box
    * never moves.
    *
-   * 4px per side is the ceiling: the checkbox has exactly 6px of clearance to
-   * the text (`.row-body > :not(.node-text)`'s margin-right) and 6px to the
-   * bullet (`.outline-row`'s gap), so this keeps 2px of daylight on both sides
-   * and the boxes still can't overlap. Coarse-only on purpose -- on a fine
-   * pointer this arm would sit under a drag-select starting at the text's first
-   * character, which is the bug that removed the vendored ::after (checkbox.tsx).
+   * 4px per side is the ceiling, and 6px is what it's measured against: the
+   * checkbox has 6px of clearance to the text and 6px to the bullet
+   * (`.outline-row`'s gap), so this keeps 2px of daylight on both sides and the
+   * boxes still can't overlap. Coarse-only on purpose -- on a fine pointer this
+   * arm would sit under a drag-select starting at the text's first character,
+   * which is the bug that removed the vendored ::after (checkbox.tsx).
    *
-   * Deliberately NOT scoped to `.outline-row`: a task renders in both paths, and
-   * the zoomed title's checkbox sits in the same `.row-body` float with the same
-   * 6px gap, so it wants the same target. Only the ::before moves, so the title's
-   * own `size-5` + `mt-2` are untouched.
+   * Deliberately NOT scoped to `.outline-row`: a task checkbox renders in THREE
+   * places, and all three want the target. Each reaches its 6px by a DIFFERENT
+   * declaration, so all three are load-bearing for the 4px arm -- shrink any one
+   * below 4px and that surface's checkbox starts eating the first character of
+   * its own text, which is this PR's bug in a new costume:
+   *   1. the list row      -- `.row-body > :not(.node-text)`'s `margin-right: 6px`
+   *   2. the zoomed title  -- the same `.row-body` float (its `me-1` loses to it)
+   *   3. quick-add (0049)  -- `.quick-add-editor`'s `gap: 0.375rem` (= 6px)
+   * Only the ::before moves, so each surface's own box size and nudge (the
+   * title's `size-5` + `mt-2`, quick-add's flex centring) are untouched.
    */
   .checkbox.touch-hitbox::before {
     left: -4px;
@@ -982,7 +988,11 @@ h2.zoomed-title .row-body > .title-pilcrow {
 /* Once BORN, the node's before-text slots (Seam F -- the todos checkbox) render
    inline ahead of the text, mirroring the list row / zoomed title. Lay the
    surface out as a flex row so the checkbox sits beside the text and the
-   contentEditable takes the remaining width (ADR 0049 inline-decoration flow). */
+   contentEditable takes the remaining width (ADR 0049 inline-decoration flow).
+   The 6px gap is load-bearing, not just rhythm: it's the clearance the coarse
+   checkbox tap target's 4px arm is sized against (ADR 0029 -- see the
+   `.checkbox.touch-hitbox::before` note). Below 4px the checkbox starts eating
+   clicks meant for the capture text. Keep it in step with the list row's 6px. */
 .quick-add-editor {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary

A to-do's checkbox carried an invisible hit area reaching 12px past itself on every side — twice its 6px clearance to the text — so clicking or drag-selecting the first characters completed the task instead of placing a caret. Removed it, and rebuilt the touch target out of the `touch-hitbox` utility that was already on the checkbox.

## Changes

1. Clicking or drag-selecting the start of a to-do's text places a caret instead of completing it. The culprit was `after:-inset-x-3 after:-inset-y-2` in the vendored shadcn checkbox: positioned, so it won the hit test over the static text span beside it.
2. Touch keeps a ~24px checkbox target, restored via `touch-hitbox`'s own width opt-in (`-4px` per side, coarse-only) instead of growing the box — no layout shift, no visual change, and `K` stays 4.25.
3. All three render paths are covered (row, zoomed title, quick-add's mini-editor), so the rule is deliberately unscoped — but each earns its 6px clearance from a *different* declaration, which makes all three load-bearing for the 4px arm. Documented at both ends.
4. ADR 0029 now records the checkbox rule; it previously documented the coarse growth as bullet-only, which is how the omission went unnoticed.
5. Two e2e guards lock the geometry — checkbox hitbox had no coverage at all before.
6. Corrected a stale `K=6.75px` comment (the rule it describes uses `4.25px`).

**Start here:** change 2 — why the checkbox widens its hitbox where the bullet grows its box.

## Test plan

- `typecheck`, `typecheck:worker`, `typecheck:test`, `lint`, `fmt:check` — clean
- `bun run test` — 659 pass
- `bunx playwright test e2e/todos.spec.ts e2e/mobile-touch-rows.spec.ts e2e/paragraph.spec.ts --workers=1` — 23/23
- Both new guards verified to bite: restoring the `::after` fails the fine-pointer guard, neutering the `-4px` fails the coarse one
- Drove a real task in `bun run cf:dev` — the `::after` computes to `none`, the gap to text measures 6px, and the first character hit-tests to `.node-text` (previously `.checkbox`) while the checkbox itself still toggles
- `/code-review high` — 6 findings, 3 applied (the third-render-path coupling, a hardcoded-gap assertion, a misapplied convention citation); 3 skipped as low-value or convention-matching
- **Needs manual check:** coarse-pointer behavior on a real iPhone. Resizing a desktop browser doesn't flip `pointer: coarse`, so only the Playwright mobile emulation exercises the 24px target — and it covers the row only; the title and quick-add ride the shared selector.
