### PR TITLE
Raise the free-tier node cap to 10,000

### DIFF
--- a/.changeset/free-tier-cap-tuning.md
+++ b/.changeset/free-tier-cap-tuning.md
@@ -1,0 +1,6 @@
+---
+---
+
+Tunes the (still-unreleased) free-tier node cap from 2,000 to 10,000 before it
+ships — the news lives in the amended `free-tier-entitlements` fragment, so this
+carries no separate changelog line (ADR 0046).

--- a/.changeset/free-tier-entitlements.md
+++ b/.changeset/free-tier-entitlements.md
@@ -2,4 +2,4 @@
 "dotflowy": minor
 ---
 
-Enforce free-tier entitlements: a free outline is capped at 2,000 live nodes (the DO refuses batches that would grow it past the cap, with an in-app upgrade toast; edits, moves, and deletes are never blocked and an over-cap outline is never locked), and MCP agent access now requires a paid plan (a free token can still handshake and list tools but every tool call is refused with an upgrade message). Paid plans are unlimited on both.
+Enforce free-tier entitlements: a free outline is capped at 10,000 live nodes (the DO refuses batches that would grow it past the cap, with an in-app upgrade toast; edits, moves, and deletes are never blocked and an over-cap outline is never locked), and MCP agent access now requires a paid plan (a free token can still handshake and list tools but every tool call is refused with an upgrade message). Paid plans are unlimited on both.

--- a/worker/outline-do.ts
+++ b/worker/outline-do.ts
@@ -350,7 +350,7 @@ export class UserOutlineDO extends DurableObject<Env> {
 
   /** Total live node rows (the cap counts every node — bullets, tasks, mirrors,
    *  containers). A single indexed COUNT: sub-millisecond even at 17k rows, so no
-   *  maintained counter is worth its drift/backfill risk at a 2,000-node cap. */
+   *  maintained counter is worth its drift/backfill risk at a 10,000-node cap. */
   private nodeCount(): number {
     const row = this.sql
       .exec<{ n: number }>("SELECT COUNT(*) AS n FROM nodes")

--- a/worker/plan.ts
+++ b/worker/plan.ts
@@ -20,7 +20,7 @@ export const PAID_PLANS = ["unlimited", "founding"] as const;
 /** Free tier ceiling: total LIVE nodes a free outline may hold (#152/#170).
  *  Generous by design — the funnel, not a wall; over-cap never locks (edits,
  *  moves, deletes always apply — see `batchExceedsNodeLimit`). Paid = no cap. */
-export const FREE_NODE_LIMIT = 2000;
+export const FREE_NODE_LIMIT = 10000;
 
 /** The node ceiling a plan enforces: free is capped, paid is unlimited (`null`,
  *  which every gate below reads as "never reject"). */


### PR DESCRIPTION
## Summary

Raises the free-tier ceiling from 2,000 to 10,000 live nodes before the 2,000 limit ever ships. Real outlines get room to grow, and the #273 daily-calendar migration can reorganize a free outline without its ~13 scaffold nodes tripping the cap.

## Changes

1. `FREE_NODE_LIMIT` 2,000 → 10,000; the over-cap upgrade toast needs no edit — it interpolates the limit from the Worker's 403.
2. Amend the still-unreleased #170 entitlements changeset fragment to 10,000 so the next release's changelog states one honest cap, not "2,000" and "raised to 10,000" in the same notes.

**Start here:** change 2 — editing the prior fragment (vs. adding a contradicting one) is deliberate; the 2,000 cap never reached a user, so there's no history to preserve in the changelog (git log keeps it).

## Test plan

- `bun run test` — 678 pass
- `bun run typecheck` / `typecheck:worker` / `typecheck:test` / `lint` / `fmt:check` — clean
- `bunx changeset status --since=origin/main` — passes (CI changeset gate)
- `worker/plan.test.ts` — 19 pass (drives the pure gate with its own cap constant; value change is transparent to it)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased the free plan’s maximum live outline nodes from 2,000 to 10,000.
  * Free-plan outlines can continue editing, moving, and deleting nodes when over the limit.
  * Paid plans remain unlimited; MCP tool calls continue to require a paid plan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->