### PR TITLE
Toast when an outline write fails instead of the edit vanishing

### DIFF
--- a/.changeset/surface-save-failures.md
+++ b/.changeset/surface-save-failures.md
@@ -1,0 +1,5 @@
+---
+"dotflowy": patch
+---
+
+Surface a toast when an outline write fails and rolls back, instead of the edit vanishing silently.

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -111,6 +111,13 @@ export async function seedOutline(
      *  the field AND keeps every other spec free of an update toast; pass a
      *  version different from package.json's to exercise the stale-tab path. */
     serverVersion?: string;
+    /** Force every structural-batch POST (`body.ops`) to fail with a 500 before
+     *  it mutates the store, so a spec can drive the save-failure rollback +
+     *  toast path (#230). Reads and the legacy seed POST are untouched, so the
+     *  seeded outline still loads normally. A received 500 resolves the fetch
+     *  (not a transport error), so the client's retry policy doesn't kick in —
+     *  the failure lands immediately. */
+    failStructuralWrites?: boolean;
   } = {},
 ): Promise<void> {
   const echoDelayMs = opts.echoDelayMs ?? 0;
@@ -189,6 +196,16 @@ export async function seedOutline(
           // Atomic structural batch: apply every op, commit ONE frame, reply with
           // its seq (mirrors the DO's applyBatch -> { seq }).
           if (body.ops) {
+            // Injected failure (#230): reject the batch BEFORE touching the
+            // store, so the optimistic overlay rolls back and the save-failure
+            // toast fires.
+            if (opts.failStructuralWrites) {
+              return route.fulfill({
+                status: 500,
+                contentType: "application/json",
+                body: JSON.stringify({ error: "boom" }),
+              });
+            }
             for (const op of body.ops) {
               if (op.op === "delete") store.delete(op.key);
               else store.set(op.value.id, op.value);

--- a/e2e/save-failure.spec.ts
+++ b/e2e/save-failure.spec.ts
@@ -1,0 +1,61 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { seedOutline, STANDARD_TREE } from "./fixtures";
+
+// A node's own editable text span.
+const text = (page: Page, id: string) =>
+  page.locator(`li[data-node-id="${id}"] > .outline-row .node-text`);
+
+// Every visible bullet's raw text in document order (empty new bullets show as
+// ""), so a rolled-back insert is observable by the count returning to normal.
+const orderedTexts = (page: Page) =>
+  page.locator(".outline-row .node-text").allTextContents();
+
+const saveFailedToast = (page: Page) =>
+  page.locator("[data-sonner-toast]", {
+    hasText: "Couldn't save your changes",
+  });
+
+// Drop the caret at the end of a bullet (Home/End/arrows are unreliable in
+// macOS Chromium contentEditable; setting the Selection directly is not needed
+// here since a fresh Enter appends at the caret we place by clicking the end).
+async function caretAtEnd(page: Page, id: string) {
+  const el = text(page, id);
+  await el.click();
+  await el.evaluate((node) => {
+    const sel = window.getSelection();
+    if (!sel) return;
+    const range = document.createRange();
+    range.selectNodeContents(node);
+    range.collapse(false);
+    sel.removeAllRanges();
+    sel.addRange(range);
+  });
+}
+
+test.describe("Save failure surfaces a toast and rolls back (#230)", () => {
+  test("a failed structural write toasts and reverts the optimistic bullet", async ({
+    page,
+  }) => {
+    // Seed loads normally; only structural-batch POSTs fail from here on.
+    await seedOutline(page, STANDARD_TREE, { failStructuralWrites: true });
+    await page.goto("/");
+    await expect(text(page, "alpha")).toBeVisible();
+
+    const before = await orderedTexts(page);
+
+    // Enter at the end of "Alpha" is a structural insert (new sibling bullet) —
+    // it routes through runStructural, whose batch POST the mock now 500s.
+    await caretAtEnd(page, "alpha");
+    await page.keyboard.press("Enter");
+
+    // The failure toast appears...
+    await expect(saveFailedToast(page)).toBeVisible({ timeout: 10_000 });
+
+    // ...and the optimistic new bullet rolls back: the visible order returns to
+    // exactly what it was before the Enter (no stray empty bullet survives).
+    await expect
+      .poll(() => orderedTexts(page), { timeout: 10_000 })
+      .toEqual(before);
+  });
+});

--- a/src/data/collection.ts
+++ b/src/data/collection.ts
@@ -10,6 +10,7 @@ import { isMirrorsEnabled } from "./flags";
 import { runPromise } from "./nodes-client-effect";
 import { makeSyncStream } from "./realtime";
 import { appRuntime } from "./runtime";
+import { persistOrNotify } from "./save-failure";
 import { nodeSchema } from "./schema";
 import { chainDisagreements } from "./sibling-chain";
 import { buildTreeIndex, childrenOf, now } from "./tree";
@@ -518,21 +519,32 @@ export const nodesCollection = createCollection({
       };
     },
   },
+  // Each handler THROWS on a failed write so TanStack DB rolls the optimistic
+  // edit back; `persistOrNotify` surfaces that rollback to the user (#230) and
+  // re-throws — the throw is load-bearing (swallowing it would drop the failure
+  // AND the rollback). A no-op toast for the node-limit case, already toasted
+  // upstream.
   onInsert: async ({ transaction }) => {
-    await createNodes(transaction.mutations.map((m) => m.modified as Node));
+    await persistOrNotify(
+      createNodes(transaction.mutations.map((m) => m.modified as Node)),
+    );
     return { refetch: false };
   },
   onUpdate: async ({ transaction }) => {
-    await updateNodes(
-      transaction.mutations.map((m) => ({
-        id: m.key as string,
-        changes: m.changes as Partial<Node>,
-      })),
+    await persistOrNotify(
+      updateNodes(
+        transaction.mutations.map((m) => ({
+          id: m.key as string,
+          changes: m.changes as Partial<Node>,
+        })),
+      ),
     );
     return { refetch: false };
   },
   onDelete: async ({ transaction }) => {
-    await deleteNodes(transaction.mutations.map((m) => m.key as string));
+    await persistOrNotify(
+      deleteNodes(transaction.mutations.map((m) => m.key as string)),
+    );
     return { refetch: false };
   },
 });

--- a/src/data/save-failure.ts
+++ b/src/data/save-failure.ts
@@ -1,0 +1,47 @@
+import { toast } from "sonner";
+
+import { NodesLimitError } from "./nodes-client-effect";
+
+/**
+ * The shared "your write didn't land" signal for the core outline path (#230).
+ *
+ * Both write seams fail by rejecting a promise that TanStack DB turns into an
+ * optimistic ROLLBACK — the structural batch (`runStructural`, structural.ts)
+ * and the field/insert/delete handlers (collection.ts). Before this, that
+ * rejection was swallowed (structural) or merely re-thrown into the void (the
+ * handlers), so a failed edit just vanished with no word to the user. This puts
+ * one honest toast on that path: the edit was undone, here's why.
+ *
+ * Two deliberate shapes:
+ *  - **Skips `NodesLimitError`.** The free-tier node ceiling (#170) is already
+ *    surfaced by `persistStructuralBatch`'s dedicated upgrade toast, and it
+ *    re-throws — so this would double-toast it. That case is NOT a mystery
+ *    failure; it has its own copy.
+ *  - **Fixed toast `id`.** A coalesced burst of field generations (or a rapid
+ *    run of structural edits) that all fail offline collapses into ONE notice,
+ *    not N stacked toasts. Sonner de-dupes on the id.
+ */
+export function notifySaveFailed(err: unknown): void {
+  if (err instanceof NodesLimitError) return;
+  toast.error("Couldn't save your changes", {
+    id: "save-failed",
+    description:
+      "Your recent edits were undone. Check your connection and try again.",
+  });
+}
+
+/**
+ * Await a write promise, and if it rejects, surface the rollback via
+ * `notifySaveFailed` before RE-THROWING — the throw is load-bearing: it's what
+ * triggers TanStack DB's optimistic rollback, so the failure must propagate.
+ * The collection field/insert/delete handlers wrap their persistence call in
+ * this so all three share one failure seam (#230).
+ */
+export async function persistOrNotify<T>(p: Promise<T>): Promise<T> {
+  try {
+    return await p;
+  } catch (err) {
+    notifySaveFailed(err);
+    throw err;
+  }
+}

--- a/src/data/structural.ts
+++ b/src/data/structural.ts
@@ -8,6 +8,7 @@ import type { Node } from "./schema";
 import { persistBatchE } from "./api";
 import { nodesCollection, waitForSeqE } from "./collection";
 import { NodesLimitError, runPromise } from "./nodes-client-effect";
+import { notifySaveFailed } from "./save-failure";
 import { chainDisagreements } from "./sibling-chain";
 import { buildTreeIndex, childrenOf } from "./tree";
 
@@ -65,10 +66,13 @@ async function persistStructuralBatch(ops: ChangeOp[]): Promise<void> {
  */
 export function runStructural<T>(body: () => T): T {
   const { result, persisted } = runStructuralTracked(body);
-  // Nobody consumes the outcome here — a failed batch already rolls the
-  // transaction back — so mark the derived promise handled to avoid an
-  // unhandled-rejection report for every offline structural write.
-  persisted.catch(() => {});
+  // Nobody awaits the outcome here — a failed batch already rolls the
+  // transaction back — but the edit vanishing silently is the #230 bug. Surface
+  // the rollback with the shared save-failure toast (which skips the node-limit
+  // case, already toasted by persistStructuralBatch, to avoid a double notice).
+  // This also marks the derived promise handled, so an offline structural write
+  // never trips an unhandled-rejection report.
+  persisted.catch(notifySaveFailed);
   return result;
 }
 


### PR DESCRIPTION
## Summary

The core outline write path failed silently: a rejected save (server 500, offline past the 8s timeout) rolled the optimistic edit back with nothing surfaced, so a just-typed bullet or just-moved subtree simply vanished. This adds one honest toast on that path. Fixes #230.

## Changes

1. A failed outline write now shows a "Couldn't save your changes" toast telling the user their recent edits were undone, instead of the edit disappearing without a word.
2. Both write seams route through one shared, id-deduped signal (`notifySaveFailed`): `runStructural`'s batch rejection and the collection `onInsert`/`onUpdate`/`onDelete` handlers (via `persistOrNotify`, which re-throws to preserve the rollback).
3. The signal skips the free-tier node-ceiling error (already surfaced by its own upgrade toast) and a fixed toast `id` collapses a coalesced burst of failed field edits into one notice.
4. e2e fixture gains a `failStructuralWrites` option so the rollback+toast path is drivable.

**Start here:** change 2 — the collection handlers must re-throw after toasting; the throw is what triggers TanStack DB's optimistic rollback.

## Breaking / Migration

None. Additive only — no change to rollback mechanics, no new await on the keystroke path.

## Test plan

- `bun run typecheck`, `typecheck:worker`, `typecheck:test`, `lint`, `fmt:check` — all green
- `bun run test` — 746 pass / 0 fail
- `e2e/save-failure.spec.ts` (new) — forces a structural write to 500, asserts the toast appears and the optimistic bullet reverts; passes in 3.4s
- `/code-review` (high) run — 2 low-severity cleanups found and applied (handler dedup, copy accuracy); no correctness findings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a notification when outline changes fail to save.
  * Failed edits now roll back visibly instead of disappearing silently.
  * Consistent save-failure handling now covers insert, update, delete, and structural edits.
  * Existing node-limit error handling remains unchanged.

* **Tests**
  * Added end-to-end coverage verifying the error notification and restoration of the previous bullet order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->