### PR TITLE
feat(announce): waitlist launch announcement endpoint + CLI

### DIFF
--- a/.changeset/waitlist-announce.md
+++ b/.changeset/waitlist-announce.md
@@ -1,0 +1,5 @@
+---
+"dotflowy": minor
+---
+
+Launch-day waitlist announcement. A new admin-only `POST /api/admin/announce` endpoint (same shape and admin gate as `/api/admin/invite`) emails the "Dotflowy is open" blast to waitlist rows through the one email seam, and `bun run announce` drives it in resumable batches. A `notifiedAt` stamp on the waitlist row (migration 0009) makes the send at-most-once, so the script is safe to re-run without double-sending.

--- a/migrations/0009_waitlist_notified.sql
+++ b/migrations/0009_waitlist_notified.sql
@@ -1,0 +1,16 @@
+-- Launch-day announcement stamp (map #151 / ticket #294). The waitlist (0005)
+-- collects interest; when signup opens to the public, the admin-only
+-- POST /api/admin/announce (driven by scripts/announce.ts) emails every waiter
+-- the "Dotflowy is open" blast through the ONE email seam (worker/email.ts).
+--
+-- `notifiedAt` mirrors the `redeemedAt` single-use pattern on `invites` (0007):
+-- NULL until the announcement is sent, then stamped once. The send is claimed by
+-- a conditional UPDATE (... WHERE notifiedAt IS NULL) so only the winning writer
+-- sends — a re-run or concurrent batch sees the row already stamped and skips it,
+-- which is what makes `bun run announce` safe to re-run without double-sending.
+--
+-- Nullable with no default, so the column adds cleanly to existing rows (every
+-- current waiter starts un-notified). Account deletion still scrubs the whole
+-- waitlist row by email (worker/account-deletion.ts), so this column carries no
+-- PII beyond a timestamp and needs no separate cleanup.
+ALTER TABLE waitlist ADD COLUMN notifiedAt INTEGER;

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "cf:dev": "bun scripts/cf-dev.ts",
     "seed:user": "bun scripts/seed-user.ts",
     "invite": "bun scripts/invite.ts",
+    "announce": "bun scripts/announce.ts",
     "deploy": "bun run build:cf && wrangler deploy",
     "gen:og": "bun scripts/gen-og.ts",
     "release": "bun scripts/release.ts",

--- a/scripts/announce.ts
+++ b/scripts/announce.ts
@@ -1,0 +1,176 @@
+/**
+ * Waitlist launch-announcement CLI (map #151 / ticket #294). Emails the
+ * "Dotflowy is open" blast to waitlist rows by driving the admin-only
+ * `POST /api/admin/announce` endpoint (worker/index.ts).
+ *
+ * Why an endpoint and not direct D1 + a mailer: the email goes through the ONE
+ * email seam (worker/email.ts -> the Cloudflare `send_email` binding), and that
+ * binding only exists inside the Worker's `fetch`. So the Worker sends and
+ * stamps `notifiedAt`; this script is the thin admin-authenticated trigger.
+ *
+ * Batched + resumable + safe to re-run: each call announces at most `--limit`
+ * rows (default 25, max 500) and the Worker stamps `notifiedAt` on every row it
+ * sends, so a row is never emailed twice — re-run until `--all` reports zero new.
+ * Loop it to drain the whole list:
+ *
+ *   while bun run announce --limit 200 | grep -q 'Announced'; do :; done
+ *
+ * Auth: signs in as an admin (email + password) through the real Better Auth
+ * endpoint — the same pattern as scripts/invite.ts — and forwards the session
+ * cookie. Set a session cookie directly with DOTFLOWY_SESSION_COOKIE to skip the
+ * sign-in (e.g. copied from the browser). The admin must satisfy the endpoint's
+ * gate (ADMIN_USER_IDS / ADMIN_EMAILS, wrangler.jsonc) or the endpoint 404s.
+ *
+ * Config (env):
+ *   DOTFLOWY_API              base URL (default https://app.dotflowy.com)
+ *   DOTFLOWY_ADMIN_EMAIL      admin account email (for sign-in)
+ *   DOTFLOWY_ADMIN_PASSWORD   admin account password (for sign-in)
+ *   DOTFLOWY_SESSION_COOKIE   raw Cookie header, an alternative to sign-in
+ *
+ * Usage:
+ *   bun run announce --limit 200        # announce to the 200 oldest un-notified rows
+ *   bun run announce --all              # announce to every un-notified waitlist row
+ *   bun run announce a@b.com c@d.com    # announce to these exact addresses
+ *   bun run announce --api http://localhost:8787 --all   # against local dev
+ */
+
+interface Args {
+  emails: string[];
+  all: boolean;
+  limit?: number;
+  api: string;
+}
+
+function parseArgs(argv: string[]): Args {
+  const emails: string[] = [];
+  let all = false;
+  let limit: number | undefined;
+  let api = process.env.DOTFLOWY_API ?? "https://app.dotflowy.com";
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]!;
+    if (arg === "--all") {
+      all = true;
+    } else if (arg === "--limit" || arg === "--count") {
+      const n = Number(argv[++i]);
+      if (!Number.isFinite(n) || n < 1) {
+        console.error(`${arg} needs a positive number`);
+        process.exit(1);
+      }
+      limit = Math.floor(n);
+    } else if (arg === "--api") {
+      api = argv[++i] ?? api;
+    } else if (arg.startsWith("--")) {
+      console.error(`unknown flag: ${arg}`);
+      process.exit(1);
+    } else {
+      emails.push(arg);
+    }
+  }
+
+  if (emails.length === 0 && !all && limit == null) {
+    console.error(
+      "Nothing to do. Pass emails, or --all, or --limit N.\n" +
+        "  bun run announce --limit 200\n" +
+        "  bun run announce --all\n" +
+        "  bun run announce a@b.com",
+    );
+    process.exit(1);
+  }
+  return { emails, all, limit, api: api.replace(/\/$/, "") };
+}
+
+/** Collapse a fetch Response's Set-Cookie headers into a single Cookie header. */
+function collectCookies(res: Response): string {
+  const setCookies =
+    typeof res.headers.getSetCookie === "function"
+      ? res.headers.getSetCookie()
+      : [res.headers.get("set-cookie")].filter((v): v is string => v != null);
+  return setCookies
+    .map((c) => c.split(";")[0]!.trim())
+    .filter(Boolean)
+    .join("; ");
+}
+
+/** Obtain a Cookie header: an explicit one, else sign in as the admin. */
+async function resolveCookie(api: string): Promise<string> {
+  const explicit = process.env.DOTFLOWY_SESSION_COOKIE;
+  if (explicit) return explicit;
+
+  const email = process.env.DOTFLOWY_ADMIN_EMAIL;
+  const password = process.env.DOTFLOWY_ADMIN_PASSWORD;
+  if (!email || !password) {
+    console.error(
+      "Set DOTFLOWY_ADMIN_EMAIL + DOTFLOWY_ADMIN_PASSWORD (an admin on the allowlist),\n" +
+        "or DOTFLOWY_SESSION_COOKIE with a signed-in session cookie.",
+    );
+    process.exit(1);
+  }
+
+  const res = await fetch(`${api}/api/auth/sign-in/email`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email, password }),
+  });
+  if (!res.ok) {
+    console.error(
+      `admin sign-in failed (status ${res.status}): ${await res.text()}`,
+    );
+    process.exit(1);
+  }
+  const cookie = collectCookies(res);
+  if (!cookie) {
+    console.error("admin sign-in returned no session cookie");
+    process.exit(1);
+  }
+  return cookie;
+}
+
+interface AnnounceResponse {
+  notified: string[];
+  skipped: string[];
+  count: number;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const cookie = await resolveCookie(args.api);
+
+  const body: { emails?: string[]; all?: boolean; limit?: number } =
+    args.emails.length > 0
+      ? { emails: args.emails }
+      : args.all
+        ? { all: true }
+        : { limit: args.limit };
+
+  const res = await fetch(`${args.api}/api/admin/announce`, {
+    method: "POST",
+    headers: { "content-type": "application/json", cookie },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    console.error(
+      `announce failed (status ${res.status}): ${await res.text()}`,
+    );
+    process.exit(1);
+  }
+
+  const data = (await res.json()) as AnnounceResponse;
+  if (data.notified.length === 0) {
+    console.log(
+      "No new announcements sent (all targets were already notified).",
+    );
+  } else {
+    console.log(`Announced to ${data.notified.length} address(es):`);
+    for (const email of data.notified) {
+      console.log(`  ${email}`);
+    }
+  }
+  if (data.skipped.length > 0) {
+    console.log(
+      `Skipped ${data.skipped.length} already-notified (or not on the waitlist).`,
+    );
+  }
+}
+
+await main();

--- a/worker/announce.test.ts
+++ b/worker/announce.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  announceEmail,
+  pendingAnnounceEmails,
+  sendAnnouncements,
+  type AnnounceEnv,
+} from "./announce";
+
+describe("announceEmail", () => {
+  test("carries the signup url and the launch facts in both bodies", () => {
+    const msg = announceEmail("https://dotflowy.com");
+    for (const body of [msg.text, msg.html]) {
+      expect(body).toContain("https://dotflowy.com");
+      expect(body).toContain("10,000");
+      expect(body).toContain("$5/mo");
+      expect(body).toContain("$48/yr");
+      expect(body).toContain("$99");
+    }
+    expect(msg.subject.length).toBeGreaterThan(0);
+  });
+
+  test("is honest about the founding plan — a fixed term that auto-renews, NOT lifetime", () => {
+    // Ticket #294 is explicit: the founding plan auto-renews after year three
+    // unless cancelled, so the copy discloses the renewal AND explicitly denies
+    // the "lifetime" framing rather than leaving it ambiguous.
+    const msg = announceEmail("https://dotflowy.com");
+    for (const body of [msg.text, msg.html]) {
+      expect(body.toLowerCase()).toContain("auto-renew");
+      expect(body.toLowerCase()).toContain("unless you cancel");
+      expect(body.toLowerCase()).toContain("not a lifetime deal");
+    }
+  });
+
+  test("acknowledges the recipient joined the waitlist", () => {
+    const msg = announceEmail("https://dotflowy.com");
+    expect(msg.text.toLowerCase()).toContain("waitlist");
+    expect(msg.html.toLowerCase()).toContain("waitlist");
+  });
+});
+
+/**
+ * A stateful in-memory `waitlist` table, just enough to exercise the two SQL
+ * statements the announcement flow issues: the conditional `notifiedAt` claim
+ * and the pending-rows SELECT. The claim mirrors real D1 semantics — an UPDATE
+ * that matches 0 rows reports `meta.changes === 0` — which is the whole
+ * idempotency guarantee under test.
+ */
+function fakeWaitlistDb(
+  rows: Array<{ email: string; createdAt: number; notifiedAt: number | null }>,
+) {
+  const db = {
+    prepare() {
+      return {
+        bind(...args: unknown[]) {
+          return {
+            run() {
+              // UPDATE waitlist SET notifiedAt = ? WHERE email = ? AND notifiedAt IS NULL
+              const [, email] = args as [number, string];
+              const row = rows.find((r) => r.email === email);
+              if (row && row.notifiedAt == null) {
+                row.notifiedAt = args[0] as number;
+                return Promise.resolve({ meta: { changes: 1 } });
+              }
+              return Promise.resolve({ meta: { changes: 0 } });
+            },
+            all() {
+              // SELECT email FROM waitlist WHERE notifiedAt IS NULL ... [LIMIT ?]
+              const limit = args.length > 0 ? (args[0] as number) : undefined;
+              const pending = rows
+                .filter((r) => r.notifiedAt == null)
+                .sort((a, b) => a.createdAt - b.createdAt)
+                .map((r) => ({ email: r.email }));
+              return Promise.resolve({
+                results: limit != null ? pending.slice(0, limit) : pending,
+              });
+            },
+          };
+        },
+        all() {
+          // The no-bind SELECT (limit === null).
+          const pending = rows
+            .filter((r) => r.notifiedAt == null)
+            .sort((a, b) => a.createdAt - b.createdAt)
+            .map((r) => ({ email: r.email }));
+          return Promise.resolve({ results: pending });
+        },
+      };
+    },
+  } as unknown as D1Database;
+  // EMAIL omitted: sendEmail falls back to console logging (never throws), so a
+  // `notified` entry means the row was claimed and the send was attempted.
+  const env: AnnounceEnv = { DB: db };
+  return { env, rows };
+}
+
+describe("sendAnnouncements idempotent stamping", () => {
+  test("stamps notifiedAt and sends once per un-notified row", async () => {
+    const { env, rows } = fakeWaitlistDb([
+      { email: "a@b.com", createdAt: 1, notifiedAt: null },
+      { email: "c@d.com", createdAt: 2, notifiedAt: null },
+    ]);
+    const res = await sendAnnouncements(
+      env,
+      ["a@b.com", "c@d.com"],
+      "https://dotflowy.com",
+    );
+    expect(res.notified.sort()).toEqual(["a@b.com", "c@d.com"]);
+    expect(res.skipped).toEqual([]);
+    // Every row is now stamped.
+    expect(rows.every((r) => r.notifiedAt != null)).toBe(true);
+  });
+
+  test("a re-run sends to nobody — the stamp makes it safe to re-run", async () => {
+    const { env } = fakeWaitlistDb([
+      { email: "a@b.com", createdAt: 1, notifiedAt: null },
+      { email: "c@d.com", createdAt: 2, notifiedAt: null },
+    ]);
+    await sendAnnouncements(
+      env,
+      ["a@b.com", "c@d.com"],
+      "https://dotflowy.com",
+    );
+    const second = await sendAnnouncements(
+      env,
+      ["a@b.com", "c@d.com"],
+      "https://dotflowy.com",
+    );
+    expect(second.notified).toEqual([]);
+    expect(second.skipped.sort()).toEqual(["a@b.com", "c@d.com"]);
+  });
+
+  test("an already-notified row is skipped, never re-sent", async () => {
+    const { env } = fakeWaitlistDb([
+      { email: "old@b.com", createdAt: 1, notifiedAt: 999 },
+      { email: "new@b.com", createdAt: 2, notifiedAt: null },
+    ]);
+    const res = await sendAnnouncements(
+      env,
+      ["old@b.com", "new@b.com"],
+      "https://dotflowy.com",
+    );
+    expect(res.notified).toEqual(["new@b.com"]);
+    expect(res.skipped).toEqual(["old@b.com"]);
+  });
+
+  test("an address not on the waitlist is skipped (0-row claim, never emailed)", async () => {
+    const { env } = fakeWaitlistDb([
+      { email: "on@b.com", createdAt: 1, notifiedAt: null },
+    ]);
+    const res = await sendAnnouncements(
+      env,
+      ["stranger@x.com", "on@b.com"],
+      "https://dotflowy.com",
+    );
+    expect(res.notified).toEqual(["on@b.com"]);
+    expect(res.skipped).toEqual(["stranger@x.com"]);
+  });
+
+  test("normalizes + de-dupes input so one address is claimed at most once", async () => {
+    const { env } = fakeWaitlistDb([
+      { email: "a@b.com", createdAt: 1, notifiedAt: null },
+    ]);
+    const res = await sendAnnouncements(
+      env,
+      ["  A@B.com ", "a@b.com", ""],
+      "https://dotflowy.com",
+    );
+    expect(res.notified).toEqual(["a@b.com"]);
+    expect(res.skipped).toEqual([]);
+  });
+});
+
+describe("pendingAnnounceEmails", () => {
+  test("returns only un-notified rows, oldest first, honoring the limit", async () => {
+    const { env } = fakeWaitlistDb([
+      { email: "second@b.com", createdAt: 2, notifiedAt: null },
+      { email: "done@b.com", createdAt: 1, notifiedAt: 500 },
+      { email: "first@b.com", createdAt: 1, notifiedAt: null },
+      { email: "third@b.com", createdAt: 3, notifiedAt: null },
+    ]);
+    expect(await pendingAnnounceEmails(env, null)).toEqual([
+      "first@b.com",
+      "second@b.com",
+      "third@b.com",
+    ]);
+    expect(await pendingAnnounceEmails(env, 2)).toEqual([
+      "first@b.com",
+      "second@b.com",
+    ]);
+  });
+});

