### PR TITLE
fix(sync): recover the sync consumer instead of dying silently

### DIFF
--- a/.changeset/supervise-sync-consumer.md
+++ b/.changeset/supervise-sync-consumer.md
@@ -1,0 +1,5 @@
+---
+"dotflowy": patch
+---
+
+Supervise the live-sync consumer so a bad inbound frame can no longer silently kill sync: the fiber now logs the failure and re-establishes (fetching a fresh snapshot) up to a bounded budget, then shows a persistent "Sync interrupted — reload" notice instead of dying quietly while the connection still looks alive.

--- a/docs/adr/0053-supervise-the-sync-consumer-fiber.md
+++ b/docs/adr/0053-supervise-the-sync-consumer-fiber.md
@@ -49,6 +49,15 @@ the failure-handling policy out as a pure, unit-tested function.
   (`notifySyncInterrupted`, same sonner mechanism as the #230 save-failure
   notice). The session can no longer die silently.
 
+The budget counts a **streak, not a lifetime**: the wiring layer records
+`lastFailureAt` and runs it through `nextStreak` (pure, unit-tested; the clock
+stays out of `decideSyncRecovery`). A failure landing more than
+`SYNC_STREAK_RESET_AFTER` (60s) after the previous one starts a fresh streak at
+0 — the intervening recovery evidently held, so its spent budget is forgiven.
+This mirrors the transport's reset-after-stable (`STABLE_AFTER`, ADR 0013) one
+layer up. Without it, a tab open for days would flip the give-up toast on its
+4th _ever_ transient glitch, even though each recovered fine.
+
 The recovery loop lives on the same fiber that cleanup interrupts, so
 `Fiber.interrupt(fiber)` still tears everything down — whether it's mid-drain,
 mid-backoff, or mid-reestablish. Additive only: `applyMessage`, the wire
@@ -62,8 +71,15 @@ protocol, and the cleanup/interrupt path are unchanged.
   loop.
 - **Interruption is explicitly excluded from the fault path.** `catchCause` sees
   interrupts too; the `hasInterruptsOnly` gate is load-bearing. An intentional
