### PR TITLE
Harden + test the Worker auth/identity gates (#232)

### DIFF
--- a/.changeset/harden-worker-auth-gates.md
+++ b/.changeset/harden-worker-auth-gates.md
@@ -1,0 +1,5 @@
+---
+"dotflowy": patch
+---
+
+Harden and unit-test the Worker's auth/identity gates: the DO tenant-isolation key (`resolveUserId`), admin allowlist, invite-code backdoor, and email shape check are now a pure, tested module; `BETTER_AUTH_SECRET` is asserted at startup (fail-closed, not silently insecure); admin access can now be pinned to a stable `user.id` (`ADMIN_USER_IDS`) instead of an unverified email; and the SSRF unfurl guard now blocks IPv4-mapped IPv6 loopback/private targets.

--- a/worker/auth.ts
+++ b/worker/auth.ts
@@ -26,6 +26,7 @@ import {
   isOwnerAccount,
 } from "./account-deletion";
 import { sendEmail } from "./email";
+import { matchesSharedInviteCode } from "./identity";
 import { isRedeemableInvite, normalizeEmail, redeemInvite } from "./invites";
 import { FOUNDING_SEAT_LIMIT, countFoundingSeats } from "./plan";
 
@@ -105,6 +106,17 @@ export function createAuth(
   requestOrigin?: string,
   executionCtx?: ExecutionContext,
 ) {
+  // Fail closed, explicitly (#232). The secret signs sessions + reset tokens;
+  // it's optional-typed only because the binding is absent in some tooling.
+  // "Better Auth fails closed without it" was an unverified claim — assert it
+  // here so a misconfigured deploy 500s loudly at construction instead of
+  // silently signing with a missing/empty secret. `bun run setup` writes it to
+  // .dev.vars; prod sets it via `wrangler secret put BETTER_AUTH_SECRET`.
+  if (!env.BETTER_AUTH_SECRET || env.BETTER_AUTH_SECRET.trim() === "") {
+    throw new Error(
+      "BETTER_AUTH_SECRET is required (unset or empty). Set it via `wrangler secret put BETTER_AUTH_SECRET` in prod, or run `bun run setup` locally.",
+    );
+  }
   return betterAuth({
     // Better Auth accepts a D1 binding directly (kysely under the hood).
     database: env.DB,
@@ -283,11 +295,7 @@ export function createAuth(
           return; // valid; the after-hook stamps it once the account exists
         }
         // (b) The shared INVITE_CODES backdoor.
-        const codes = (env.INVITE_CODES ?? "")
-          .split(",")
-          .map((c) => c.trim())
-          .filter(Boolean);
-        if (supplied && codes.includes(supplied)) return;
+        if (matchesSharedInviteCode(supplied, env.INVITE_CODES)) return;
         throw new APIError("FORBIDDEN", {
           message:
             "Dotflowy is invite-only during alpha. Ask for an invite code, or join the waitlist.",

--- a/worker/identity.test.ts
+++ b/worker/identity.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Unit tests for the Worker auth/identity gates (ticket #232). These are the
+ * security-critical decisions e2e can't reach (the mock intercepts /api/auth),
+ * so this is their only coverage. See worker/identity.ts.
+ */
+
+import { describe, expect, it } from "bun:test";
+
+import {
+  isAdminSession,
+  isPlausibleEmail,
+  matchesSharedInviteCode,
+  resolveUserId,
+} from "./identity";
+
+const session = (id: string, email: string) => ({ user: { id, email } });
+
+describe("resolveUserId (DO tenant-isolation key)", () => {
+  it("routes a normal user to their own user.id, never the email", () => {
+    expect(resolveUserId("user_abc", {})).toBe("user_abc");
+    expect(resolveUserId("user_abc", { OWNER_USER_ID: "user_owner" })).toBe(
+      "user_abc",
+    );
+  });
+
+  it("collapses ONLY the exact OWNER_USER_ID to the 'default' DO", () => {
+    expect(resolveUserId("user_owner", { OWNER_USER_ID: "user_owner" })).toBe(
+      "default",
+    );
+    // A near-miss must not bridge — no prefix/substring matching.
+    expect(resolveUserId("user_owner2", { OWNER_USER_ID: "user_owner" })).toBe(
+      "user_owner2",
+    );
+  });
+
+  it("does not bridge when OWNER_USER_ID is unset or empty", () => {
+    expect(resolveUserId("default", {})).toBe("default"); // a user literally named 'default' still maps to itself
+    expect(resolveUserId("user_x", { OWNER_USER_ID: "" })).toBe("user_x");
+  });
+});
+
+describe("isAdminSession", () => {
+  it("fails closed with no session", () => {
+    expect(isAdminSession(null, { ADMIN_USER_IDS: "user_a" })).toBe(false);
+    expect(isAdminSession(null, { ADMIN_EMAILS: "a@b.com" })).toBe(false);
+  });
+
+  it("fails closed when neither allowlist is set", () => {
+    expect(isAdminSession(session("user_a", "a@b.com"), {})).toBe(false);
+    expect(
+      isAdminSession(session("user_a", "a@b.com"), {
+        ADMIN_USER_IDS: "",
+        ADMIN_EMAILS: "",
+      }),
+    ).toBe(false);
+    expect(
+      isAdminSession(session("user_a", "a@b.com"), {
+        ADMIN_USER_IDS: "   ",
+      }),
+    ).toBe(false);
+  });
+
+  describe("pinned to user.id (ADMIN_USER_IDS set)", () => {
+    const env = { ADMIN_USER_IDS: "user_a, user_b" };
+
+    it("matches on the exact user.id", () => {
+      expect(isAdminSession(session("user_a", "a@b.com"), env)).toBe(true);
+      expect(isAdminSession(session("user_b", "anything@x.com"), env)).toBe(
+        true,
+      );
+    });
+
+    it("does not match a non-listed id", () => {
+      expect(isAdminSession(session("user_c", "a@b.com"), env)).toBe(false);
+    });
+
+    it("ignores ADMIN_EMAILS entirely — the email path is closed", () => {
+      // Even if the session's email is on the (still-set) email allowlist, a
+      // non-listed user.id is NOT admin. This is the register-first fix.
+      const both = {
+        ADMIN_USER_IDS: "user_a",
+        ADMIN_EMAILS: "attacker@b.com",
+      };
+      expect(isAdminSession(session("user_evil", "attacker@b.com"), both)).toBe(
+        false,
+      );
+      expect(isAdminSession(session("user_a", "attacker@b.com"), both)).toBe(
+        true,
+      );
+    });
+
+    it("is case-sensitive on the id (ids are not emails)", () => {
+      expect(isAdminSession(session("USER_A", "a@b.com"), env)).toBe(false);
+    });
+  });
+
+  describe("legacy email fallback (only ADMIN_EMAILS set)", () => {
+    const env = { ADMIN_EMAILS: "Admin@Dotflowy.com , other@x.com" };
+
+    it("matches case-insensitively, trimming whitespace", () => {
+      expect(isAdminSession(session("user_a", "admin@dotflowy.com"), env)).toBe(
+        true,
+      );
+      expect(isAdminSession(session("user_b", "ADMIN@DOTFLOWY.COM"), env)).toBe(
+        true,
+      );
+      expect(isAdminSession(session("user_c", "other@x.com"), env)).toBe(true);
+    });
+
+    it("does not match a non-listed email", () => {
+      expect(isAdminSession(session("user_a", "nope@x.com"), env)).toBe(false);
+    });
+  });
+});
+
+describe("isPlausibleEmail", () => {
+  it("accepts a normal address", () => {
+    expect(isPlausibleEmail("a@b.com")).toBe(true);
+    expect(isPlausibleEmail("first.last+tag@sub.example.co")).toBe(true);
+  });
+
+  it("rejects junk and over-long input", () => {
+    expect(isPlausibleEmail("")).toBe(false);
+    expect(isPlausibleEmail("no-at-sign")).toBe(false);
+    expect(isPlausibleEmail("a@b")).toBe(false); // no dot in domain
+    expect(isPlausibleEmail("a @b.com")).toBe(false); // whitespace
+    expect(isPlausibleEmail("a@b.com ")).toBe(false); // trailing space
+    expect(isPlausibleEmail(`${"a".repeat(250)}@b.com`)).toBe(false); // > 254
+  });
+});
+
+describe("matchesSharedInviteCode (the INVITE_CODES backdoor)", () => {
+  it("denies everything when INVITE_CODES is unset, empty, or whitespace", () => {
+    expect(matchesSharedInviteCode("anything", undefined)).toBe(false);
+    expect(matchesSharedInviteCode("anything", "")).toBe(false);
+    expect(matchesSharedInviteCode("anything", "   ")).toBe(false);
+    expect(matchesSharedInviteCode("anything", " , , ")).toBe(false);
+  });
+
+  it("denies an empty supplied code even when codes exist", () => {
+    expect(matchesSharedInviteCode("", "alpha,beta")).toBe(false);
+  });
+
+  it("matches an exact code, tolerating list whitespace", () => {
+    expect(matchesSharedInviteCode("alpha", "alpha, beta")).toBe(true);
+    expect(matchesSharedInviteCode("beta", " alpha , beta ")).toBe(true);
+  });
+
+  it("does not match an unknown code and is case-sensitive", () => {
+    expect(matchesSharedInviteCode("gamma", "alpha,beta")).toBe(false);
+    expect(matchesSharedInviteCode("ALPHA", "alpha,beta")).toBe(false);
+  });
+});

--- a/worker/identity.ts
+++ b/worker/identity.ts
@@ -1,0 +1,97 @@
+/**
+ * The Worker's auth/identity gates, as pure functions (map #151 / ticket #232).
+ *
+ * These decide tenant isolation (which DO a session touches), admin access, and
+ * the shape/validity of the invite + email inputs. They use NO Workers globals
+ * and NO bindings — only plain string env fields — so they import cleanly under
+ * `bun test` (worker/identity.test.ts). e2e can't reach them (the mock
+ * intercepts `/api/auth`), so unit tests are the only coverage this
+ * security-critical logic gets. Keep them pure; the request wiring stays in
+ * worker/index.ts / worker/auth.ts. See docs/adr/0011-the-auth-gate.md.
+ */
+
+/** The env slice these gates read — all plain config strings, no bindings. */
+export interface IdentityEnv {
+  /** The owner's Better Auth `user.id`; collapses that one account to the
+   *  constant 'default' DO. See resolveUserId. */
+  OWNER_USER_ID?: string;
+  /** Comma-separated Better Auth `user.id`s allowed on admin surfaces — the
+   *  PINNED admin identity (item 3, #232). When non-empty this is the sole
+   *  admin check and ADMIN_EMAILS is ignored. */
+  ADMIN_USER_IDS?: string;
+  /** Legacy comma-separated admin email allowlist. Honored ONLY as a fallback
+   *  when ADMIN_USER_IDS is empty, so a deploy that set only this keeps working.
+   *  Prefer ADMIN_USER_IDS: an email is unverified (verification is off for
+   *  beta), so the email path can be pre-registered; a `user.id` can't. */
+  ADMIN_EMAILS?: string;
+}
+
+/** The owner-continuity DO name: the constant 'default' DO holding the pre-auth
+ *  outline. Also the sentinel the Worker checks to run the one-time legacy
+ *  import. */
+export const OWNER_DO_ID = "default";
+
+/**
+ * The Durable Object name for a signed-in user's outline.
+ *
+ * LOCKED DECISION: a DO name is permanent and cannot be renamed, so it must
+ * NEVER be an email or any value that can change — keying by email would orphan
+ * a user's whole outline on an email/auth-provider change. Key by the stable
+ * `user.id`. The one exception is the owner-continuity bridge: OWNER_USER_ID's
+ * account maps to the constant 'default' DO (where the pre-auth outline lives),
+ * carrying existing data over with zero copy. Do NOT key this off the email.
+ */
+export function resolveUserId(sessionUserId: string, env: IdentityEnv): string {
+  if (env.OWNER_USER_ID && sessionUserId === env.OWNER_USER_ID)
+    return OWNER_DO_ID;
+  return sessionUserId;
+}
+
+/** Split a comma-separated env list into trimmed, non-empty entries. */
+function splitList(raw: string | undefined): string[] {
+  return (raw ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Is this session on the admin allowlist? Fail-closed at every step: no session,
+ * neither var set, or no match → false.
+ *
+ * Pins to `user.id` (ADMIN_USER_IDS) when that's set — the hardened primary,
+ * because it closes the register-the-admin-email-first path permanently (item 3,
+ * #232). Falls back to the legacy case-insensitive email allowlist only when no
+ * user-id allowlist is configured.
+ */
+export function isAdminSession(
+  session: { user: { id: string; email: string } } | null,
+  env: IdentityEnv,
+): boolean {
+  if (!session) return false;
+  const ids = splitList(env.ADMIN_USER_IDS);
+  if (ids.length > 0) return ids.includes(session.user.id);
+  const emails = splitList(env.ADMIN_EMAILS).map((e) => e.toLowerCase());
+  return emails.includes(session.user.email.toLowerCase());
+}
+
+/** Good-enough shape check for an address someone wants an invite sent to.
+ *  Deliverability is unknowable here; this only rejects obvious junk. */
+export function isPlausibleEmail(email: string): boolean {
+  return email.length <= 254 && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
+/**
+ * Does `supplied` match the shared INVITE_CODES backdoor? Pure half of the
+ * signup gate's branch (b) (worker/auth.ts) — the per-email single-use path (a)
+ * needs a D1 read and stays there. Fail-closed: an empty/whitespace-only
+ * INVITE_CODES, or an empty supplied code, denies. Codes are matched verbatim
+ * (already trimmed by the caller); no normalization.
+ */
+export function matchesSharedInviteCode(
+  supplied: string,
+  inviteCodes: string | undefined,
+): boolean {
+  if (!supplied) return false;
+  return splitList(inviteCodes).includes(supplied);
+}

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -46,6 +46,12 @@ import {
   isBackupDateKey,
 } from "./backup";
 import {
+  OWNER_DO_ID,
+  isAdminSession,
+  isPlausibleEmail,
+  resolveUserId,
+} from "./identity";
+import {
   mintInvites,
   normalizeEmail,
   pendingWaitlistEmails,
@@ -106,10 +112,15 @@ interface Env extends AuthEnv {
   UNFURL_LIMIT: RateLimit;
   /** Per-IP rate limiter for the public alpha-waitlist endpoint. */
   WAITLIST_LIMIT: RateLimit;
-  /** Comma-separated emails allowed on admin surfaces (the waitlist view).
-   *  Fail-closed: unset = no admins. Email is fine HERE (unlike DO keying) —
-   *  it's an allowlist entry, not a permanent storage key; if the admin's
-   *  email changes, update the var in wrangler.jsonc. */
+  /** Comma-separated Better Auth `user.id`s allowed on admin surfaces — the
+   *  PINNED admin identity (#232). When set, this is the sole admin check and
+   *  ADMIN_EMAILS is ignored, closing the register-the-admin-email-first path
+   *  (email is unverified during beta; a `user.id` can't be forged). Fail-closed.
+   *  See isAdminSession in worker/identity.ts. */
+  ADMIN_USER_IDS?: string;
+  /** Legacy comma-separated admin email allowlist. Honored ONLY as a fallback
+   *  when ADMIN_USER_IDS is empty (so an older deploy keeps working). Prefer
+   *  ADMIN_USER_IDS. Fail-closed: neither set = no admins. */
   ADMIN_EMAILS?: string;
 }
 
@@ -136,28 +147,6 @@ const KV_COLLECTIONS = new Set([
   "changelog",
   "saved-queries",
 ]);
-
-/**
- * The Durable Object name for the signed-in user's outline.
- *
- * LOCKED DECISION: a DO name is permanent and cannot be renamed, so it must
- * never be an email or any value that can change — keying by email would orphan
- * a user's whole outline on an email or auth-provider change. We key by the
- * session's stable `user.id`. Do NOT key this off the email.
- *
- * The one exception is the owner-continuity bridge: the pre-auth outline lives
- * in the constant 'default' DO (seeded from legacy D1). Setting OWNER_USER_ID to
- * the owner's `user.id` maps that one account back to 'default', carrying their
- * existing data over with zero copy. Removable once that data is wherever it
- * belongs.
- */
-const OWNER_DO_ID = "default";
-
-function resolveUserId(sessionUserId: string, env: Env): string {
-  if (env.OWNER_USER_ID && sessionUserId === env.OWNER_USER_ID)
-    return OWNER_DO_ID;
-  return sessionUserId;
-}
 
 /**
  * The provenance stamp for an MCP write: the human-facing name of the OAuth
@@ -509,25 +498,6 @@ function waitlistCorsHeaders(request: Request): Record<string, string> {
   return origin && WAITLIST_ALLOWED_ORIGINS.has(origin)
     ? { "access-control-allow-origin": origin, vary: "Origin" }
     : {};
-}
-
-/** Good-enough shape check for an address someone wants an invite sent to.
- *  Deliverability is unknowable here; this only rejects obvious junk. */
-function isPlausibleEmail(email: string): boolean {
-  return email.length <= 254 && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
-}
-
-/** Is this session's email on the ADMIN_EMAILS allowlist? Fail-closed. */
-function isAdminSession(
-  session: { user: { email: string } } | null,
-  env: Env,
-): boolean {
-  if (!session) return false;
-  const admins = (env.ADMIN_EMAILS ?? "")
-    .split(",")
-    .map((e) => e.trim().toLowerCase())
-    .filter(Boolean);
-  return admins.includes(session.user.email.toLowerCase());
 }
 
 /**

--- a/worker/unfurl-core.ts
+++ b/worker/unfurl-core.ts
@@ -43,6 +43,23 @@ function isPrivateIpv4(host: string): boolean {
   );
 }
 
+/** Decode an IPv4-mapped IPv6 host (`::ffff:127.0.0.1` or its canonicalized hex
+ *  form `::ffff:7f00:1`) to its dotted IPv4 string, else null. WHATWG `new URL`
+ *  canonicalizes the dotted form to hex, so the hex tail is what the guard
+ *  actually sees — both are handled. Lets isPrivateIpv4 catch a loopback/private
+ *  target smuggled through the v6 mapping (#232, item 4). */
+function mappedIpv4(host: string): string | null {
+  const m = /^::ffff:(.+)$/i.exec(host);
+  if (!m) return null;
+  const tail = m[1]!;
+  if (/^\d{1,3}(\.\d{1,3}){3}$/.test(tail)) return tail; // dotted
+  const hex = /^([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i.exec(tail); // h:h (two 16-bit groups)
+  if (!hex) return null;
+  const hi = parseInt(hex[1]!, 16);
+  const lo = parseInt(hex[2]!, 16);
+  return `${(hi >> 8) & 255}.${hi & 255}.${(lo >> 8) & 255}.${lo & 255}`;
+}
+
 /** The SSRF target guard: a fully-formed http(s) URL whose host isn't an obvious
  *  internal destination. Re-run on every redirect hop -- a 302 to an internal
  *  target is the classic redirect bounce. A blocked target yields `{title:null}`
@@ -67,6 +84,8 @@ export function isAllowedUnfurlTarget(raw: string): boolean {
   )
     return false; // IPv6 link-local / ULA
   if (isPrivateIpv4(host)) return false;
+  const mapped = mappedIpv4(host); // IPv4-mapped IPv6 smuggling a private target
+  if (mapped && isPrivateIpv4(mapped)) return false;
   return true;
 }
 

--- a/worker/unfurl.test.ts
+++ b/worker/unfurl.test.ts
@@ -70,6 +70,21 @@ describe("isAllowedUnfurlTarget (SSRF guard)", () => {
     expect(isAllowedUnfurlTarget("http://[fd00::1]/")).toBe(false);
   });
 
+  it("blocks IPv4-mapped IPv6 that smuggles a private target (#232)", () => {
+    // WHATWG canonicalizes the dotted form to hex, so both spellings resolve to
+    // the same host the guard sees — assert the raw inputs anyway.
+    expect(isAllowedUnfurlTarget("http://[::ffff:127.0.0.1]/")).toBe(false);
+    expect(isAllowedUnfurlTarget("http://[::ffff:7f00:1]/")).toBe(false); // canonical hex
+    expect(isAllowedUnfurlTarget("http://[::ffff:10.0.0.1]/")).toBe(false);
+    expect(isAllowedUnfurlTarget("http://[::ffff:169.254.169.254]/")).toBe(
+      false,
+    ); // mapped cloud metadata
+  });
+
+  it("still allows an IPv4-mapped IPv6 pointing at a public address", () => {
+    expect(isAllowedUnfurlTarget("http://[::ffff:8.8.8.8]/")).toBe(true);
+  });
+
   it("rejects unparseable input", () => {
     expect(isAllowedUnfurlTarget("not a url")).toBe(false);
     expect(isAllowedUnfurlTarget("")).toBe(false);

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -34,9 +34,17 @@
     // routing path and lets the asset/SPA fallback flow through env.ASSETS.
     "run_worker_first": true,
   },
-  // Non-secret config. ADMIN_EMAILS gates the admin surfaces (the waitlist
-  // view at /admin/waitlist); knowing the email grants nothing — admin still
-  // requires signing IN as that account. Unset = no admins (fail-closed).
+  // Non-secret config. Admin surfaces (the waitlist view /admin/waitlist, the
+  // restore + invite endpoints) are gated by isAdminSession (worker/identity.ts):
+  // knowing the value grants nothing — admin still requires signing IN as that
+  // account. Fail-closed: neither var set = no admins.
+  //
+  // ADMIN_USER_IDS (the pinned identity, #232) takes precedence: set it to the
+  // admin's Better Auth `user.id` (from the D1 `user` table) to CLOSE the
+  // register-the-admin-email-first path — when set, ADMIN_EMAILS is ignored.
+  // Left unset for now so ADMIN_EMAILS keeps working; flip it on once the id is
+  // confirmed (a wrong id locks admin until this line is fixed).
+  //   "ADMIN_USER_IDS": "<owner user.id>",
   "vars": {
     "ADMIN_EMAILS": "cameronandrewpak@gmail.com",
     // Public Sentry DSN (#227) — errors-only monitoring for the Worker + DO.


### PR DESCRIPTION
## Summary

Audit finding 4 (from #159): the Worker's auth-boundary logic was untested and partly unhardened. This extracts the pure gates into one tested module and closes four gaps. Additive/hardening only — no behavior change on the happy path.

Closes #232.

## Changes

- **New `worker/identity.ts`** — moves `resolveUserId` (the DO tenant-isolation key), `isAdminSession`, `isPlausibleEmail`, and the shared-invite-code predicate out of `index.ts`/`auth.ts` into one pure, binding-free module, with **`worker/identity.test.ts`** (e2e can't reach these — the mock intercepts `/api/auth`).
- **`BETTER_AUTH_SECRET` asserted** non-empty at `createAuth` — a misconfigured deploy now 500s loudly instead of signing with a missing/empty secret ("fails closed" was an unverified claim).
- **Admin identity can pin to `user.id`** via a new `ADMIN_USER_IDS` var (precedence over the legacy `ADMIN_EMAILS` fallback), closing the register-the-admin-email-first path. Left **unset** in `wrangler.jsonc` so `ADMIN_EMAILS` keeps working until the id is confirmed.
- **SSRF nit** — the unfurl guard now blocks IPv4-mapped IPv6 (`::ffff:127.0.0.1` and its canonical hex form), decoding the mapped tail and reusing `isPrivateIpv4`.

## Flow

Request → `resolveUserId(session.user.id, env)` → per-user DO (never the email). Admin routes → `isAdminSession` (pinned `user.id` when `ADMIN_USER_IDS` set, else email fallback, both fail-closed). Signup `/sign-up/email` → per-email invite OR `matchesSharedInviteCode(INVITE_CODES)`.

## Breaking

None. `ADMIN_EMAILS` behavior is unchanged until `ADMIN_USER_IDS` is set.

**Action for Cam (optional, activates item 3):** set `ADMIN_USER_IDS` in `wrangler.jsonc` to your Better Auth `user.id` (from the D1 `user` table) to close the email-registration path. A wrong id locks admin until the line is fixed, hence left unset.

## Test plan

- `bun test worker/identity.test.ts worker/unfurl.test.ts` — 32 pass (new + mapped-IPv6 cases).
- Full suite `bun test src worker/` — 678 pass; `typecheck` ×3, `lint`, `fmt:check` all green.
- No runtime UI surface; gates + unit tests are the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)