### PR TITLE
fix(daily): opening a day note survives failed saves and races

### DIFF
--- a/.changeset/harden-daily-get-or-create.md
+++ b/.changeset/harden-daily-get-or-create.md
@@ -2,4 +2,4 @@
 "dotflowy": patch
 ---
 
-Opening or filing into a daily note is more reliable: creating today's note now waits for the write to durably land before navigating, so a failed save shows a clear message instead of dropping you on a note that vanishes, and "Send to Today" no longer misfiles a node when today's note was just created.
+Opening or filing into a daily note is more reliable: creating today's note now waits for the write to durably land before navigating, so a failed save shows a clear message instead of dropping you on a note that vanishes, and "Send to Today" no longer misfiles a node when today's note was just created. Quick-add now keeps your draft and shows an error if today's note can't be opened (instead of silently filing the capture at the top level), and hitting the free-plan limit while opening a daily note shows only the upgrade notice, not a second generic error.

--- a/.changeset/harden-daily-get-or-create.md
+++ b/.changeset/harden-daily-get-or-create.md
@@ -1,0 +1,5 @@
+---
+"dotflowy": patch
+---
+
+Opening or filing into a daily note is more reliable: creating today's note now waits for the write to durably land before navigating, so a failed save shows a clear message instead of dropping you on a note that vanishes, and "Send to Today" no longer misfiles a node when today's note was just created.

--- a/src/components/quick-add.tsx
+++ b/src/components/quick-add.tsx
@@ -82,6 +82,7 @@ import {
   setText,
   toggleCompleted,
 } from "../data/mutations";