-  teardown never triggers a re-establish or the toast. This is the one thing the
-  unit tests pin hardest.
+  teardown _effectively_ never triggers a re-establish or the toast — the only
+  exception is an astronomically narrow race where a defect lands at the same
+  moment as the teardown interrupt on the final budget-exhausting drain: the
+  combined Die+Interrupt cause fails `hasInterruptsOnly`, decides GiveUp, and
+  the toast's `Effect.sync` runs before the interrupt wins. Accepted: the
+  outcome is one stray (dismissible) toast during a teardown that required a
+  real defect to coincide, and closing the window would cost an uninterruptible
+  region around the whole handler. This is the one thing the unit tests pin
+  hardest (the deterministic split, not the race).
 - **The policy is pure and testable.** The interrupt-vs-fault split, the budget
   boundary, and the backoff schedule are covered by `sync-supervision.test.ts`
   without driving the socket. The Effect wiring (catchCause + re-establish on the
@@ -73,6 +89,12 @@ protocol, and the cleanup/interrupt path are unchanged.
   and socket. The previous run's scope (and its WS) already finalized when the
   drain failed, so there's no double-subscribe — the socket's own scope finalizer
   is what closes the old WS, exactly as ADR 0013 intends.
+- **After GiveUp, `resyncNodes()` becomes a silent no-op.** The producer is dead
+  (its last run's scope finalized with the failed drain) and the module-level
+  `resyncFn` forks `resync` against orphaned refs no loop is watching. Harmless —
+  the persistent toast already says reload, which rebuilds everything — but
+  recorded so nobody expects the daily loser-path's resync to revive a
+  given-up session.
 
 ## Alternatives considered
 

--- a/docs/adr/0053-supervise-the-sync-consumer-fiber.md
+++ b/docs/adr/0053-supervise-the-sync-consumer-fiber.md
@@ -1,0 +1,86 @@
+# 53. Supervise the inbound-sync consumer fiber
+
+## Status
+
+Accepted.
+
+## Context
+
+The sync socket is an Effect scoped resource (ADR 0013): one long-lived fiber on
+`appRuntime` drains a `Stream<SyncEvent>` and folds each frame into the TanStack
+DB sync primitives via `applyMessage` (`collection.ts`). The fork was bare:
+
+    const fiber = appRuntime.runFork(Stream.runForEach(events, apply));
+
+`Stream.runForEach` runs the fold in an `Effect.sync`, so a throw inside
+`applyMessage` surfaces as a **defect** that DIES the fiber. Nothing restarts it.
+The failure mode is nasty and silent: the WebSocket still looks connected (its
+scope finalizer never runs — the fiber is dead, not interrupted), no frame is
+ever applied again, and because structural writes hold their overlay until their
+echo (ADR 0009), every one hangs its echo-wait to the 8s timeout with no signal
+to the user. The session is dead but looks alive.
+
+Today this is near-unreachable — the wire schema and the collection schema are
+field-for-field identical, and inbound frames are Schema-validated at decode
+(ADR 0014), so a malformed frame is dropped by the producer and never reaches
+`applyMessage`. But any future drift between the two schemas turns a one-frame
+glitch into a permanently, silently dead sync. The fork deserved cheap
+supervision.
+
+## Decision
+
+Wrap the drain in a self-recursive supervisor on **one outer fiber**, and split
+the failure-handling policy out as a pure, unit-tested function.
+
+`decideSyncRecovery(cause, recoveriesUsed)` (`sync-supervision.ts`) returns:
+
+- **Stop** when the cause is interrupt-only (`Cause.hasInterruptsOnly`) — cleanup
+  and same-page account switches tear the fiber down by interrupting it, and that
+  is teardown, not a fault. The supervisor re-raises the cause (`Effect.failCause`)
+  so the fiber terminates as interrupted; **no recovery, no toast**.
+- **Reestablish(delay)** for a genuine fault (a defect/throw) while a bounded
+  budget remains — log the cause (`console.error` + `Cause.pretty`, the house
+  convention) and re-open the stream after an exponential backoff. Recovery first
+  runs `resync` (force the next connection to ignore the cursor), so the server
+  replies with a fresh `snapshot` that truncates and replaces the collection —
+  healing a _transient_ one-frame glitch.
+- **GiveUp** once the budget (`SYNC_RECOVERY_BUDGET = 3`) is spent — stop retrying
+  and flip a **visible** persistent "Sync interrupted — reload" toast
+  (`notifySyncInterrupted`, same sonner mechanism as the #230 save-failure
+  notice). The session can no longer die silently.
+
+The recovery loop lives on the same fiber that cleanup interrupts, so
+`Fiber.interrupt(fiber)` still tears everything down — whether it's mid-drain,
+mid-backoff, or mid-reestablish. Additive only: `applyMessage`, the wire
+protocol, and the cleanup/interrupt path are unchanged.
+
+## Consequences
+
+- **A deterministically-poisonous frame can't hot-loop.** If a bad frame
+  re-poisons every snapshot, the budget caps re-establishes at 3 (500ms → 1s → 2s
+  backoff) before giving up to the visible notice — no unbounded snapshot-fetch
+  loop.
+- **Interruption is explicitly excluded from the fault path.** `catchCause` sees
+  interrupts too; the `hasInterruptsOnly` gate is load-bearing. An intentional
+  teardown never triggers a re-establish or the toast. This is the one thing the
+  unit tests pin hardest.
+- **The policy is pure and testable.** The interrupt-vs-fault split, the budget
+  boundary, and the backoff schedule are covered by `sync-supervision.test.ts`
+  without driving the socket. The Effect wiring (catchCause + re-establish on the
+  same fiber) is thin glue over the tested decision.
+- **Recovery re-runs `Stream.runForEach(events, …)`.** `events` is a
+  `Stream.callback`; each run starts a fresh connection loop with its own queue
+  and socket. The previous run's scope (and its WS) already finalized when the
+  drain failed, so there's no double-subscribe — the socket's own scope finalizer
+  is what closes the old WS, exactly as ADR 0013 intends.
+
+## Alternatives considered
+
+- **Visible state only (no recovery).** Flip the "reload" toast on any defect and
+  stop. Simpler, but forfeits self-healing of a transient glitch that a fresh
+  snapshot would fix. Kept as the give-up fallback, not the first response.
+- **Unbounded `Effect.retry`.** Rejected — a deterministic poison frame would
+  hot-loop snapshot fetches forever with no user signal.
+- **Reintroduce a callback socket with an onError restart.** Rejected — it
+  violates ADR 0013's Effect model; supervision belongs at the consumer's fork
+  site, in-model.

--- a/src/data/collection.ts
+++ b/src/data/collection.ts
@@ -1,5 +1,7 @@
+import type { Socket } from "effect/unstable/socket";
+
 import { createCollection } from "@tanstack/react-db";
-import { type Cause, Duration, Effect, Fiber, Schema, Stream } from "effect";
+import { Cause, Duration, Effect, Fiber, Schema, Stream } from "effect";
 
 import type { ChangeOp, ServerMessage, SyncEvent } from "./realtime";
 import type { Node } from "./schema";
@@ -13,6 +15,7 @@ import { appRuntime } from "./runtime";
 import { persistOrNotify } from "./save-failure";
 import { nodeSchema } from "./schema";
 import { chainDisagreements } from "./sibling-chain";
+import { decideSyncRecovery, notifySyncInterrupted } from "./sync-supervision";
 import { buildTreeIndex, childrenOf, now } from "./tree";
 
 /**
@@ -500,18 +503,64 @@ export const nodesCollection = createCollection({
         appRuntime.runFork(resync);
       };
 
-      const fiber = appRuntime.runFork(
-        Stream.runForEach(events, (event: SyncEvent) =>
-          Effect.sync(() => {
-            if (event._tag === "InitialError") {
-              initialError = event.error;
-              ensureReady();
-            } else {
-              applyMessage(event.message);
+      // Drain the event stream once. A throw inside `applyMessage` (schema drift,
+      // a future wire change) surfaces here as a DIE — without supervision it
+      // kills the consumer permanently while the socket still looks connected
+      // (issue #234). `drainOnce` folding is otherwise unchanged from before.
+      const drainOnce = Stream.runForEach(events, (event: SyncEvent) =>
+        Effect.sync(() => {
+          if (event._tag === "InitialError") {
+            initialError = event.error;
+            ensureReady();
+          } else {
+            applyMessage(event.message);
+          }
+        }),
+      );
+
+      // Supervise the drain inside ONE outer fiber so cleanup's interrupt still
+      // tears everything down (the socket's scope finalizer closes the WS). On a
+      // genuine defect we log the cause and re-establish (a fresh snapshot heals a
+      // transient one-frame glitch) up to a bounded budget; when it exhausts we
+      // flip a visible "reload" notice instead of dying silently. The policy —
+      // and crucially the interrupt-vs-fault split, so an intentional teardown is
+      // NOT treated as a failure — lives in `decideSyncRecovery`. See ADR 0053.
+      const superviseDrain = (
+        recoveriesUsed: number,
+      ): Effect.Effect<void, never, Socket.WebSocketConstructor> =>
+        drainOnce.pipe(
+          Effect.catchCause((cause) => {
+            const decision = decideSyncRecovery(cause, recoveriesUsed);
+            switch (decision._tag) {
+              case "Stop":
+                // Intentional interrupt (cleanup / account switch). Re-raise the
+                // cause so the fiber terminates as interrupted rather than
+                // swallowing it — no recovery, no toast.
+                return Effect.failCause(cause);
+              case "GiveUp":
+                console.error(
+                  "[sync] consumer fiber gave up after retries",
+                  Cause.pretty(cause),
+                );
+                return Effect.sync(notifySyncInterrupted);
+              case "Reestablish":
+                console.error(
+                  "[sync] consumer fiber failed; re-establishing",
+                  Cause.pretty(cause),
+                );
+                // Force the next connection to ignore the cursor (fresh snapshot),
+                // back off, then re-open the stream on the SAME fiber.
+                return resync.pipe(
+                  Effect.andThen(Effect.sleep(decision.delay)),
+                  Effect.andThen(
+                    Effect.suspend(() => superviseDrain(recoveriesUsed + 1)),
+                  ),
+                );
             }
           }),
-        ),
-      );
+        );
+
+      const fiber = appRuntime.runFork(superviseDrain(0));
 
       return () => {
         resyncFn = null;

--- a/src/data/collection.ts
+++ b/src/data/collection.ts
@@ -15,7 +15,11 @@ import { appRuntime } from "./runtime";
 import { persistOrNotify } from "./save-failure";
 import { nodeSchema } from "./schema";
 import { chainDisagreements } from "./sibling-chain";
-import { decideSyncRecovery, notifySyncInterrupted } from "./sync-supervision";
+import {
+  decideSyncRecovery,
+  nextStreak,
+  notifySyncInterrupted,
+} from "./sync-supervision";
 import { buildTreeIndex, childrenOf, now } from "./tree";
 
 /**
@@ -525,12 +529,22 @@ export const nodesCollection = createCollection({
       // flip a visible "reload" notice instead of dying silently. The policy —
       // and crucially the interrupt-vs-fault split, so an intentional teardown is
       // NOT treated as a failure — lives in `decideSyncRecovery`. See ADR 0053.
+      //
+      // The budget is a STREAK, not a lifetime count: `lastFailureAt` lives here
+      // (the impure wiring layer; the policy stays clock-free) and `nextStreak`
+      // resets the count when a failure lands long after the previous one — a
+      // tab open for days must not flip the give-up toast on its 4th ever
+      // transient glitch when each recovery held.
+      let lastFailureAt: number | null = null;
       const superviseDrain = (
         recoveriesUsed: number,
       ): Effect.Effect<void, never, Socket.WebSocketConstructor> =>
         drainOnce.pipe(
           Effect.catchCause((cause) => {
-            const decision = decideSyncRecovery(cause, recoveriesUsed);
+            const failedAt = Date.now();
+            const streak = nextStreak(lastFailureAt, failedAt, recoveriesUsed);
+            lastFailureAt = failedAt;
+            const decision = decideSyncRecovery(cause, streak);
             switch (decision._tag) {
               case "Stop":
                 // Intentional interrupt (cleanup / account switch). Re-raise the
@@ -553,7 +567,7 @@ export const nodesCollection = createCollection({
                 return resync.pipe(
                   Effect.andThen(Effect.sleep(decision.delay)),
                   Effect.andThen(
-                    Effect.suspend(() => superviseDrain(recoveriesUsed + 1)),
+                    Effect.suspend(() => superviseDrain(streak + 1)),
                   ),
                 );
             }

--- a/src/data/sync-supervision.test.ts
+++ b/src/data/sync-supervision.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+import { Cause, Duration } from "effect";
+
+import { decideSyncRecovery, SYNC_RECOVERY_BUDGET } from "./sync-supervision";
+
+// The supervision policy for the inbound-sync consumer fiber (#234). Pins the
+// two things easy to get wrong: an intentional interrupt must NEVER be treated
+// as a fault (no recovery, no toast), and the retry budget must be bounded so a
+// deterministically-poisonous frame can't hot-loop snapshot fetches.
+
+describe("decideSyncRecovery", () => {
+  test("an interrupt-only cause STOPS (never recovers, never toasts)", () => {
+    // Cleanup / account switch tears the fiber down by interrupting it; that is
+    // teardown, not a fault. Even at a zero recovery count it must map to Stop,
+    // so the give-up toast can't fire on an intentional shutdown.
+    expect(decideSyncRecovery(Cause.interrupt(1), 0)).toEqual({ _tag: "Stop" });
+    // And it stays Stop regardless of how much budget is nominally left.
+    expect(
+      decideSyncRecovery(Cause.interrupt(1), SYNC_RECOVERY_BUDGET),
+    ).toEqual({ _tag: "Stop" });
+  });
+
+  test("a defect RE-ESTABLISHES while budget remains", () => {
+    const cause = Cause.die(new Error("applyMessage threw"));
+    for (let used = 0; used < SYNC_RECOVERY_BUDGET; used++) {
+      const decision = decideSyncRecovery(cause, used);
+      expect(decision._tag).toBe("Reestablish");
+    }
+  });
+
+  test("re-establish backs off exponentially, capped at 5s", () => {
+    const cause = Cause.die(new Error("boom"));
+    const delayMs = (used: number) => {
+      const d = decideSyncRecovery(cause, used, 100);
+      if (d._tag !== "Reestablish") throw new Error("expected Reestablish");
+      return Duration.toMillis(d.delay);
+    };
+    expect(delayMs(0)).toBe(500);
+    expect(delayMs(1)).toBe(1000);
+    expect(delayMs(2)).toBe(2000);
+    expect(delayMs(3)).toBe(4000);
+    // 500 * 2^4 = 8000 -> capped to 5000; every higher attempt stays capped.
+    expect(delayMs(4)).toBe(5000);
+    expect(delayMs(10)).toBe(5000);
+  });
+
+  test("a defect GIVES UP once the budget is spent", () => {
+    const cause = Cause.die(new Error("poison frame"));
+    expect(decideSyncRecovery(cause, SYNC_RECOVERY_BUDGET)).toEqual({
+      _tag: "GiveUp",
+    });
+    expect(decideSyncRecovery(cause, SYNC_RECOVERY_BUDGET + 5)).toEqual({
+      _tag: "GiveUp",
+    });
+  });
+
+  test("a typed failure cause is a fault too (recovers, then gives up)", () => {
+    // The consumer's error channel is `never`, but guard the classification
+    // anyway: a Fail is a fault, not an interrupt, so it recovers within budget
+    // and gives up after — same as a defect.
+    const cause = Cause.fail("some error" as never);
+    expect(decideSyncRecovery(cause, 0)._tag).toBe("Reestablish");
+    expect(decideSyncRecovery(cause, SYNC_RECOVERY_BUDGET)._tag).toBe("GiveUp");
+  });
+
+  test("budget is configurable", () => {
+    const cause = Cause.die(new Error("x"));
+    expect(decideSyncRecovery(cause, 0, 0)._tag).toBe("GiveUp");
+    expect(decideSyncRecovery(cause, 0, 1)._tag).toBe("Reestablish");
+    expect(decideSyncRecovery(cause, 1, 1)._tag).toBe("GiveUp");
+  });
+});

--- a/src/data/sync-supervision.test.ts
+++ b/src/data/sync-supervision.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import { Cause, Duration } from "effect";
 
-import { decideSyncRecovery, SYNC_RECOVERY_BUDGET } from "./sync-supervision";
+import {
+  decideSyncRecovery,
+  nextStreak,
+  SYNC_RECOVERY_BUDGET,
+  SYNC_STREAK_RESET_AFTER,
+} from "./sync-supervision";
 
 // The supervision policy for the inbound-sync consumer fiber (#234). Pins the
 // two things easy to get wrong: an intentional interrupt must NEVER be treated
@@ -68,5 +73,67 @@ describe("decideSyncRecovery", () => {
     expect(decideSyncRecovery(cause, 0, 0)._tag).toBe("GiveUp");
     expect(decideSyncRecovery(cause, 0, 1)._tag).toBe("Reestablish");
     expect(decideSyncRecovery(cause, 1, 1)._tag).toBe("GiveUp");
+  });
+});
+
+// The streak reset (the impure wiring in collection.ts records `lastFailureAt`
+// and calls this with `Date.now()`). Without it the budget is a LIFETIME count:
+// a tab open for days would flip the give-up toast on its 4th ever transient
+// glitch even though every recovery held.
+
+describe("nextStreak", () => {
+  const RESET = Duration.toMillis(SYNC_STREAK_RESET_AFTER);
+
+  test("first failure (no prior) keeps the count as-is", () => {
+    expect(nextStreak(null, 1_000_000, 0)).toBe(0);
+  });
+
+  test("a failure within the window CONTINUES the streak", () => {
+    const t0 = 1_000_000;
+    expect(nextStreak(t0, t0 + 1, 2)).toBe(2);
+    expect(nextStreak(t0, t0 + RESET, 2)).toBe(2); // boundary: exactly the window
+  });
+
+  test("a failure after the window RESETS the streak to 0", () => {
+    const t0 = 1_000_000;
+    expect(nextStreak(t0, t0 + RESET + 1, 2)).toBe(0);
+    expect(nextStreak(t0, t0 + 10 * RESET, SYNC_RECOVERY_BUDGET)).toBe(0);
+  });
+
+  test("separated glitches never exhaust the budget (the day-old-tab scenario)", () => {
+    // 10 transient glitches, each a stable stretch apart: every one is decided
+    // at streak 0 -> Reestablish, never GiveUp.
+    const cause = Cause.die(new Error("transient"));
+    let last: number | null = null;
+    let used = 0;
+    let now = 0;
+    for (let i = 0; i < 10; i++) {
+      now += RESET + 5_000; // well past the window each time
+      const streak = nextStreak(last, now, used);
+      last = now;
+      expect(decideSyncRecovery(cause, streak)._tag).toBe("Reestablish");
+      used = streak + 1;
+    }
+  });
+
+  test("rapid-fire failures still exhaust the budget (poison frame)", () => {
+    const cause = Cause.die(new Error("poison"));
+    let last: number | null = null;
+    let used = 0;
+    let now = 1_000_000;
+    const decisions: string[] = [];
+    for (let i = 0; i <= SYNC_RECOVERY_BUDGET; i++) {
+      now += 500; // immediate re-failure, inside the window
+      const streak = nextStreak(last, now, used);
+      last = now;
+      decisions.push(decideSyncRecovery(cause, streak)._tag);
+      used = streak + 1;
+    }
+    expect(decisions).toEqual([
+      "Reestablish",
+      "Reestablish",
+      "Reestablish",
+      "GiveUp",
+    ]);
   });
 });

--- a/src/data/sync-supervision.ts
+++ b/src/data/sync-supervision.ts
@@ -24,6 +24,14 @@ import { toast } from "sonner";
  *  frame (one that re-poisons every snapshot) can't hot-loop snapshot fetches. */
 export const SYNC_RECOVERY_BUDGET = 3;
 
+/** A failure arriving this long after the previous one is a NEW streak, not a
+ *  continuation: the intervening recovery evidently held, so its spent budget
+ *  is forgiven. Without this the counter is lifetime — a tab open for days
+ *  would flip the give-up toast on its 4th ever transient glitch even though
+ *  each recovered fine. Mirrors the transport's reset-after-stable
+ *  (`STABLE_AFTER`, realtime.ts) one layer up. */
+export const SYNC_STREAK_RESET_AFTER = Duration.seconds(60);
+
 /** Backoff floor + cap between re-establish attempts (jitter-free; the failure is
  *  rare and self-inflicted, so plain exponential is enough — no thundering herd). */
 const RECOVERY_BASE = Duration.millis(500);
@@ -68,6 +76,25 @@ export function decideSyncRecovery(
     Duration.toMillis(RECOVERY_BASE) * 2 ** recoveriesUsed,
   );
   return { _tag: "Reestablish", delay: Duration.millis(ms) };
+}
+
+/**
+ * Whether a fresh failure continues the current streak or starts a new one.
+ * Pure companion to `decideSyncRecovery` (which stays clock-free): the impure
+ * wiring in collection.ts records `lastFailureAt` and passes `Date.now()` here.
+ * A failure more than `resetAfterMs` after the previous one means the last
+ * re-establish evidently held — the streak resets to 0 and the budget is
+ * forgiven. `null` (no prior failure) keeps `used` as-is (it's 0 on the first
+ * failure anyway).
+ */
+export function nextStreak(
+  lastFailureAt: number | null,
+  now: number,
+  used: number,
+  resetAfterMs: number = Duration.toMillis(SYNC_STREAK_RESET_AFTER),
+): number {
+  if (lastFailureAt === null) return used;
+  return now - lastFailureAt > resetAfterMs ? 0 : used;
 }
 
 /**

--- a/src/data/sync-supervision.ts
+++ b/src/data/sync-supervision.ts
@@ -1,0 +1,90 @@
+import { Cause, Duration } from "effect";
+import { toast } from "sonner";
+
+/**
+ * Supervision policy for the inbound-sync consumer fiber (collection.ts).
+ *
+ * The consumer drains `Stream<SyncEvent>` and folds each frame into the TanStack
+ * DB sync primitives via `applyMessage`. A throw inside `applyMessage` (today
+ * near-unreachable — the wire schema and collection schema are field-for-field
+ * identical, but any future drift is one bad frame away) would otherwise DIE the
+ * fiber permanently: the WebSocket still looks connected, no frame is ever
+ * applied again, and every structural write hangs its echo-wait to the 8s
+ * timeout with no signal to the user. See issue #234 / ADR 0053.
+ *
+ * This module is the cheap supervision: a pure decision function (below) the
+ * fiber consults on failure, plus the visible "reload" notice for the give-up
+ * path. Keeping the policy pure is what makes it unit-testable without driving
+ * the whole socket. The Effect wiring (catchCause + re-establish) lives at the
+ * fork site in collection.ts.
+ */
+
+/** Max consecutive re-establish attempts before we stop retrying and flip to the
+ *  visible "reload" state. Bounds the recovery so a DETERMINISTICALLY poisonous
+ *  frame (one that re-poisons every snapshot) can't hot-loop snapshot fetches. */
+export const SYNC_RECOVERY_BUDGET = 3;
+
+/** Backoff floor + cap between re-establish attempts (jitter-free; the failure is
+ *  rare and self-inflicted, so plain exponential is enough — no thundering herd). */
+const RECOVERY_BASE = Duration.millis(500);
+const RECOVERY_CAP = Duration.seconds(5);
+
+/**
+ * What the supervisor should do after the consumer fiber ends.
+ *  - `Stop`        — an intentional interrupt (session cleanup, account switch).
+ *                    Tear down quietly: NOT a fault, so never recover, never toast.
+ *  - `Reestablish` — a genuine failure (a defect/throw) with budget left: log the
+ *                    cause and re-open the stream after `delay` (a fresh snapshot
+ *                    truncates + replaces the collection, healing a transient
+ *                    one-frame glitch).
+ *  - `GiveUp`      — budget exhausted: stop retrying and surface the visible
+ *                    "sync interrupted — reload" notice so the session can't die
+ *                    silently.
+ */
+export type SyncRecoveryDecision =
+  | { readonly _tag: "Stop" }
+  | { readonly _tag: "Reestablish"; readonly delay: Duration.Duration }
+  | { readonly _tag: "GiveUp" };
+
+/**
+ * Decide how to supervise the consumer fiber given the failure `cause` and how
+ * many re-establishes have already been spent this streak. Pure: no clock, no
+ * socket, no toast — just the policy, so the interrupt-vs-fault split and the
+ * retry budget are pinned by unit tests (sync-supervision.test.ts).
+ *
+ * The interrupt check is load-bearing: `catchCause` sees interruptions too, and
+ * cleanup tears the fiber down by interrupting it. An interrupt-only cause MUST
+ * map to `Stop` so an intentional teardown never triggers recovery or the toast.
+ */
+export function decideSyncRecovery(
+  cause: Cause.Cause<never>,
+  recoveriesUsed: number,
+  budget: number = SYNC_RECOVERY_BUDGET,
+): SyncRecoveryDecision {
+  if (Cause.hasInterruptsOnly(cause)) return { _tag: "Stop" };
+  if (recoveriesUsed >= budget) return { _tag: "GiveUp" };
+  const ms = Math.min(
+    Duration.toMillis(RECOVERY_CAP),
+    Duration.toMillis(RECOVERY_BASE) * 2 ** recoveriesUsed,
+  );
+  return { _tag: "Reestablish", delay: Duration.millis(ms) };
+}
+
+/**
+ * The give-up notice: a persistent toast telling the user live sync stopped and
+ * to reload. Reuses the same sonner mechanism as `notifySaveFailed` (#230) — a
+ * fixed `id` de-dupes, and `duration: Infinity` keeps it on screen (a silently
+ * dead sync fiber is exactly what #234 exists to prevent). The action reloads,
+ * which re-runs the sync bootstrap from a clean slate.
+ */
+export function notifySyncInterrupted(): void {
+  toast.error("Sync interrupted", {
+    id: "sync-interrupted",
+    duration: Infinity,
+    description: "Live sync stopped unexpectedly. Reload to reconnect.",
+    action: {
+      label: "Reload",
+      onClick: () => window.location.reload(),
+    },
+  });
+}


### PR DESCRIPTION
## Summary

A throw inside `applyMessage` used to kill the inbound-sync consumer fiber permanently while the socket still looked connected — no frame applied again, every write hanging its echo-wait, no signal to the user. The consumer is now supervised: it logs the cause and re-establishes with a fresh snapshot, and if failures keep coming it flips a persistent "Sync interrupted — reload" toast instead of dying silently.

Fixes #234

## Changes

1. A failure in the sync consumer now recovers instead of silently ending live sync: the drain is supervised on one outer fiber and re-establishes with a forced fresh snapshot after exponential backoff (500ms doubling, 5s cap).
2. When three rapid failures exhaust the budget, a persistent "Sync interrupted — reload" toast appears (same sonner mechanism as save-failure notices) — the session can never die silently.
3. Intentional teardown (session cleanup, account switch) is excluded from recovery: an interrupt-only cause stops quietly — no retry, no toast.
4. The retry budget is a streak, not a lifetime count: failures more than 60s apart reset it, so a days-old tab that recovered from a few separated glitches never spuriously gives up.
5. The policy is pure and pinned: `decideSyncRecovery` + `nextStreak` in `sync-supervision.ts` with 11 unit tests; ADR 0053 records the design and its accepted edges.

**Start here:** change 3 — `catchCause` sees interrupts too; `Cause.hasInterruptsOnly` → re-raise is what keeps teardown from toasting.

## Test plan

- `bun test src worker/` — 822 pass, 0 fail (11 new supervision tests: interrupt→Stop, retry/backoff schedule, budget boundaries, streak reset, poison-frame give-up)
- `typecheck`, `typecheck:worker`, `typecheck:test`, `lint`, `fmt:check`, `bun run build` — all green
- Adversarial review pass verified against library source: interrupt semantics, old-socket-closes-before-reopen, TanStack DB partial-`begin()` healed by the next snapshot
- Failure path is unreachable from the UI today (wire and collection schemas are field-for-field identical), so no e2e — unit coverage is the bar per #234