--- a/worker/announce.ts
+++ b/worker/announce.ts
@@ -1,0 +1,129 @@
+/// <reference types="@cloudflare/workers-types" />
+
+/**
+ * Launch-day "Dotflowy is open" blast (map #151 / ticket #294). When signup
+ * graduates from invite-only to public, every waitlist row (migration 0005) gets
+ * one announcement email. The counterpart to worker/invites.ts's MINT/SEND half:
+ * same shape, same reasons.
+ *
+ *  - The send runs on the Worker because it goes through the ONE email seam
+ *    (worker/email.ts -> the `send_email` binding), which only exists inside
+ *    `fetch`. scripts/announce.ts is the thin admin-authenticated trigger.
+ *  - Idempotency is a `notifiedAt` stamp on the waitlist row (migration 0009),
+ *    mirroring `invites.redeemedAt`: a row is claimed by a CONDITIONAL UPDATE
+ *    (`WHERE notifiedAt IS NULL`) and only the winner sends, so a re-run or a
+ *    concurrent batch can't double-send. That's what makes the CLI resumable.
+ *
+ * Unlike an invite, the announcement carries no per-recipient secret — every
+ * waiter gets the identical message — so the email body is built once per batch.
+ */
+
+import { sendEmail } from "./email";
+import { normalizeEmail } from "./invites";
+
+/** The env slice the announcement flow needs: D1 (the `waitlist` table) and the
+ *  email seam. */
+export interface AnnounceEnv {
+  DB: D1Database;
+  /** The `send_email` binding; absent in plain local dev (sends log instead). */
+  EMAIL?: SendEmail;
+}
+
+/** The result of a batch: addresses freshly emailed vs. addresses skipped
+ *  (already notified, or not on the waitlist). */
+export interface AnnounceBatchResult {
+  notified: string[];
+  skipped: string[];
+}
+
+/** The launch announcement (HTML + text; both always sent, per the email seam's
+ *  spam-score + client-compat rule). One message for everyone — no per-recipient
+ *  secret — so it takes only the public signup URL. Facts (free tier, pricing,
+ *  founding plan) are pinned to ticket #294; keep them honest if edited. */
+export function announceEmail(signupUrl: string) {
+  return {
+    subject: "Dotflowy is open",
+    text: `You joined the Dotflowy waitlist a while back — thanks for waiting.
+
+Signup is open now, and you don't need an invite code anymore. Come in: ${signupUrl}
+
+The free plan is the whole outliner: up to 10,000 live nodes, and export is always free. Going over the cap never locks you out.
+
+If you want more, unlimited nodes plus agents is $5/mo or $48/yr.
+
+There's also a founding plan — $99 for 3 years, capped at 50 seats. Being straight with you: it's a fixed-term subscription that auto-renews after year three unless you cancel. Not a lifetime deal, just a long runway at a fixed price.
+
+Either way, your account's ready when you are: ${signupUrl}
+
+— The Dotflowy team`,
+    html: `<div style="font-family: system-ui, -apple-system, sans-serif; max-width: 32rem; margin: 0 auto; padding: 24px; color: #111; line-height: 1.5;">
+  <h1 style="font-size: 18px; font-weight: 600;">Dotflowy is open</h1>
+  <p style="font-size: 14px; color: #444;">You joined the Dotflowy waitlist a while back — thanks for waiting. Signup is open now, and you don't need an invite code anymore.</p>
+  <p style="margin: 20px 0;"><a href="${signupUrl}" style="display: inline-block; background: #111; color: #fff; text-decoration: none; font-size: 14px; padding: 10px 16px; border-radius: 6px;">Create your account</a></p>
+  <p style="font-size: 14px; color: #444;">The free plan is the whole outliner: up to 10,000 live nodes, and export is always free. Going over the cap never locks you out.</p>
+  <p style="font-size: 14px; color: #444;">If you want more, unlimited nodes plus agents is <strong>$5/mo</strong> or <strong>$48/yr</strong>.</p>
+  <p style="font-size: 14px; color: #444;">There's also a founding plan — <strong>$99 for 3 years</strong>, capped at 50 seats. Being straight with you: it's a fixed-term subscription that auto-renews after year three unless you cancel. Not a lifetime deal, just a long runway at a fixed price.</p>
+  <p style="font-size: 13px; color: #666;">Your account's ready when you are — <a href="${signupUrl}" style="color: #111;">${signupUrl}</a>.</p>
+  <p style="font-size: 13px; color: #666;">— The Dotflowy team</p>
+</div>`,
+  };
+}
+
+/** Waitlist addresses not yet announced to (`notifiedAt IS NULL`), oldest first.
+ *  `limit` null = every pending row. Mirrors invites' pendingWaitlistEmails. */
+export async function pendingAnnounceEmails(
+  env: AnnounceEnv,
+  limit: number | null,
+): Promise<string[]> {
+  const base =
+    "SELECT email FROM waitlist WHERE notifiedAt IS NULL ORDER BY createdAt ASC";
+  const stmt =
+    limit != null
+      ? env.DB.prepare(`${base} LIMIT ?`).bind(limit)
+      : env.DB.prepare(base);
+  const { results } = await stmt.all<{ email: string }>();
+  return results.map((r) => r.email);
+}
+
+/**
+ * Email the announcement to each address, claiming each waitlist row first so a
+ * send happens at most once. The claim is a CONDITIONAL UPDATE stamping
+ * `notifiedAt` only `WHERE notifiedAt IS NULL`; `meta.changes === 1` means THIS
+ * call won the row (mirrors mintInvites reading `meta.changes` off its
+ * INSERT ... ON CONFLICT). A row already stamped — a re-run, a concurrent batch,
+ * or an address that isn't on the waitlist at all — flips 0 rows and is skipped,
+ * so no one is emailed twice.
+ *
+ * The stamp lands BEFORE the send, and sendEmail never throws (it logs and
+ * swallows), so a delivery failure leaves the row stamped — same trade as
+ * mintInvites, and resendable the same way: clear `notifiedAt` for those rows
+ * and re-run. That's the deliberate choice for an at-most-once blast.
+ */
+export async function sendAnnouncements(
+  env: AnnounceEnv,
+  emails: string[],
+  signupUrl: string,
+): Promise<AnnounceBatchResult> {
+  const notified: string[] = [];
+  const skipped: string[] = [];
+  const seen = new Set<string>();
+  // Identical for everyone (no per-recipient secret) — build once.
+  const message = announceEmail(signupUrl);
+  for (const raw of emails) {
+    const email = normalizeEmail(raw);
+    if (!email || seen.has(email)) continue;
+    seen.add(email);
+    const res = await env.DB.prepare(
+      "UPDATE waitlist SET notifiedAt = ? WHERE email = ? AND notifiedAt IS NULL",
+    )
+      .bind(Date.now(), email)
+      .run();
+    if (res.meta.changes === 0) {
+      skipped.push(email);
+      continue;
+    }
+    await sendEmail(env, { to: email, ...message });
+    notified.push(email);
+  }
+  return { notified, skipped };
+}

