### PR TITLE
Redact spoilers in MCP write confirmations; harden SSRF name check

### DIFF
--- a/.changeset/spoiler-redact-mcp-writes.md
+++ b/.changeset/spoiler-redact-mcp-writes.md
@@ -1,0 +1,5 @@
+---
+"dotflowy": patch
+---
+
+Harden two Worker egress paths: MCP write-tool confirmations (add_node, add_subtree, move_nodes, mirror_node, import_opml) now redact spoiler runs in the destination parent's text, matching the read tools; and the unfurl SSRF guard strips a trailing dot from the hostname so an FQDN like `foo.internal.` can't slip the internal-name checks.

--- a/worker/mcp-tools.ts
+++ b/worker/mcp-tools.ts
@@ -737,7 +737,7 @@ export const tools: ReadonlyArray<ToolDef> = [
         );
         yield* commit(store, plan.ops);
         const where = plan.parentId
-          ? `under "${index.byId.get(plan.parentId)?.text ?? plan.parentId}"`
+          ? `under "${redactSpoilers(index.byId.get(plan.parentId)?.text ?? plan.parentId)}"`
           : "at the top level";
         return `Added "${input.text}" ${where} (id: ${plan.nodeId}).`;
       }),
@@ -804,7 +804,7 @@ export const tools: ReadonlyArray<ToolDef> = [
         );
         yield* commit(store, plan.ops);
         const where = plan.parentId
-          ? `under "${index.byId.get(plan.parentId)?.text ?? plan.parentId}"`
+          ? `under "${redactSpoilers(index.byId.get(plan.parentId)?.text ?? plan.parentId)}"`
           : "at the top level";
         const kind = plan.parentId ? "bullet(s)" : "top-level bullet(s)";
         return `Added ${plan.rootIds.length} ${kind} ${where}:\n${renderCreatedForest(plan.ops, plan.rootIds)}`;
@@ -897,7 +897,7 @@ export const tools: ReadonlyArray<ToolDef> = [
             : "No change — the node(s) are already in that position.";
         }
         const where = plan.parentId
-          ? `under "${index.byId.get(plan.parentId)?.text ?? plan.parentId}" (id: ${plan.parentId})`
+          ? `under "${redactSpoilers(index.byId.get(plan.parentId)?.text ?? plan.parentId)}" (id: ${plan.parentId})`
           : "to the top level";
         const noun = plan.parentId ? "children" : "items";
         const pos =
@@ -954,7 +954,7 @@ export const tools: ReadonlyArray<ToolDef> = [
         );
         yield* commit(store, plan.ops);
         const where = input.parentId
-          ? `under "${index.byId.get(trueSourceOf(index, input.parentId))?.text ?? input.parentId}"`
+          ? `under "${redactSpoilers(index.byId.get(trueSourceOf(index, input.parentId))?.text ?? input.parentId)}"`
           : "at the top level";
         return `Mirrored node ${plan.sourceId} ${where} (mirror id: ${plan.nodeId}).`;
       }),
@@ -1114,7 +1114,7 @@ export const tools: ReadonlyArray<ToolDef> = [
         );
         if (!dryRun) yield* commit(store, plan.ops);
         const landing = parentId
-          ? `under "${index.byId.get(parentId)?.text ?? parentId}" (id: ${parentId})`
+          ? `under "${redactSpoilers(index.byId.get(parentId)?.text ?? parentId)}" (id: ${parentId})`
           : "at the top level";
         return renderImportReceipt({
           report,

--- a/worker/mcp.test.ts
+++ b/worker/mcp.test.ts
@@ -321,6 +321,22 @@ describe("MCP tools", () => {
     expect(toolText(json)).toContain('Added "new bullet"');
   });
 
+  test("write-tool confirmation redacts a spoiler in the parent's text", async () => {
+    // The read tools redact ||spoiler|| on egress; the write-tool confirmation
+    // strings echo the destination parent's text, so they must redact too, or an
+    // agent could harvest spoiler plaintext the read path withholds.
+    const fake = makeStore([
+      makeNode({ id: "p", text: "plan ||launch-date||" }),
+    ]);
+    const json = await callTool(fake.store, "add_node", {
+      text: "child",
+      parentId: "p",
+    });
+    const text = toolText(json);
+    expect(text).not.toContain("launch-date");
+    expect(text).toContain("[spoiler]");
+  });
+
   test("add_subtree inserts a nested forest as ONE atomic batch, stamping origin on all", async () => {
     const fake = makeStore(fixture());
     const json = await callTool(fake.store, "add_subtree", {

--- a/worker/unfurl-core.ts
+++ b/worker/unfurl-core.ts
@@ -72,7 +72,10 @@ export function isAllowedUnfurlTarget(raw: string): boolean {
     return false;
   }
   if (u.protocol !== "http:" && u.protocol !== "https:") return false;
-  const host = u.hostname.toLowerCase().replace(/^\[|]$/g, ""); // strip IPv6 brackets
+  const host = u.hostname
+    .toLowerCase()
+    .replace(/^\[|]$/g, "") // strip IPv6 brackets
+    .replace(/\.$/, ""); // strip a trailing dot so "foo.internal." can't slip the name checks
   if (!host) return false;
   if (host === "localhost" || host.endsWith(".localhost")) return false;
   if (host.endsWith(".local") || host.endsWith(".internal")) return false;

--- a/worker/unfurl.test.ts
+++ b/worker/unfurl.test.ts
@@ -48,6 +48,12 @@ describe("isAllowedUnfurlTarget (SSRF guard)", () => {
     expect(isAllowedUnfurlTarget("http://db.internal/")).toBe(false);
   });
 
+  it("blocks internal-suffix hostnames with a trailing dot (FQDN form)", () => {
+    expect(isAllowedUnfurlTarget("http://db.internal./")).toBe(false);
+    expect(isAllowedUnfurlTarget("http://printer.local./")).toBe(false);
+    expect(isAllowedUnfurlTarget("http://app.localhost./")).toBe(false);
+  });
+
   it("blocks private / loopback / link-local IPv4 literals", () => {
     expect(isAllowedUnfurlTarget("http://127.0.0.1/")).toBe(false);
     expect(isAllowedUnfurlTarget("http://10.0.0.5/")).toBe(false);


### PR DESCRIPTION
## Summary

A security review of the Worker surface turned up two egress gaps: MCP write-tool confirmations leaked spoiler plaintext the read tools redact, and the unfurl SSRF guard could be slipped by a trailing-dot FQDN. Both are now closed.

## Changes

1. MCP write confirmations (`add_node`, `add_subtree`, `move_nodes`, `mirror_node`, `import_opml`) redact `||spoiler||` runs in the destination parent's echoed text, matching the read tools' egress redaction.
2. The unfurl SSRF guard strips a trailing dot from the hostname, so an FQDN like `foo.internal.` can no longer bypass the `.internal`/`.local`/`.localhost` name checks.

## Test plan

- `bun test worker/mcp.test.ts worker/unfurl.test.ts` — 58 pass (added a confirmation-redaction regression + a trailing-dot FQDN case)
- `bun run typecheck:worker`, `bun run typecheck:test`, `bun run lint` — clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Write-tool confirmation messages now redact spoiler content when displaying destination and parent-node details.
  * Improved protection against unsafe URL fetching by correctly handling hostnames with trailing dots.
* **Security**
  * Internal and localhost-style hostnames using fully qualified trailing-dot forms are now blocked consistently.
* **Tests**
  * Added coverage for spoiler redaction in write confirmations and trailing-dot hostname validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->