### PR TITLE
feat(landing): pricing section on dotflowy.com (#171)

### DIFF
--- a/.changeset/flat-worlds-stare.md
+++ b/.changeset/flat-worlds-stare.md
@@ -1,0 +1,4 @@
+---
+---
+
+Landing-site only: add the pricing section to dotflowy.com. No app changes, so this is intentionally not app changelog news.

--- a/landing/src/components/Landing.tsx
+++ b/landing/src/components/Landing.tsx
@@ -1,7 +1,13 @@
 import type { VariantProps } from "class-variance-authority";
 
 import { Star } from "lucide-react";
-import { useState, type FormEvent, type ReactNode } from "react";
+import {
+  useEffect,
+  useRef,
+  useState,
+  type FormEvent,
+  type ReactNode,
+} from "react";
 
 import { Logo } from "@/components/Logo";
 import { buttonVariants } from "@/components/ui/button-variants";
@@ -178,7 +184,7 @@ function Hero() {
         Open source. Real-time sync. Export everything, anytime.
       </p>
 
-      <div className="mt-10">
+      <div id="waitlist" className="mt-10 scroll-mt-20">
         <WaitlistForm />
         <p className="mt-3 font-mono text-xs text-muted-foreground">
           In private alpha · have an invite?{" "}
@@ -189,6 +195,232 @@ function Hero() {
             Sign in
           </a>
         </p>
+      </div>
+    </section>
+  );
+}
+
+/** Scroll-reveal: opacity + a small translateY, once, on entering the viewport.
+ * Strong ease-out curve, ≤300ms. Honours prefers-reduced-motion (shows at once,
+ * no movement) and never blocks — content is always in the DOM for crawlers. */
+function Reveal({
+  children,
+  delay = 0,
+  className,
+}: {
+  children: ReactNode;
+  delay?: number;
+  className?: string;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [shown, setShown] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+      setShown(true);
+      return;
+    }
+    const io = new IntersectionObserver(
+      ([entry]) => {
+        if (entry?.isIntersecting) {
+          setShown(true);
+          io.disconnect();
+        }
+      },
+      { rootMargin: "0px 0px -10% 0px", threshold: 0.1 },
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, []);
+
+  return (
+    <div
+      ref={ref}
+      style={{
+        transitionTimingFunction: "cubic-bezier(0.23, 1, 0.32, 1)",
+        transitionDelay: shown ? `${delay}ms` : "0ms",
+      }}
+      className={cn(
+        "transition-[opacity,transform] duration-300 motion-reduce:transition-none",
+        // Hint the compositor before the reveal; drop it once shown so we don't
+        // keep a GPU layer alive for the life of the page.
+        shown
+          ? "translate-y-0 opacity-100"
+          : "translate-y-2 opacity-0 will-change-[opacity,transform]",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+type Tier = {
+  name: string;
+  price: ReactNode;
+  tagline: string;
+  features: string[];
+  // One quiet label above the name — a first-party note, not a fabricated stat.
+  label?: string;
+  // The emphasized tier (Unlimited): brand-blue accent + ring.
+  accent?: boolean;
+  // The limited offer (Founding): a distinct muted fill.
+  distinct?: boolean;
+  // Founding's honest renewal disclosure (a hard requirement — Stripe can't
+  // pre-schedule non-renewal).
+  note?: string;
+};
+
+const TIERS: Tier[] = [
+  {
+    name: "Free",
+    price: (
+      <span className="text-4xl font-semibold tracking-tight tabular-nums">
+        $0
+      </span>
+    ),
+    tagline: "The full outliner, forever.",
+    features: [
+      "Everything in the editor — daily notes, tags, filters, real-time sync.",
+      "Up to 10,000 nodes.",
+      "Export everything, anytime — OPML and Markdown.",
+      "Hit the cap and nothing locks: keep reading, editing, and exporting. You just can't add new nodes until you upgrade.",
+    ],
+  },
+  {
+    name: "Unlimited",
+    label: "Recommended",
+    accent: true,
+    price: (
+      <div>
+        <span className="text-4xl font-semibold tracking-tight tabular-nums">
+          $5
+        </span>
+        <span className="ml-1.5 text-sm text-muted-foreground">/mo</span>
+        <p className="mt-1.5 font-mono text-xs text-muted-foreground">
+          or $48/yr — that's $4/mo, billed yearly
+        </p>
+      </div>
+    ),
+    tagline: "For everything you're building.",
+    features: [
+      "Everything in Free.",
+      "Unlimited nodes.",
+      "AI agents — connect Claude and other agents to your outline over MCP.",
+    ],
+  },
+  {
+    name: "Founding",
+    label: "Limited — 50 seats",
+    distinct: true,
+    price: (
+      <div>
+        <span className="text-4xl font-semibold tracking-tight tabular-nums">
+          $99
+        </span>
+        <span className="ml-1.5 text-sm text-muted-foreground">
+          for 3 years
+        </span>
+      </div>
+    ),
+    tagline: "Back Dotflowy early, lock in three years.",
+    features: [
+      "Everything in Unlimited.",
+      "One payment covers three full years.",
+    ],
+    note: "Renews after 3 years unless you cancel — cancel anytime.",
+  },
+];
+
+function PricingCard({ tier }: { tier: Tier }) {
+  return (
+    <div
+      className={cn(
+        "rounded-xl border p-6 sm:p-7",
+        tier.distinct ? "bg-secondary" : "bg-card",
+        tier.accent
+          ? "border-brand-blue/40 ring-brand-blue/20 ring-1"
+          : "border-border",
+      )}
+    >
+      {tier.label && (
+        <p
+          className={cn(
+            "font-mono text-[11px] font-medium tracking-wider uppercase",
+            tier.accent ? "text-brand-blue" : "text-muted-foreground",
+          )}
+        >
+          {tier.label}
+        </p>
+      )}
+      <h3
+        className={cn(
+          "mt-1 text-lg font-semibold tracking-tight",
+          tier.accent && "text-brand-blue",
+        )}
+      >
+        {tier.name}
+      </h3>
+      <div className="mt-3">{tier.price}</div>
+      <p className="mt-3 text-[15px] text-muted-foreground">{tier.tagline}</p>
+      <ul className="mt-5 space-y-2.5 text-[15px] text-muted-foreground">
+        {tier.features.map((f) => (
+          <li key={f} className="flex items-start gap-2.5">
+            {/* mt centers the dot on the first text line when a line wraps */}
+            <Dot className="mt-2" />
+            <span>{f}</span>
+          </li>
+        ))}
+      </ul>
+      {tier.note && (
+        <p className="mt-5 border-t border-border/60 pt-4 font-mono text-xs leading-relaxed text-muted-foreground">
+          {tier.note}
+        </p>
+      )}
+    </div>
+  );
+}
+
+/** Pricing. Three tiers, one emphasized (Unlimited), Founding as the distinct
+ * limited offer. Checkout is invite-gated during beta, so every card's action is
+ * the same honest one: join the waitlist. */
+function Pricing() {
+  return (
+    <section className="border-t border-border/60">
+      <div className="mx-auto w-full max-w-2xl px-6 py-20 sm:py-24">
+        <Reveal>
+          <h2 className="text-3xl font-semibold tracking-tight text-balance sm:text-4xl">
+            Honest pricing.
+          </h2>
+          <p className="mt-4 max-w-xl text-[15px] leading-relaxed text-pretty text-muted-foreground">
+            Start free. Upgrade when you outgrow it. Your outline is always
+            yours to export — OPML or Markdown, on any plan.
+          </p>
+        </Reveal>
+
+        <div className="mt-10 flex flex-col gap-4">
+          {TIERS.map((tier, i) => (
+            <Reveal key={tier.name} delay={i * 70}>
+              <PricingCard tier={tier} />
+            </Reveal>
+          ))}
+        </div>
+
+        <Reveal delay={TIERS.length * 70} className="mt-8">
+          <LinkButton
+            href="#waitlist"
+            size="lg"
+            className="h-11 px-5 text-[15px]"
+          >
+            Join the waitlist
+          </LinkButton>
+          <p className="mt-3 font-mono text-xs text-muted-foreground">
+            Dotflowy is in invite beta — join the waitlist and we'll send you an
+            invite.
+          </p>
+        </Reveal>
       </div>
     </section>
   );
@@ -253,6 +485,7 @@ export function Landing() {
       <Nav />
       <main className="flex-1">
         <Hero />
+        <Pricing />
       </main>
       <Footer />
     </div>


### PR DESCRIPTION
## Summary

Adds a **pricing section** to the dotflowy.com landing page (ticket #171, landing half), below the hero/waitlist. Three tiers, styled to read as a continuation of the existing page — same type scale, tokens, `Dot`, and `LinkButton`. Checkout is invite-gated during beta, so no card links to Stripe; the section's one CTA smooth-scrolls to the existing waitlist form.

## Changes

- **New `Pricing` section** in `landing/src/components/Landing.tsx` (single file; reuses existing helpers):
  - **Free — $0**: full outliner, 10,000 nodes, export always free, with the honest "hit the cap and nothing locks" framing.
  - **Unlimited — $5/mo or $48/yr** ($4/mo billed yearly): the emphasized tier (brand-blue accent + ring, "Recommended"), unlimited nodes + AI agents over MCP.
  - **Founding — $99 for 3 years**: the distinct limited offer (muted fill, "Limited — 50 seats" static copy), with the required renewal disclosure: *"Renews after 3 years unless you cancel — cancel anytime."*
- **`Reveal` wrapper**: subtle scroll-reveal (opacity + 8px translateY, strong ease-out, 300ms, staggered ~70ms), honours `prefers-reduced-motion` (shows instantly, no movement).
- Added `id="waitlist"` + `scroll-mt-20` to the hero waitlist wrapper so the CTA anchor lands cleanly (site already has global `scroll-behavior: smooth`).
- Empty changeset (`.changeset/flat-worlds-stare.md`) — landing-only, intentionally not app changelog news.

## Flow

`<a href="#waitlist">` CTA → native smooth-scroll to the hero `WaitlistForm` (unchanged). No new network calls, no checkout, no seat-count fetch.

## Breaking

None. Landing-only; no app, worker, or shared code touched.

## Test plan

- `bun run typecheck` and `bun run build` (with prerender) green.
- Drove it in the browser (`vite dev`): verified **desktop + mobile (390px)**, **light + dark** — cards stack cleanly, blue accent reads on the Unlimited card only, Founding's muted fill + disclosure render correctly.
- Confirmed the CTA sets `#waitlist` and the target exists (smooth-scroll works), and the `Reveal` IntersectionObserver flips content from opacity-0 → visible on scroll.
- `/code-review` (high) run on the diff; applied the legit findings (reuse `LinkButton` for the CTA instead of a hand-rolled `<a>`; drop `will-change` after the one-shot reveal).

### Screenshots

Verified in-browser. Pricing section (mobile, both themes):

- **Dark**: "Honest pricing." heading → Free card ($0, dot-bulleted features) → Unlimited card (blue "RECOMMENDED" + blue tier name + blue ring, $5/mo + yearly subline) → Founding card (muted fill, "LIMITED — 50 SEATS", $99 for 3 years, hairline-separated renewal disclosure) → "Join the waitlist" CTA + invite-beta note.
- **Light**: identical layout, semantic tokens resolve to the light palette (white cards, grey Founding fill, dark CTA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