--- a/worker/announce.ts
+++ b/worker/announce.ts
@@ -43,28 +43,30 @@ export interface AnnounceBatchResult {
 export function announceEmail(signupUrl: string) {
   return {
     subject: "Dotflowy is open",
-    text: `You joined the Dotflowy waitlist a while back — thanks for waiting.
+    text: `You joined the Dotflowy waitlist a while back. Thanks for waiting.
 
-Signup is open now, and you don't need an invite code anymore. Come in: ${signupUrl}
+Signup's open now, no invite code needed: ${signupUrl}
 
-The free plan is the whole outliner: up to 10,000 live nodes, and export is always free. Going over the cap never locks you out.
+The free plan is the whole outliner: up to 10,000 live nodes, export always free, and going over the cap never locks you out.
 
-If you want more, unlimited nodes plus agents is $5/mo or $48/yr.
+If you want more, unlimited nodes plus agents is $5/mo or $48/yr. There's also a founding plan, $99 for 3 years, capped at 50 seats. It auto-renews after year three unless you cancel. Not a lifetime deal.
 
-There's also a founding plan — $99 for 3 years, capped at 50 seats. Being straight with you: it's a fixed-term subscription that auto-renews after year three unless you cancel. Not a lifetime deal, just a long runway at a fixed price.
+Your account's ready when you are: ${signupUrl}
 
-Either way, your account's ready when you are: ${signupUrl}
+— from Cam Pak
+dotflowy.com
 
-— The Dotflowy team`,
+(Written by Claude to be organized well, content and heart from Cam.)`,
     html: `<div style="font-family: system-ui, -apple-system, sans-serif; max-width: 32rem; margin: 0 auto; padding: 24px; color: #111; line-height: 1.5;">
   <h1 style="font-size: 18px; font-weight: 600;">Dotflowy is open</h1>
-  <p style="font-size: 14px; color: #444;">You joined the Dotflowy waitlist a while back — thanks for waiting. Signup is open now, and you don't need an invite code anymore.</p>
+  <p style="font-size: 14px; color: #444;">You joined the Dotflowy waitlist a while back. Thanks for waiting.</p>
+  <p style="font-size: 14px; color: #444;">Signup's open now, no invite code needed.</p>
   <p style="margin: 20px 0;"><a href="${signupUrl}" style="display: inline-block; background: #111; color: #fff; text-decoration: none; font-size: 14px; padding: 10px 16px; border-radius: 6px;">Create your account</a></p>
-  <p style="font-size: 14px; color: #444;">The free plan is the whole outliner: up to 10,000 live nodes, and export is always free. Going over the cap never locks you out.</p>
-  <p style="font-size: 14px; color: #444;">If you want more, unlimited nodes plus agents is <strong>$5/mo</strong> or <strong>$48/yr</strong>.</p>
-  <p style="font-size: 14px; color: #444;">There's also a founding plan — <strong>$99 for 3 years</strong>, capped at 50 seats. Being straight with you: it's a fixed-term subscription that auto-renews after year three unless you cancel. Not a lifetime deal, just a long runway at a fixed price.</p>
-  <p style="font-size: 13px; color: #666;">Your account's ready when you are — <a href="${signupUrl}" style="color: #111;">${signupUrl}</a>.</p>
-  <p style="font-size: 13px; color: #666;">— The Dotflowy team</p>
+  <p style="font-size: 14px; color: #444;">The free plan is the whole outliner: up to 10,000 live nodes, export always free, and going over the cap never locks you out.</p>
+  <p style="font-size: 14px; color: #444;">If you want more, unlimited nodes plus agents is <strong>$5/mo</strong> or <strong>$48/yr</strong>. There's also a founding plan, <strong>$99 for 3 years</strong>, capped at 50 seats. It auto-renews after year three unless you cancel. Not a lifetime deal.</p>
+  <p style="font-size: 14px; color: #444;">Your account's ready when you are: <a href="${signupUrl}" style="color: #111;">${signupUrl}</a></p>
+  <p style="font-size: 13px; color: #666; margin-bottom: 4px;">— from Cam Pak<br>dotflowy.com</p>
+  <p style="font-size: 12px; color: #999;">(Written by Claude to be organized well, content and heart from Cam.)</p>
 </div>`,
   };
 }

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -35,6 +35,11 @@ import { Data, Effect, Schema } from "effect";
 import type { AuthEnv } from "./auth";
 import type { Node } from "./wire";
 
+import {
+  pendingAnnounceEmails,
+  sendAnnouncements,
+  type AnnounceBatchResult,
+} from "./announce";
 import { createAuth } from "./auth";
 import {
   OutlineSnapshotSchema,
@@ -65,6 +70,7 @@ import { resolveRestorePoint } from "./restore";
 import { workerSentryOptions } from "./sentry";
 import { isHttpUrlString, unfurlTitle } from "./unfurl";
 import {
+  AdminAnnouncePostBody,
   AdminInvitePostBody,
   AdminRestorePostBody,
   AdminSnapshotRestorePostBody,
@@ -591,6 +597,43 @@ async function runInviteBatch(
   return { ...result, count: result.invited.length };
 }
 
+/** Default number of pending waitlist rows a batch announces to when neither
+ *  explicit emails nor `all` is given. Kept small so a bare call is safe. */
+const ANNOUNCE_BATCH_DEFAULT = 25;
+const ANNOUNCE_BATCH_MAX = 500;
+
+/** The public site where signup is now open (#294). The launch blast points at
+ *  the marketing origin, NOT the app origin the invite email uses — signup
+ *  graduated to public here. Pinned, not derived from url.origin. */
+const ANNOUNCE_SIGNUP_URL = "https://dotflowy.com";
+
+/**
+ * Resolve the target addresses for an admin announcement batch, then email + stamp
+ * each (#294). Explicit `emails` win; otherwise it pulls not-yet-notified waitlist
+ * rows — every row with `all`, else the oldest `limit`. Runs on the Worker because
+ * sendAnnouncements sends through the `send_email` binding, which only exists here.
+ * The `notifiedAt` stamp (migration 0009) makes a re-run safe to re-send.
+ */
+async function runAnnounceBatch(
+  env: Env,
+  body: { emails?: readonly string[]; all?: boolean; limit?: number },
+): Promise<AnnounceBatchResult & { count: number }> {
+  let targets: string[];
+  if (body.emails && body.emails.length > 0) {
+    targets = body.emails.map(normalizeEmail).filter(isPlausibleEmail);
+  } else {
+    const limit = body.all
+      ? null
+      : Math.max(
+          1,
+          Math.min(body.limit ?? ANNOUNCE_BATCH_DEFAULT, ANNOUNCE_BATCH_MAX),
+        );
+    targets = await pendingAnnounceEmails(env, limit);
+  }
+  const result = await sendAnnouncements(env, targets, ANNOUNCE_SIGNUP_URL);
+  return { ...result, count: result.notified.length };
+}
+
 // --- Admin restore (PITR) ----------------------------------------------------
 
 /**
@@ -727,6 +770,25 @@ function handleApiRequest(
       return json(
         yield* Effect.promise(() => runInviteBatch(env, body, url.origin)),
       );
+    }
+
+    // Admin-only: email the launch "Dotflowy is open" blast to the waitlist
+    // (#294). Same 404-not-401 admin gate + method order as /api/admin/invite —
+    // the surface shouldn't advertise itself. Driven by scripts/announce.ts.
+    // Lives on the Worker because the send needs the `send_email` binding; the
+    // `notifiedAt` stamp (migration 0009) makes it safe to re-run.
+    if (url.pathname === "/api/admin/announce") {
+      const session = yield* Effect.promise(() =>
+        auth.api.getSession({ headers: request.headers }),
+      );
+      if (!isAdminSession(session, env)) {
+        return yield* Effect.fail(new RouteNotFound({ path: url.pathname }));
+      }
+      if (request.method !== "POST") {
+        return json({ error: "method not allowed" }, 405);
+      }
+      const body = yield* decodeBody(request, AdminAnnouncePostBody);
+      return json(yield* Effect.promise(() => runAnnounceBatch(env, body)));
     }
 
     // Admin-only: restore ONE user's outline to a point in the DO's free 30-day

--- a/worker/wire.ts
+++ b/worker/wire.ts
@@ -87,6 +87,17 @@ export const AdminInvitePostBody = Schema.Struct({
   limit: Schema.optional(Schema.Number),
 });
 
+/** POST /api/admin/announce — email the launch "Dotflowy is open" blast (#294).
+ *  Same shape + admin gate as /api/admin/invite. Provide `emails` to announce to
+ *  specific addresses, or `all`/`limit` to pull not-yet-notified waitlist rows.
+ *  The schema only guards shape; targeting + idempotent stamping live in the
+ *  route (runAnnounceBatch -> sendAnnouncements). */
+export const AdminAnnouncePostBody = Schema.Struct({
+  emails: Schema.optional(Schema.Array(Schema.String)),
+  all: Schema.optional(Schema.Boolean),
+  limit: Schema.optional(Schema.Number),
+});
+
 /** POST /api/admin/restore — restore one user's outline to a point in time via
  *  the DO's 30-day PITR (#220). Admin-gated in the route (session + ADMIN_EMAILS).
  *  Identify the user by `email` OR `userId`; restore to a time (`at`, epoch ms or


### PR DESCRIPTION
Fixes #294

Gives the launch-day "we're open" blast a send path. Today `/api/admin/invite`
sends to exactly one address; this adds a waitlist-wide announcement on the same
seam.

## What changed
- **`POST /api/admin/announce`** (`worker/announce.ts`, wired in `worker/index.ts`) —
  same request shape and admin gate as `/api/admin/invite`. The send runs on the
  Worker and routes through the existing `worker/email.ts` seam (the `send_email`
  binding only exists inside `fetch` — the lesson from #251).
- **`bun run announce`** (`scripts/announce.ts`) — reads the D1 `waitlist` and drives
  the endpoint. Batched (default 25, max 500), resumable, safe to re-run.
- **Idempotency** — new `notifiedAt` column on `waitlist` (`migrations/0009_waitlist_notified.sql`),
  mirroring the `redeemedAt` pattern. Each row is claimed by a conditional
  `UPDATE ... WHERE notifiedAt IS NULL`; only the winning writer sends, so a
  re-run or concurrent batch can't double-send. Only `notifiedAt IS NULL` rows are
  targeted by `--all`/`--limit`.
- **Email copy** — real "Dotflowy is open" launch copy (subject + text + HTML,
  matching the invite email's composition). Draft for review; edit freely.
- Not exporting the list to any third-party mail tool (rejected in the issue).

## Verified
- New unit tests (`worker/announce.test.ts`): idempotent stamping, re-run sends to
  nobody, already-notified/non-waitlist skip, copy facts + honest founding-plan framing.
- Account deletion unaffected: `deleteResidualUserRows` still scrubs the waitlist row
  by email; `worker/account-deletion.test.ts` passes unchanged.
- Gates: `fmt`, `lint`, `typecheck`, `typecheck:worker`, `typecheck:test`,
  `bun test src worker/` (860 pass), `bun run build` — all green.
- **The script has NOT been run and no emails were sent.** No remote D1, no deploy,
  no live-worker calls — tests use in-memory mocks only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
