### PR TITLE
fix(auth): require password confirmation on signup and reset

### DIFF
--- a/.changeset/confirm-password.md
+++ b/.changeset/confirm-password.md
@@ -1,0 +1,5 @@
+---
+"dotflowy": patch
+---
+
+Signup and password reset now ask you to confirm the password, so a typo can't quietly lock you out of a brand-new or reset account.

--- a/src/components/auth-screen.tsx
+++ b/src/components/auth-screen.tsx
@@ -41,6 +41,13 @@ export function AuthScreen() {
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  // Signup only: a second field so a mistyped password is caught before an
+  // account is created (nobody can recover a password they never meant to set).
+  const [confirmPassword, setConfirmPassword] = useState("");
+  // Gate the mismatch message so it doesn't fire on the first keystroke — shown
+  // once the field has been blurred or a submit was attempted.
+  const [confirmTouched, setConfirmTouched] = useState(false);
+  const confirmRef = useRef<HTMLInputElement>(null);
   const [inviteCode, setInviteCode] = useState("");
   const [error, setError] = useState<string | null>(null);
   // Non-error status line (e.g. "account created, confirm your email"). Shown
@@ -67,6 +74,13 @@ export function AuthScreen() {
 
   const isSignup = mode === "signup";
   const isForgot = mode === "forgot";
+  // Only compare once both fields have content, so the message never shows on
+  // the very first character typed into the confirm field.
+  const passwordsMismatch =
+    password.length > 0 &&
+    confirmPassword.length > 0 &&
+    password !== confirmPassword;
+  const showConfirmError = isSignup && confirmTouched && passwordsMismatch;
   // Turnstile guards signup + password reset (never sign-in). Only relevant
   // when the deploy configured a site key.
   const captchaMode = isSignup || isForgot;
@@ -179,6 +193,14 @@ export function AuthScreen() {
     }
     setError(null);
     setNotice(null);
+    // Signup: block a mismatched confirmation before we hit the network. The
+    // field-level message (below the input) carries the explanation, so this
+    // only flips it on and moves focus there.
+    if (isSignup && password !== confirmPassword) {
+      setConfirmTouched(true);
+      confirmRef.current?.focus();
+      return;
+    }
     // Signup is Turnstile-gated when a site key is configured; sign-in never is
     // (captchaRequired is false outside signup/forgot by construction).
     if (captchaBlocked()) return;
@@ -254,6 +276,8 @@ export function AuthScreen() {
           "Account created. Check your inbox to confirm your email, then sign in.",
         );
         setCaptchaToken(null);
+        setConfirmPassword("");
+        setConfirmTouched(false);
       } else if (oauthQuery) {
         resumeAuthorize();
         return;
@@ -354,6 +378,27 @@ export function AuthScreen() {
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
               />
+            )}
+            {isSignup && (
+              <>
+                <Input
+                  ref={confirmRef}
+                  type="password"
+                  placeholder="Confirm password"
+                  autoComplete="new-password"
+                  required
+                  minLength={8}
+                  aria-invalid={showConfirmError || undefined}
+                  value={confirmPassword}
+                  onChange={(e) => setConfirmPassword(e.target.value)}
+                  onBlur={() => setConfirmTouched(true)}
+                />
+                {showConfirmError && (
+                  <p className="text-sm text-destructive">
+                    Passwords don't match.
+                  </p>
+                )}
+              </>
             )}
             {/* Invite code only while signup is gated. When SIGNUP_OPEN is on,
                 the server skips the invite requirement, so the field would be
@@ -480,6 +525,8 @@ export function AuthScreen() {
                   setError(null);
                   setNotice(null);
                   setCaptchaToken(null);
+                  setConfirmPassword("");
+                  setConfirmTouched(false);
                 }}
               >
                 {isSignup

--- a/src/routes/reset-password.tsx
+++ b/src/routes/reset-password.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { useState, type FormEvent } from "react";
+import { useRef, useState, type FormEvent } from "react";
 
 import { Button } from "../components/ui/button";
 import { Input } from "../components/ui/input";
@@ -37,16 +37,35 @@ export const Route = createFileRoute("/reset-password")({
 function ResetPassword() {
   const { token, error: linkError } = Route.useSearch();
   const [password, setPassword] = useState("");
+  // A confirmation field so a mistyped new password can't lock the user out.
+  const [confirmPassword, setConfirmPassword] = useState("");
+  // Gate the mismatch message: shown after the field is blurred or on submit,
+  // not on the first keystroke.
+  const [confirmTouched, setConfirmTouched] = useState(false);
+  const confirmRef = useRef<HTMLInputElement>(null);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [done, setDone] = useState(false);
 
   const invalidLink = !token || Boolean(linkError);
+  // Only compare once both fields have content.
+  const passwordsMismatch =
+    password.length > 0 &&
+    confirmPassword.length > 0 &&
+    password !== confirmPassword;
+  const showConfirmError = confirmTouched && passwordsMismatch;
 
   async function onSubmit(e: FormEvent) {
     e.preventDefault();
     if (!token) return;
     setError(null);
+    // Block a mismatched confirmation before hitting the network; the
+    // field-level message explains, so this just surfaces it and moves focus.
+    if (password !== confirmPassword) {
+      setConfirmTouched(true);
+      confirmRef.current?.focus();
+      return;
+    }
     setBusy(true);
     try {
       const res = await resetPassword({ newPassword: password, token });
@@ -101,6 +120,21 @@ function ResetPassword() {
               value={password}
               onChange={(e) => setPassword(e.target.value)}
             />
+            <Input
+              ref={confirmRef}
+              type="password"
+              placeholder="Confirm new password"
+              autoComplete="new-password"
+              required
+              minLength={8}
+              aria-invalid={showConfirmError || undefined}
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              onBlur={() => setConfirmTouched(true)}
+            />
+            {showConfirmError && (
+              <p className="text-sm text-destructive">Passwords don't match.</p>
+            )}
 
             {error && <p className="text-sm text-destructive">{error}</p>}
 


### PR DESCRIPTION
## What

Adds a **confirm password** field to both places a new password is set:

- **Signup** (`src/components/auth-screen.tsx`) — now user-facing since signup opened to the public behind Turnstile (#296).
- **Reset password** (`src/routes/reset-password.tsx`).

Login mode is untouched (no confirm field there).

## Why

Without a second input, a typo silently creates an account (or resets a password) to something the user can't reproduce, locking them out. Fixes #132.

## Behavior

- Client-side validation blocks submit when the two fields don't match and shows an inline `text-destructive` error matching the existing form-error styling.
- The mismatch message only appears once the confirm field is blurred or a submit is attempted (both fields non-empty) — never on the first keystroke.
- On a blocked submit, focus moves to the confirm field; the field also gets `aria-invalid` for the built-in Input error styling.
- Confirm state resets on the signup/signin toggle and after a successful signup.

## Verification

- `bun run fmt`, `bun run lint` — clean
- `bun run typecheck`, `typecheck:worker`, `typecheck:test` — all pass
- `bun test src worker/` — 851 pass, 0 fail
- `bun run build` — succeeds
- e2e: `playwright test e2e/sign-out.spec.ts` (the auth-flow spec) — 2 passed. Signup/reset flows have no e2e specs and the suite mocks `get-session`, so no existing spec types into these password fields; nothing to update.
- Browser: confirmed both fields render on `/reset-password` via the accessibility tree. Interactive click/JS driving was blocked by a local Chrome-extension environment issue (navigate + read_page worked); the mismatch logic is simple derived state covered by typecheck.

Added a patch changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added password confirmation fields to signup and password reset forms.
  * Added validation messages when passwords do not match.
  * Prevented account creation or password resets until matching passwords are entered.
  * Automatically focuses the confirmation field when validation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->