### PR TITLE
Publish /terms and /privacy legal pages in the app

### DIFF
--- a/.changeset/legal-pages.md
+++ b/.changeset/legal-pages.md
@@ -1,0 +1,5 @@
+---
+"dotflowy": minor
+---
+
+Read the Terms of Service and Privacy Policy in the app at /terms and /privacy, linked from the signup screen and the More menu.

--- a/docs/legal/terms.md
+++ b/docs/legal/terms.md
@@ -26,7 +26,7 @@ You can export your entire outline at any time, in OPML or Markdown, on any plan
 
 Payments are processed by Stripe. We never see or store your card number.
 
-- **Free** — the full outliner, capped at 2,000 total live nodes. Going over the cap never locks you out: you keep full access to your existing notes and export always works.
+- **Free** — the full outliner, capped at 10,000 total live nodes. Going over the cap never locks you out: you keep full access to your existing notes and export always works.
 - **Paid** — unlimited nodes plus AI agent (MCP) access: **$5/month** or **$48/year**.
 - **Founding** — **$99 for 3 years** of the paid plan, limited to 50 seats. **Plain disclosure: the founding plan is a fixed 3-year term, not a lifetime deal, and it auto-renews at the end of year 3 at the then-current annual price unless you cancel first.** We'll remind you before that renewal.
 

--- a/src/components/auth-screen.tsx
+++ b/src/components/auth-screen.tsx
@@ -279,6 +279,26 @@ export function AuthScreen() {
                     ? "Sign up"
                     : "Sign in"}
             </Button>
+
+            {isSignup && (
+              <p className="text-center text-xs text-muted-foreground">
+                By signing up you agree to our{" "}
+                <a
+                  href="/terms"
+                  className="underline underline-offset-4 hover:text-foreground"
+                >
+                  Terms
+                </a>{" "}
+                and{" "}
+                <a
+                  href="/privacy"
+                  className="underline underline-offset-4 hover:text-foreground"
+                >
+                  Privacy Policy
+                </a>
+                .
+              </p>
+            )}
           </form>
         )}
 