+import { isNodesLimitError } from "../data/nodes-client-effect";
 import { appRuntime } from "../data/runtime";
 import { runStructural } from "../data/structural";
 import {
@@ -709,17 +710,22 @@ function QuickAddOverlay({ onClose }: { onClose: () => void }) {
       // The destination provider (Seam L) REJECTS when it named a target it
       // couldn't mint (F2) -- a failure, NOT the legit `null` = "top level". Abort
       // the born: create NOTHING, keep the draft text + the overlay so nothing is
-      // lost, and surface it once. Returning null below releases the cached
-      // promise, so a later keystroke retries. An untouched draft that never typed
-      // won't reach here (born fires only on non-empty input).
+      // lost, and surface it once -- unless the rejection is the free-tier cap
+      // (`isNodesLimitError`), whose dedicated upgrade toast already fired
+      // (persistStructuralBatch), so the generic notice would double-toast.
+      // Returning null below releases the cached promise, so a later keystroke
+      // retries. An untouched draft that never typed won't reach here (born
+      // fires only on non-empty input).
       let resolved: string | null;
       try {
         resolved = await d.resolveParent();
-      } catch {
-        toast.error(`Couldn't open ${destRef.current.label}`, {
-          id: "quick-add-destination-failed",
-          description: "Check your connection and try again.",
-        });
+      } catch (err) {
+        if (!isNodesLimitError(err)) {
+          toast.error(`Couldn't open ${destRef.current.label}`, {
+            id: "quick-add-destination-failed",
+            description: "Check your connection and try again.",
+          });
+        }
         return null;
       }
       if (d.text.trim() === "") return null; // empty -> no node

--- a/src/components/quick-add.tsx
+++ b/src/components/quick-add.tsx
@@ -706,7 +706,22 @@ function QuickAddOverlay({ onClose }: { onClose: () => void }) {
       await prev; // preserve create order across drafts (bug 6)
       await awaitResolveGate(); // deferred-resolve test seam
       if (d.id) return d.id;
-      const resolved = await d.resolveParent();
+      // The destination provider (Seam L) REJECTS when it named a target it
+      // couldn't mint (F2) -- a failure, NOT the legit `null` = "top level". Abort
+      // the born: create NOTHING, keep the draft text + the overlay so nothing is
+      // lost, and surface it once. Returning null below releases the cached
+      // promise, so a later keystroke retries. An untouched draft that never typed
+      // won't reach here (born fires only on non-empty input).
+      let resolved: string | null;
+      try {
+        resolved = await d.resolveParent();
+      } catch {
+        toast.error(`Couldn't open ${destRef.current.label}`, {
+          id: "quick-add-destination-failed",
+          description: "Check your connection and try again.",
+        });
+        return null;
+      }
       if (d.text.trim() === "") return null; // empty -> no node
       // A retarget that landed after we called resolveParent wins at create time.
       const target = d.desiredParent ? d.desiredParent.value : resolved;

--- a/src/data/nodes-client-effect.ts
+++ b/src/data/nodes-client-effect.ts
@@ -75,6 +75,13 @@ export class NodesLimitError extends Data.TaggedError("NodesLimitError")<{
   }
 }
 
+/** Was this the free-tier node-ceiling refusal (#170)? The cap has its own
+ *  upgrade toast (structural.ts), so failure funnels use this to SKIP a generic
+ *  "couldn't save/open" notice and avoid double-toasting the same event. */
+export function isNodesLimitError(err: unknown): err is NodesLimitError {
+  return err instanceof NodesLimitError;
+}
+
 export type NodesError =
   | NodesTransportError
   | NodesResponseError

--- a/src/data/save-failure.ts
+++ b/src/data/save-failure.ts
@@ -1,6 +1,6 @@
 import { toast } from "sonner";
 
-import { NodesLimitError } from "./nodes-client-effect";
+import { isNodesLimitError } from "./nodes-client-effect";
 
 /**
  * The shared "your write didn't land" signal for the core outline path (#230).
@@ -22,7 +22,7 @@ import { NodesLimitError } from "./nodes-client-effect";
  *    not N stacked toasts. Sonner de-dupes on the id.
  */
 export function notifySaveFailed(err: unknown): void {
-  if (err instanceof NodesLimitError) return;
+  if (isNodesLimitError(err)) return;
   toast.error("Couldn't save your changes", {
     id: "save-failed",
     description:

--- a/src/data/structural.ts
+++ b/src/data/structural.ts
@@ -93,6 +93,9 @@ export function runStructuralTracked<T>(body: () => T): {
   // Join the outer transaction so the whole flow is ONE frame; never open a
   // second (which would re-tear the very thing we're fixing). The outer
   // transaction owns persistence, so there is nothing separate to track.
+  // CONSTRAINT: this `persisted` resolves INSTANTLY (carries no durability
+  // guarantee), so a persist-gated flow (e.g. daily #233's materializeNewDay,
+  // which navigates only after `persisted`) must NEVER run nested.
   if (getActiveTransaction())
     return { result: body(), persisted: Promise.resolve() };
 

--- a/src/plugins/daily/index.tsx
+++ b/src/plugins/daily/index.tsx
@@ -58,7 +58,11 @@ import {
   moveNode,
   setText,
 } from "../../data/mutations";
-import { runStructural, runStructuralSliced } from "../../data/structural";
+import {
+  runStructural,
+  runStructuralSliced,
+  runStructuralTracked,
+} from "../../data/structural";
 import { buildTreeIndex, childrenOf, createId } from "../../data/tree";
 import {
   definePlugin,
@@ -225,7 +229,7 @@ async function materializeNewDay(
   if (claimed.some((c) => !c.won && !c.present)) resyncNodes();
 
   const parentId = chain && week ? week.id : container.id;
-  runStructural(() => {
+  const { persisted } = runStructuralTracked(() => {
     // Container: appended at the end of the top level (special, not sorted).
     if (!hasNode(container.id)) {
       const tops = childrenOf(buildTreeIndex(nodesCollection.toArray), null);
@@ -263,6 +267,19 @@ async function materializeNewDay(
     if (seedEntryLine && !hasChildInLiveCollection(day.id))
       appendChild(day.id, null, "");
   });
+  // Phantom-success guard (#233): the optimistic overlay makes `hasNode(day.id)`
+  // true the instant the batch applies, so returning here unconditionally would
+  // let a caller `setMapping` + navigate to a day that VANISHES when the send
+  // fails and rolls back. Gate the ok-return on the batch's durable echo (the
+  // OPML-import discipline, ADR 0037): a rejected persist means nothing landed,
+  // so return null and let the caller surface its "couldn't open" toast. The
+  // already-exists path (healExistingDay) stays synchronous -- its node is
+  // already durable, so there is nothing to wait on.
+  try {
+    await persisted;
+  } catch {
+    return null;
+  }
   return hasNode(day.id) ? day.id : null;
 }
 
@@ -736,11 +753,17 @@ export default definePlugin({
           return;
         }
         if (todayId === nodeId) return; // can't move today's note under itself
-        const kids = childrenOf(ctx.tree, todayId);
+        // Rebuild fresh: today may have just been created, so ctx.tree is stale
+        // (no new day, no `after`) and reading its siblings would wire the move
+        // against a stale head -- a sibling fan (#233). Read the live collection
+        // instead, mirroring the runMany + mirror-to-today paths. Capture AFTER,
+        // so undo restores the move without deleting the fresh day note.
+        const index = buildTreeIndex(nodesCollection.toArray);
+        const kids = childrenOf(index, todayId);
         const after = kids.length ? kids[kids.length - 1]!.id : null;
         const moved = runStructural(() => {
-          capture(ctx.tree, nodeId);
-          return moveNode(ctx.tree, nodeId, todayId, after);
+          capture(index, nodeId);
+          return moveNode(index, nodeId, todayId, after);
         });
         // No-op move (already last child of today) still captured an undo
         // point; drop it so Cmd+Z isn't a dead step and redo history survives.

--- a/src/plugins/daily/index.tsx
+++ b/src/plugins/daily/index.tsx
@@ -58,6 +58,7 @@ import {
   moveNode,
   setText,
 } from "../../data/mutations";
+import { isNodesLimitError } from "../../data/nodes-client-effect";
 import {
   runStructural,
   runStructuralSliced,
@@ -191,6 +192,14 @@ function healExistingDay(
   }
 }
 
+/** Outcome of a NEW-day create. `id` non-null = the durable day node. `id` null
+ *  = the create failed and rolled back; `capped` distinguishes the free-tier
+ *  ceiling (#170, its upgrade toast ALREADY fired -- callers skip the generic
+ *  one, F3) from every other failure (which wants the generic toast). Contained
+ *  to {@link materializeNewDay} <-> {@link getOrCreateDay}; the latter translates
+ *  it back to `string | null` for external callers. */
+type NewDayResult = { id: string } | { id: null; capped: boolean };
+
 /**
  * Materialize a genuinely NEW day and whichever calendar levels above it are
  * missing, in ONE structural batch (ADR 0009). Called only when the day node is
@@ -208,7 +217,7 @@ async function materializeNewDay(
   day: { id: string; won: boolean; present: boolean },
   key: string,
   seedEntryLine: boolean,
-): Promise<string | null> {
+): Promise<NewDayResult> {
   // The day is absent -> derive + claim its Y/M/W chain (concurrently). A
   // non-calendar key (defensive) lands the day directly under the container.
   const chain = dayKeyToScaffoldChain(key);
@@ -268,19 +277,25 @@ async function materializeNewDay(
       appendChild(day.id, null, "");
   });
   // Phantom-success guard (#233): the optimistic overlay makes `hasNode(day.id)`
-  // true the instant the batch applies, so returning here unconditionally would
-  // let a caller `setMapping` + navigate to a day that VANISHES when the send
-  // fails and rolls back. Gate the ok-return on the batch's durable echo (the
-  // OPML-import discipline, ADR 0037): a rejected persist means nothing landed,
-  // so return null and let the caller surface its "couldn't open" toast. The
-  // already-exists path (healExistingDay) stays synchronous -- its node is
-  // already durable, so there is nothing to wait on.
+  // true the instant the batch applies, so returning the id off it would let a
+  // caller `setMapping` + navigate to a day that VANISHES on a failed send. Gate
+  // the ok-return on the batch's durable echo (the OPML-import discipline, ADR
+  // 0037). Two null paths, both reported honestly:
+  //   1. PERSIST REJECTED -> the send failed and the overlay rolled back, so
+  //      nothing landed. `capped` = the free-tier ceiling (its upgrade toast
+  //      already fired, so the caller skips the generic one -- F3).
+  //   2. ECHO MISSING -> persist resolved but waitForSeqE COMPLETES on its 8s
+  //      timeout without failing (collection.ts), so `hasNode(day.id)` can be
+  //      false though the POST committed. `resyncNodes()` self-heals (the durable
+  //      mapping makes the next attempt succeed); report a non-cap failure (F4).
   try {
     await persisted;
-  } catch {
-    return null;
+  } catch (err) {
+    return { id: null, capped: isNodesLimitError(err) };
   }
-  return hasNode(day.id) ? day.id : null;
+  if (hasNode(day.id)) return { id: day.id };
+  resyncNodes();
+  return { id: null, capped: false };
 }
 
 /** Does `parentId` have any child in the LIVE nodes collection? Used for the
@@ -461,6 +476,16 @@ async function runDailyMigration(
   toast.success("Organized your daily notes by week");
 }
 
+/** In-flight NEW-day creates, keyed by date key (F1). A create's optimistic
+ *  rows + mapping exist the instant its batch applies, but its DURABILITY isn't
+ *  confirmed until the echo lands -- so a concurrent caller for the SAME key
+ *  reading those optimistic rows would return a phantom id (the #233 defect,
+ *  re-openable because quick-add borns with `trackNavigation:false` and
+ *  `withDailyNavigation` is a counter, not a mutex). A same-key second caller
+ *  JOINS the entry here instead of re-running the fast path. Only the CREATE
+ *  path registers, so an already-durable day never touches this map. */
+const inFlightDays = new Map<string, Promise<string | null>>();
+
 /** Ensure the container + the day exist and return the day's node id (no nav).
  *  Reads the LIVE collection throughout (not a passed index) so the Today button,
  *  the `/` command, AND the Cmd+K virtual action (Seam J -- which has no
@@ -468,9 +493,26 @@ async function runDailyMigration(
  *  Async: it may round-trip the atomic claims before the node ids are settled. */
 async function getOrCreateDay(
   key: string,
-  opts?: { seedEntryLine?: boolean; trackNavigation?: boolean },
+  opts?: {
+    seedEntryLine?: boolean;
+    trackNavigation?: boolean;
+    /** Copy for the generic "couldn't open" toast when a NEW-day CREATE fails
+     *  for a NON-cap reason (F3 -- the cap already toasted its upgrade notice, so
+     *  this funnel skips it). `null` SUPPRESSES the toast (quick-add owns its own
+     *  failure toast via startBorn, ADR 0049). Default: today's-note copy. */
+    failureToast?: string | null;
+  },
 ): Promise<string | null> {
   const run = async () => {
+    // Single-flight join, checked FIRST (F1): while a same-key create is in
+    // flight, the claims + `day.present` fast path below read the creator's
+    // OPTIMISTIC rows (the claim already set the mapping, the batch already
+    // applied locally) -- durability pending -- so they'd return a phantom via
+    // healExistingDay without ever reaching the create path's check. The present
+    // fast path cannot be trusted while a create is in flight; join it instead.
+    // With nothing in flight, the genuinely-durable fast path runs untouched.
+    const joined = inFlightDays.get(key);
+    if (joined) return joined;
     // Freshest cross-device mappings before placement OR the migration plan
     // (finding 4): a cold load hasn't fetched the index yet, and remote-created
     // days' MAPPINGS aren't broadcast -- either leaves sorted insertion / the
@@ -492,7 +534,32 @@ async function getOrCreateDay(
       healExistingDay(day.id, key, opts?.seedEntryLine ?? false);
       return day.id;
     }
-    return materializeNewDay(container, day, key, opts?.seedEntryLine ?? false);
+    // Re-check at the create seam (F1): a caller that entered run() BEFORE this
+    // create registered (the top check saw nothing) can land here after its own
+    // claims -- join rather than double-create. Registered synchronously (no
+    // await between the materializeNewDay call and the `set`), deleted in
+    // `finally`. A joiner inherits this create's seed decision.
+    const inFlight = inFlightDays.get(key);
+    if (inFlight) return inFlight;
+    const creating = materializeNewDay(
+      container,
+      day,
+      key,
+      opts?.seedEntryLine ?? false,
+    ).then((result) => {
+      if (result.id !== null) return result.id;
+      // Translate NewDayResult -> string|null for external callers, owning the
+      // generic toast HERE so every caller drops its duplicate (F3). The cap
+      // case already showed its upgrade toast; `null` copy suppresses (quick-add).
+      if (!result.capped && opts?.failureToast !== null)
+        toast.error(opts?.failureToast ?? "Couldn't open today's daily note");
+      return null;
+    });
+    inFlightDays.set(key, creating);
+    void creating.finally(() => {
+      if (inFlightDays.get(key) === creating) inFlightDays.delete(key);
+    });
+    return creating;
   };
   // `trackNavigation: false` skips the shared nav-pending signal (ADR 0049): a
   // background quick-add born resolves today's note WITHOUT spinning the
@@ -505,11 +572,10 @@ export { getOrCreateDay };
 /** get-or-create the day, then zoom to it -- a date-chip click (a reference,
  *  seed-free; the Today button navigates the route with focus=last instead). */
 async function goToDate(key: string, ctx: PluginContext): Promise<void> {
-  const dayId = await getOrCreateDay(key);
-  if (!dayId) {
-    toast.error("Couldn't open that daily note");
-    return;
-  }
+  const dayId = await getOrCreateDay(key, {
+    failureToast: "Couldn't open that daily note",
+  });
+  if (!dayId) return; // getOrCreateDay owns the generic toast now (F3)
   ctx.nav.zoom(dayId);
 }
 
@@ -551,10 +617,7 @@ function TodayButton({ getCtx }: { getCtx: () => PluginContext }) {
             const dayId = await getOrCreateDay(localDateKey(), {
               seedEntryLine: true,
             });
-            if (!dayId) {
-              toast.error("Couldn't open today's daily note");
-              return;
-            }
+            if (!dayId) return; // getOrCreateDay owns the generic toast now (F3)
             navigate({
               to: "/$nodeId",
               params: { nodeId: dayId },
@@ -748,22 +811,15 @@ export default definePlugin({
       available: () => true,
       run: async (nodeId, ctx) => {
         const todayId = await getOrCreateDay(localDateKey());
-        if (!todayId) {
-          toast.error("Couldn't open today's daily note");
-          return;
-        }
+        if (!todayId) return; // getOrCreateDay owns the generic toast now (F3)
         if (todayId === nodeId) return; // can't move today's note under itself
-        // Rebuild fresh: today may have just been created, so ctx.tree is stale
-        // (no new day, no `after`) and reading its siblings would wire the move
-        // against a stale head -- a sibling fan (#233). Read the live collection
-        // instead, mirroring the runMany + mirror-to-today paths. Capture AFTER,
-        // so undo restores the move without deleting the fresh day note.
-        const index = buildTreeIndex(nodesCollection.toArray);
-        const kids = childrenOf(index, todayId);
-        const after = kids.length ? kids[kids.length - 1]!.id : null;
+        // Reuse moveManyNodes (F5): it rebuilds the index per move and appends
+        // as today's last child -- identical to the old hand-rolled block and the
+        // runMany twin below. Capture the FRESH index (today may have just been
+        // created), so undo restores the move without deleting the new day note.
         const moved = runStructural(() => {
-          capture(index, nodeId);
-          return moveNode(index, nodeId, todayId, after);
+          capture(buildTreeIndex(nodesCollection.toArray), nodeId);
+          return moveManyNodes(todayId, [nodeId]);
         });
         // No-op move (already last child of today) still captured an undo
         // point; drop it so Cmd+Z isn't a dead step and redo history survives.
@@ -784,10 +840,7 @@ export default definePlugin({
       // deleting the new day note.
       runMany: async (ids, ctx) => {
         const todayId = await getOrCreateDay(localDateKey());
-        if (!todayId) {
-          toast.error("Couldn't open today's daily note");
-          return;
-        }
+        if (!todayId) return; // getOrCreateDay owns the generic toast now (F3)
         const targets = ids.filter((id) => id !== todayId);
         if (targets.length === 0) return;
         const moved = runStructural(() => {
@@ -817,10 +870,7 @@ export default definePlugin({
       available: () => isMirrorsEnabled(),
       run: async (nodeId, ctx) => {
         const todayId = await getOrCreateDay(localDateKey());
-        if (!todayId) {
-          toast.error("Couldn't open today's daily note");
-          return;
-        }
+        if (!todayId) return; // getOrCreateDay owns the generic toast now (F3)
         // Rebuild fresh: today may have just been created, so ctx.tree is stale
         // (no `after`, no cycle context). Capture AFTER, so undo removes the
         // mirror but keeps the new day note (mirrors the runMany path below).
@@ -843,10 +893,7 @@ export default definePlugin({
       // undo removes the mirrors without deleting the freshly created day note.
       runMany: async (ids, ctx) => {
         const todayId = await getOrCreateDay(localDateKey());
-        if (!todayId) {
-          toast.error("Couldn't open today's daily note");
-          return;
-        }
+        if (!todayId) return; // getOrCreateDay owns the generic toast now (F3)
         const made = runStructural(() => {
           capture(buildTreeIndex(nodesCollection.toArray), ids[0]!);
           return mirrorManyNodes(todayId, ids);
@@ -955,10 +1002,20 @@ export default definePlugin({
   // open never mints today's note. Core resolves this without importing daily.
   captureDestination: () => ({
     label: "Today",
-    resolve: () =>
-      getOrCreateDay(localDateKey(), {
+    // REJECT on a failed create rather than returning null (F2): null is the
+    // Seam-L value for "top level", so a swallowed failure would silently misfile
+    // the capture at the outline root. `failureToast: null` suppresses daily's
+    // own generic toast -- quick-add's startBorn owns the failure toast + keeps
+    // the draft (ADR 0049). A durable id passes straight through.
+    resolve: async () => {
+      const id = await getOrCreateDay(localDateKey(), {
         trackNavigation: false,
-      }),
+        failureToast: null,
+      });
+      if (id === null)
+        throw new Error("daily: couldn't open today's note for quick-add");
+      return id;
+    },
   }),
 
   // Seam J: a VIRTUAL switcher row that appears only when today's note does NOT
@@ -981,9 +1038,11 @@ export default definePlugin({
         // line and land the caret on it via focus=last.
         run: () =>
           void getOrCreateDay(key, { seedEntryLine: true })
+            // getOrCreateDay owns the generic failure toast now (F3); this only
+            // navigates on success. The catch is defensive (a synchronous body
+            // throw), mutually exclusive with the internal toast, so no double.
             .then((id) => {
               if (id) ctx.goTo(id, { focus: "last" });
-              else toast.error("Couldn't open today's daily note");
             })
             .catch(() => toast.error("Couldn't open today's daily note")),
       },

--- a/src/plugins/daily/index.tsx
+++ b/src/plugins/daily/index.tsx
@@ -192,13 +192,14 @@ function healExistingDay(
   }
 }
 
-/** Outcome of a NEW-day create. `id` non-null = the durable day node. `id` null
- *  = the create failed and rolled back; `capped` distinguishes the free-tier
- *  ceiling (#170, its upgrade toast ALREADY fired -- callers skip the generic
- *  one, F3) from every other failure (which wants the generic toast). Contained
- *  to {@link materializeNewDay} <-> {@link getOrCreateDay}; the latter translates
- *  it back to `string | null` for external callers. */
-type NewDayResult = { id: string } | { id: null; capped: boolean };
+/** Outcome of a day get-or-create. `id` non-null = the durable day node. `id`
+ *  null = the create failed and rolled back; `cause` is the persist rejection
+ *  (null on the echo-missing tail) so callers can distinguish the free-tier
+ *  ceiling (#170, `isNodesLimitError` -- its upgrade toast ALREADY fired, F3)
+ *  and quick-add's Seam-L rejection can rethrow the REAL NodesLimitError.
+ *  Contained to this module; {@link getOrCreateDay} translates it back to
+ *  `string | null` for external callers. */
+type NewDayResult = { id: string } | { id: null; cause: unknown };
 
 /**
  * Materialize a genuinely NEW day and whichever calendar levels above it are
@@ -282,20 +283,21 @@ async function materializeNewDay(
   // the ok-return on the batch's durable echo (the OPML-import discipline, ADR
   // 0037). Two null paths, both reported honestly:
   //   1. PERSIST REJECTED -> the send failed and the overlay rolled back, so
-  //      nothing landed. `capped` = the free-tier ceiling (its upgrade toast
-  //      already fired, so the caller skips the generic one -- F3).
+  //      nothing landed. `cause` carries the rejection so each caller can make
+  //      its OWN cap-vs-generic toast call (F3) and quick-add's Seam-L rejection
+  //      can rethrow a real NodesLimitError.
   //   2. ECHO MISSING -> persist resolved but waitForSeqE COMPLETES on its 8s
   //      timeout without failing (collection.ts), so `hasNode(day.id)` can be
   //      false though the POST committed. `resyncNodes()` self-heals (the durable
-  //      mapping makes the next attempt succeed); report a non-cap failure (F4).
+  //      mapping makes the next attempt succeed); a null `cause` = non-cap (F4).
   try {
     await persisted;
   } catch (err) {
-    return { id: null, capped: isNodesLimitError(err) };
+    return { id: null, cause: err };
   }
   if (hasNode(day.id)) return { id: day.id };
   resyncNodes();
-  return { id: null, capped: false };
+  return { id: null, cause: null };
 }
 
 /** Does `parentId` have any child in the LIVE nodes collection? Used for the
@@ -483,27 +485,21 @@ async function runDailyMigration(
  *  re-openable because quick-add borns with `trackNavigation:false` and
  *  `withDailyNavigation` is a counter, not a mutex). A same-key second caller
  *  JOINS the entry here instead of re-running the fast path. Only the CREATE
- *  path registers, so an already-durable day never touches this map. */
-const inFlightDays = new Map<string, Promise<string | null>>();
+ *  path registers, so an already-durable day never touches this map. The map
+ *  caches the RAW {@link NewDayResult} -- never a toast-translated chain -- so
+ *  every joiner evaluates its OWN toast/rejection decision on the shared result
+ *  (a baked-in side effect would inherit the ORIGINATOR's copy/suppression). */
+const inFlightDays = new Map<string, Promise<NewDayResult>>();
 
-/** Ensure the container + the day exist and return the day's node id (no nav).
- *  Reads the LIVE collection throughout (not a passed index) so the Today button,
- *  the `/` command, AND the Cmd+K virtual action (Seam J -- which has no
- *  `PluginContext`) all reuse the exact same get-or-create (ADR 0001).
- *  Async: it may round-trip the atomic claims before the node ids are settled. */
-async function getOrCreateDay(
+/** The shared get-or-create body: readiness + claims + migration + heal-or-
+ *  create, single-flighted per key. Returns the RAW {@link NewDayResult} and
+ *  performs NO toasting -- callers ({@link getOrCreateDay}, the Seam-L
+ *  `captureDestination.resolve`) each translate per their own surface. */
+async function getOrCreateDayResult(
   key: string,
-  opts?: {
-    seedEntryLine?: boolean;
-    trackNavigation?: boolean;
-    /** Copy for the generic "couldn't open" toast when a NEW-day CREATE fails
-     *  for a NON-cap reason (F3 -- the cap already toasted its upgrade notice, so
-     *  this funnel skips it). `null` SUPPRESSES the toast (quick-add owns its own
-     *  failure toast via startBorn, ADR 0049). Default: today's-note copy. */
-    failureToast?: string | null;
-  },
-): Promise<string | null> {
-  const run = async () => {
+  opts?: { seedEntryLine?: boolean; trackNavigation?: boolean },
+): Promise<NewDayResult> {
+  const run = async (): Promise<NewDayResult> => {
     // Single-flight join, checked FIRST (F1): while a same-key create is in
     // flight, the claims + `day.present` fast path below read the creator's
     // OPTIMISTIC rows (the claim already set the mapping, the batch already
@@ -532,7 +528,7 @@ async function getOrCreateDay(
     // placement is the migration's job (finding 3).
     if (day.present) {
       healExistingDay(day.id, key, opts?.seedEntryLine ?? false);
-      return day.id;
+      return { id: day.id };
     }
     // Re-check at the create seam (F1): a caller that entered run() BEFORE this
     // create registered (the top check saw nothing) can land here after its own
@@ -546,15 +542,7 @@ async function getOrCreateDay(
       day,
       key,
       opts?.seedEntryLine ?? false,
-    ).then((result) => {
-      if (result.id !== null) return result.id;
-      // Translate NewDayResult -> string|null for external callers, owning the
-      // generic toast HERE so every caller drops its duplicate (F3). The cap
-      // case already showed its upgrade toast; `null` copy suppresses (quick-add).
-      if (!result.capped && opts?.failureToast !== null)
-        toast.error(opts?.failureToast ?? "Couldn't open today's daily note");
-      return null;
-    });
+    );
     inFlightDays.set(key, creating);
     void creating.finally(() => {
       if (inFlightDays.get(key) === creating) inFlightDays.delete(key);
@@ -565,6 +553,31 @@ async function getOrCreateDay(
   // background quick-add born resolves today's note WITHOUT spinning the
   // unrelated header "Today" button, which is reserved for an actual navigation.
   return opts?.trackNavigation === false ? run() : withDailyNavigation(run);
+}
+
+/** Ensure the container + the day exist and return the day's node id (no nav).
+ *  Reads the LIVE collection throughout (not a passed index) so the Today button,
+ *  the `/` command, AND the Cmd+K virtual action (Seam J -- which has no
+ *  `PluginContext`) all reuse the exact same get-or-create (ADR 0001).
+ *  Async: it may round-trip the atomic claims before the node ids are settled.
+ *  On a failed create THIS caller decides its own toast (F3): the cap skips the
+ *  generic notice (the upgrade toast already fired), everything else shows the
+ *  caller's `failureToast` copy -- per-caller even across an in-flight join. */
+async function getOrCreateDay(
+  key: string,
+  opts?: {
+    seedEntryLine?: boolean;
+    trackNavigation?: boolean;
+    /** Copy for the generic "couldn't open" toast when the create fails for a
+     *  NON-cap reason. Default: today's-note copy. */
+    failureToast?: string;
+  },
+): Promise<string | null> {
+  const result = await getOrCreateDayResult(key, opts);
+  if (result.id !== null) return result.id;
+  if (!isNodesLimitError(result.cause))
+    toast.error(opts?.failureToast ?? "Couldn't open today's daily note");
+  return null;
 }
 
 export { getOrCreateDay };
@@ -1004,17 +1017,18 @@ export default definePlugin({
     label: "Today",
     // REJECT on a failed create rather than returning null (F2): null is the
     // Seam-L value for "top level", so a swallowed failure would silently misfile
-    // the capture at the outline root. `failureToast: null` suppresses daily's
-    // own generic toast -- quick-add's startBorn owns the failure toast + keeps
-    // the draft (ADR 0049). A durable id passes straight through.
+    // the capture at the outline root. Consumes the RAW result (no daily toast --
+    // quick-add's startBorn owns the failure toast + keeps the draft, ADR 0049)
+    // and rethrows the REAL NodesLimitError on a cap hit, so quick-add can skip
+    // its generic toast (the upgrade one already fired) via the shared
+    // data-layer `isNodesLimitError` -- no core-imports-daily leak.
     resolve: async () => {
-      const id = await getOrCreateDay(localDateKey(), {
+      const result = await getOrCreateDayResult(localDateKey(), {
         trackNavigation: false,
-        failureToast: null,
       });
-      if (id === null)
-        throw new Error("daily: couldn't open today's note for quick-add");
-      return id;
+      if (result.id !== null) return result.id;
+      if (isNodesLimitError(result.cause)) throw result.cause;
+      throw new Error("daily: couldn't open today's note for quick-add");
     },
   }),
 

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -640,8 +640,11 @@ export interface CaptureDestination {
   label: string;
   /** Get-or-create (SEED-FREE) the node new captures append into as its LAST
    *  child -- invoked LAZILY at born-on-first-keystroke, never on open. Returns
-   *  the parent node id, or null for the top level / on failure. Async: it may
-   *  round-trip the daily atomic claim. */
+   *  the parent node id, or null for the TOP LEVEL. REJECTS on failure (F2): a
+   *  provider that named a destination but couldn't mint it is a failure, NOT
+   *  "top level" -- quick-add's startBorn catches the rejection, creates nothing,
+   *  keeps the draft, and toasts once (returning null here would silently misfile
+   *  the capture at the outline root). Async: it may round-trip the daily claim. */
   resolve(): Promise<string | null>;
 }
 


### PR DESCRIPTION
## Summary

Opening or filing into a daily note no longer trusts the optimistic overlay: day creation succeeds only when the write durably lands, and every surface that raced or misread that window (concurrent opens, Send to Today, quick-add) now behaves honestly on failure. Audit finding 5 from #159.

Fixes #233

## Changes

1. Creating a day note waits for the write to durably land before navigating — a failed save shows one clear error instead of dropping you on a note that vanishes (offline, first-of-day open now reports failure rather than opening a doomed note; a deliberate correctness-for-availability trade).
2. Concurrent opens of the same day join one in-flight creation instead of trusting another caller's optimistic rows (single-flight map consulted before the mapping fast path).
3. Send to Today wires the move against the day's live sibling state, so a just-created today can't misfile the node (now via the shared `moveManyNodes` append discipline).
4. Quick-add keeps your draft and shows an error when today's note can't be created, instead of silently filing the capture at the outline root under an "Added to Today" toast (Seam-L `resolve()` now rejects on failure).
5. Hitting the free-tier cap shows only the upgrade toast everywhere — including quick-add: the in-flight map shares the raw result so each caller evaluates its own toast, and the actual `NodesLimitError` rides the Seam-L rejection for quick-add to suppress its generic copy.
6. A creation whose persist succeeded but whose echo never arrived resyncs and returns failure honestly (self-heals next attempt) instead of an undocumented spurious-error path; `runStructuralTracked`'s nested instant-resolve caveat is now documented.

**Start here:** change 2 — the in-flight join must run *before* the `day.present` fast path, because that path reads optimistic state and can't be trusted while a create is in flight.

## Test plan

- `bun run typecheck` / `typecheck:worker` / `typecheck:test` / `lint` — pass
- `bun run test` — 773 pass, 0 fail
- `bun run test:e2e` (workers=2) — 342 passed; 9 failures in untouched specs (atomic-structural-writes, breadcrumb-mobile, changelog) re-ran clean serially — the documented parallel-contention flake
- `bun run test:e2e:serial -- e2e/daily-notes.spec.ts e2e/quick-add.spec.ts` — 47 passed
- `/code-review` high: 8 finder angles → 10 verified candidates → 6 fixed here, 1 pre-existing spun off as #290, 1 refuted, 2 disclosed
- **Needs manual check:** drive a failed day-create against the live Worker (kill `wrangler dev` mid-create) to see the error toast, and confirm quick-add keeps the draft — the e2e mock can't fail the persist on this path

🤖 Generated with [Claude Code](https://claude.com/claude-code)