--- a/src/components/header-more-menu.tsx
+++ b/src/components/header-more-menu.tsx
@@ -5,9 +5,11 @@ import {
   CircleCheckIcon,
   ClipboardCopyIcon,
   DownloadIcon,
+  FileTextIcon,
   FileUpIcon,
   FocusIcon,
   LinkIcon,
+  ShieldCheckIcon,
   LogOutIcon,
   MonitorIcon,
   MessageSquareWarningIcon,
@@ -295,6 +297,24 @@ export function HeaderMoreMenu() {
           >
             <GitHubIcon />
             GitHub
+          </DropdownMenuItem>
+
+          <DropdownMenuItem
+            onClick={() =>
+              window.open("/terms", "_blank", "noopener,noreferrer")
+            }
+          >
+            <FileTextIcon />
+            Terms
+          </DropdownMenuItem>
+
+          <DropdownMenuItem
+            onClick={() =>
+              window.open("/privacy", "_blank", "noopener,noreferrer")
+            }
+          >
+            <ShieldCheckIcon />
+            Privacy Policy
           </DropdownMenuItem>
 
           <DropdownMenuSeparator />

--- a/src/components/legal-page.tsx
+++ b/src/components/legal-page.tsx
@@ -1,0 +1,152 @@
+import type { ReactNode } from "react";
+
+/**
+ * Renders the committed legal drafts (`docs/legal/*.md`, imported as raw
+ * strings via Vite `?raw`) as public, prerender-safe pages — no data layer,
+ * no dependency. The markdown surface those drafts use is small and fixed
+ * (h1/h2/h3, paragraphs, `-` lists, `**bold**`, and `[text](url)` links), so a
+ * focused parser returning React nodes is faithful and avoids both a markdown
+ * dependency and `dangerouslySetInnerHTML`. Anything richer than that grammar
+ * lands verbatim as text rather than mis-rendering.
+ *
+ * These routes render OUTSIDE the root AuthGate (see `__root.tsx`
+ * `PUBLIC_ROUTES`) so a signed-out visitor — or a crawler — can read them.
+ */
+
+/** Split the source into blank-line-separated blocks. */
+function splitBlocks(md: string): string[] {
+  return md
+    .replace(/\r\n/g, "\n")
+    .split(/\n{2,}/)
+    .map((b) => b.trim())
+    .filter(Boolean);
+}
+
+/** Map a markdown link href to what the app should navigate to: a relative
+ *  `./privacy.md` becomes the SPA route `/privacy`; everything else is left
+ *  as-authored (mailto:, http(s)://). */
+function resolveHref(href: string): string {
+  const md = href.match(/^\.?\/?([\w-]+)\.md$/);
+  return md ? `/${md[1]}` : href;
+}
+
+const INLINE = /\*\*([^*]+)\*\*|\[([^\]]+)\]\(([^)]+)\)/g;
+
+/** Parse the inline grammar (`**bold**`, `[text](url)`) into React nodes. */
+function renderInline(text: string, keyPrefix: string): ReactNode[] {
+  const nodes: ReactNode[] = [];
+  let last = 0;
+  let match: RegExpExecArray | null;
+  let i = 0;
+  INLINE.lastIndex = 0;
+  while ((match = INLINE.exec(text)) !== null) {
+    if (match.index > last) {
+      nodes.push(text.slice(last, match.index));
+    }
+    if (match[1] !== undefined) {
+      nodes.push(
+        <strong
+          key={`${keyPrefix}-b${i}`}
+          className="font-semibold text-foreground"
+        >
+          {match[1]}
+        </strong>,
+      );
+    } else {
+      const href = resolveHref(match[3] ?? "");
+      const external = /^https?:\/\//.test(href);
+      nodes.push(
+        <a
+          key={`${keyPrefix}-a${i}`}
+          href={href}
+          {...(external
+            ? { target: "_blank", rel: "noopener noreferrer" }
+            : {})}
+          className="font-medium text-foreground underline underline-offset-4 hover:text-primary"
+        >
+          {match[2]}
+        </a>,
+      );
+    }
+    last = match.index + match[0].length;
+    i += 1;
+  }
+  if (last < text.length) nodes.push(text.slice(last));
+  return nodes;
+}
+
+/** Render one block (heading / list / paragraph) to a React element. */
+function renderBlock(block: string, key: number): ReactNode {
+  const heading = block.match(/^(#{1,3})\s+(.*)$/);
+  if (heading) {
+    const level = (heading[1] ?? "").length;
+    const content = renderInline(heading[2] ?? "", `h${key}`);
+    if (level === 1)
+      return (
+        <h1
+          key={key}
+          className="mt-0 mb-6 text-2xl font-semibold tracking-tight text-foreground"
+        >
+          {content}
+        </h1>
+      );
+    if (level === 2)
+      return (
+        <h2
+          key={key}
+          className="mt-10 mb-3 text-lg font-semibold tracking-tight text-foreground"
+        >
+          {content}
+        </h2>
+      );
+    return (
+      <h3
+        key={key}
+        className="mt-6 mb-2 text-base font-semibold text-foreground"
+      >
+        {content}
+      </h3>
+    );
+  }
+
+  const lines = block.split("\n");
+  if (lines.every((l) => /^[-*]\s+/.test(l))) {
+    return (
+      <ul key={key} className="my-4 list-disc space-y-2 pl-6">
+        {lines.map((l, idx) => (
+          <li key={idx}>
+            {renderInline(l.replace(/^[-*]\s+/, ""), `l${key}-${idx}`)}
+          </li>
+        ))}
+      </ul>
+    );
+  }
+
+  // A plain paragraph — join wrapped lines with a space.
+  return (
+    <p key={key} className="my-4 leading-relaxed">
+      {renderInline(lines.join(" "), `p${key}`)}
+    </p>
+  );
+}
+
+export function LegalPage({ markdown }: Readonly<{ markdown: string }>) {
+  const blocks = splitBlocks(markdown);
+  return (
+    <main className="min-h-dvh bg-background text-foreground">
+      <div className="mx-auto max-w-2xl px-6 py-10">
+        <div className="mb-8 border-b border-border pb-4">
+          <a
+            href="/"
+            className="text-sm font-medium text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+          >
+            ← Back to Dotflowy
+          </a>
+        </div>
+        <article className="text-sm text-muted-foreground">
+          {blocks.map((block, i) => renderBlock(block, i))}
+        </article>
+      </div>
+    </main>
+  );
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -10,7 +10,9 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as TodayRouteImport } from './routes/today'
+import { Route as TermsRouteImport } from './routes/terms'
 import { Route as ResetPasswordRouteImport } from './routes/reset-password'
+import { Route as PrivacyRouteImport } from './routes/privacy'
 import { Route as NodeIdRouteImport } from './routes/$nodeId'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as AdminWaitlistRouteImport } from './routes/admin.waitlist'
@@ -21,9 +23,19 @@ const TodayRoute = TodayRouteImport.update({
   path: '/today',
   getParentRoute: () => rootRouteImport,
 } as any)
+const TermsRoute = TermsRouteImport.update({
+  id: '/terms',
+  path: '/terms',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ResetPasswordRoute = ResetPasswordRouteImport.update({
   id: '/reset-password',
   path: '/reset-password',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const PrivacyRoute = PrivacyRouteImport.update({
+  id: '/privacy',
+  path: '/privacy',
   getParentRoute: () => rootRouteImport,
 } as any)
 const NodeIdRoute = NodeIdRouteImport.update({
@@ -50,7 +62,9 @@ const AdminRestoreRoute = AdminRestoreRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/$nodeId': typeof NodeIdRoute
+  '/privacy': typeof PrivacyRoute
   '/reset-password': typeof ResetPasswordRoute
+  '/terms': typeof TermsRoute
   '/today': typeof TodayRoute
   '/admin/restore': typeof AdminRestoreRoute
   '/admin/waitlist': typeof AdminWaitlistRoute
@@ -58,7 +72,9 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/$nodeId': typeof NodeIdRoute
+  '/privacy': typeof PrivacyRoute
   '/reset-password': typeof ResetPasswordRoute
+  '/terms': typeof TermsRoute
   '/today': typeof TodayRoute
   '/admin/restore': typeof AdminRestoreRoute
   '/admin/waitlist': typeof AdminWaitlistRoute
@@ -67,7 +83,9 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/$nodeId': typeof NodeIdRoute
+  '/privacy': typeof PrivacyRoute
   '/reset-password': typeof ResetPasswordRoute
+  '/terms': typeof TermsRoute
   '/today': typeof TodayRoute
   '/admin/restore': typeof AdminRestoreRoute
   '/admin/waitlist': typeof AdminWaitlistRoute
@@ -77,7 +95,9 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/$nodeId'
+    | '/privacy'
     | '/reset-password'
+    | '/terms'
     | '/today'
     | '/admin/restore'
     | '/admin/waitlist'
@@ -85,7 +105,9 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/$nodeId'
+    | '/privacy'
     | '/reset-password'
+    | '/terms'
     | '/today'
     | '/admin/restore'
     | '/admin/waitlist'
@@ -93,7 +115,9 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/$nodeId'
+    | '/privacy'
     | '/reset-password'
+    | '/terms'
     | '/today'
     | '/admin/restore'
     | '/admin/waitlist'
@@ -102,7 +126,9 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   NodeIdRoute: typeof NodeIdRoute
+  PrivacyRoute: typeof PrivacyRoute
   ResetPasswordRoute: typeof ResetPasswordRoute
+  TermsRoute: typeof TermsRoute
   TodayRoute: typeof TodayRoute
   AdminRestoreRoute: typeof AdminRestoreRoute
   AdminWaitlistRoute: typeof AdminWaitlistRoute
@@ -117,11 +143,25 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof TodayRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/terms': {
+      id: '/terms'
+      path: '/terms'
+      fullPath: '/terms'
+      preLoaderRoute: typeof TermsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/reset-password': {
       id: '/reset-password'
       path: '/reset-password'
       fullPath: '/reset-password'
       preLoaderRoute: typeof ResetPasswordRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/privacy': {
+      id: '/privacy'
+      path: '/privacy'
+      fullPath: '/privacy'
+      preLoaderRoute: typeof PrivacyRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/$nodeId': {
@@ -158,7 +198,9 @@ declare module '@tanstack/react-router' {
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   NodeIdRoute: NodeIdRoute,
+  PrivacyRoute: PrivacyRoute,
   ResetPasswordRoute: ResetPasswordRoute,
+  TermsRoute: TermsRoute,
   TodayRoute: TodayRoute,
   AdminRestoreRoute: AdminRestoreRoute,
   AdminWaitlistRoute: AdminWaitlistRoute,

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -121,10 +121,11 @@ export const Route = createRootRoute({
 
 /** Routes that render for a VISITOR — outside the AuthGate (which would swap
  *  them for the login screen) and outside the editor chrome, whose dialogs
- *  assume a signed-in data layer. Today just the password-reset landing page
- *  (its visitor has no session — revokeSessionsOnPasswordReset killed them);
- *  a future signed-out landing (e.g. email verification) is added HERE. */
-const PUBLIC_ROUTES = new Set(["/reset-password"]);
+ *  assume a signed-in data layer. The password-reset landing page (its visitor
+ *  has no session — revokeSessionsOnPasswordReset killed them) and the legal
+ *  pages (public by definition, and linked from the signup screen where there
+ *  is no session yet); a future signed-out landing is added HERE. */
+const PUBLIC_ROUTES = new Set(["/reset-password", "/terms", "/privacy"]);
 
 function RootComponent() {
   // Trailing-slash-tolerant: the router matches `/reset-password/` to the

--- a/src/routes/privacy.tsx
+++ b/src/routes/privacy.tsx
@@ -1,0 +1,19 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+// The committed legal draft (docs/legal/privacy.md), bundled as a raw string at
+// build time. Rendered by the shared LegalPage; this route is PUBLIC — see
+// __root.tsx's PUBLIC_ROUTES, which renders it OUTSIDE the AuthGate so a
+// signed-out visitor can read it.
+import privacyMarkdown from "../../docs/legal/privacy.md?raw";
+import { LegalPage } from "../components/legal-page";
+
+export const Route = createFileRoute("/privacy")({
+  head: () => ({
+    meta: [{ title: "Privacy Policy — Dotflowy" }],
+  }),
+  component: Privacy,
+});
+
+function Privacy() {
+  return <LegalPage markdown={privacyMarkdown} />;
+}

--- a/src/routes/terms.tsx
+++ b/src/routes/terms.tsx
@@ -1,0 +1,19 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+// The committed legal draft (docs/legal/terms.md), bundled as a raw string at
+// build time. Rendered by the shared LegalPage; this route is PUBLIC — see
+// __root.tsx's PUBLIC_ROUTES, which renders it OUTSIDE the AuthGate so a
+// signed-out visitor can read it.
+import termsMarkdown from "../../docs/legal/terms.md?raw";
+import { LegalPage } from "../components/legal-page";
+
+export const Route = createFileRoute("/terms")({
+  head: () => ({
+    meta: [{ title: "Terms of Service — Dotflowy" }],
+  }),
+  component: Terms,
+});
+
+function Terms() {
+  return <LegalPage markdown={termsMarkdown} />;
+}


### PR DESCRIPTION
## Summary

Publishes the committed legal drafts as public in-app pages at `/terms` and `/privacy`, linked from the signup screen and the header More menu. Publishing is gated on #225 (support@dotflowy.com) resolving before the promise is true.

Fixes #226

## Changes

1. `/terms` and `/privacy` render the `docs/legal/*.md` drafts to any visitor — signed-out or crawler — via new file-based routes added to `__root.tsx`'s `PUBLIC_ROUTES` (rendered outside the AuthGate, like `/reset-password`).
2. The signup screen gains a "By signing up you agree to our Terms and Privacy Policy" line linking both pages.
3. The header More menu gains Terms and Privacy Policy items (open in a new tab).
4. A small self-contained markdown renderer (`legal-page.tsx`) turns the drafts (imported as raw strings via Vite `?raw`) into React nodes — no dependency, no `dangerouslySetInnerHTML`, prerender-safe.

**Start here:** change 4 — the renderer handles only the drafts' fixed grammar (h1–h3, `-` lists, `**bold**`, `[text](url)`); anything richer lands as verbatim text rather than mis-rendering. Relative `./privacy.md` links are rewritten to the `/privacy` route.

## Breaking / Migration

None. Additive routes and links; no `Node` field, schema, or wire change.

## Test plan

- `bun run typecheck`, `bun run lint`, `bun run test` (746 pass), `bun run build` — all green; route tree regenerated.
- Served the production build (SPA fallback) signed-OUT: `/terms` and `/privacy` render full content (headings, lists, bold, links); `./privacy.md` cross-link resolves to `/privacy`; `support@dotflowy.com` mailto intact; theme-aware.
- Real Worker (`cf:dev`): `GET /terms` and `/privacy` return 200 signed-out (ASSETS short-circuit before auth).
- Drove the signed-out signup screen: the agreement line renders under Sign up with `Terms → /terms` and `Privacy Policy → /privacy`.
- **Needs manual check:** confirm support@dotflowy.com resolves (#225) before treating the pages' contact promise as live. The founding-plan node cap in the copy still reads "2,000" while the app cap is now 10k (#282) — legal copy is maintained separately; flagging, not changing it here.
