### PR TITLE
Heal Daily when upgraded sync skips KV migrate

### DIFF
--- a/.changeset/lunora-migrate-kv-heal.md
+++ b/.changeset/lunora-migrate-kv-heal.md
@@ -1,0 +1,5 @@
+---
+"dotflowy": patch
+---
+
+Heal incomplete classic→upgraded-sync migrate: backfill daily-index (and other side-collections) when outline nodes already landed, so Daily is not left empty after opting in.

--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -34,22 +34,21 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          GOOGLE_GENERATIVE_AI_API_KEY:
-            ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
+          GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
           MOONSHOT_API_KEY: ${{ secrets.MOONSHOT_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
-          
+
           # for Amazon Bedrock (https://docs.pullfrog.com/bedrock)
           # AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
           # AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           # AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           # AWS_REGION: us-east-1
           # BEDROCK_MODEL_ID: <bedrock-model-id>
-          
+
           # for Google Vertex AI (https://docs.pullfrog.com/vertex)
           # VERTEX_SERVICE_ACCOUNT_JSON: >-
           #   ${{ secrets.VERTEX_SERVICE_ACCOUNT_JSON }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -550,7 +550,7 @@ Screenshots **cannot capture view-transition overlays** (they show the settled D
 - Prefer deepening Effect TS and XState usage where they fit.
 - In Cursor, prefer Cursor Auto or Cursor Grok 4.5 for implementation subagents.
 - Lunora sync must stay opt-in (user-facing beta/settings flag); do not force a production cutover while Lunora is alpha.
-- User-facing Settings/beta copy must not name Lunora — frame it as an upgraded/experimental sync option users can try (helps improve Dotflowy; they still own their data).
+- User-facing Settings/beta copy must not name Lunora — frame it as an upgraded/experimental sync option users can try (helps improve Dotflowy; they still own their data); disclose that turning it off returns to the last classic snapshot (cutover is one-way; edits while on stay on that backend).
 
 ## Learned Workspace Facts
 
@@ -558,3 +558,5 @@ Screenshots **cannot capture view-transition overlays** (they show the settled D
 - Daily is a first-party always-on plugin (`src/plugins/daily/`). Core chrome (e.g. `backlinks.tsx` → `useScaffoldKey`) and one bounded plugin read (`node-links` `[[` picker → `getMappedId` to suppress the mapped day uuid row when a date suggestion wins, ADR 0038/0057) may depend on daily-index — deliberate exemptions, not a cross-plugin seam precedent.
 - Lunora (`anolilab/lunora`) is the experimental outline-sync path behind synced `account-prefs`/`lunora-beta` (mirrors localStorage `dotflowy:flag:lunora-sync`) and Worker `LUNORA_OUTLINE`; classic per-user DO remains the default.
 - Vite proxies for `/api` and `/_lunora` need explicit `ws: true` — string shorthand does not upgrade WebSockets and blocks Lunora dogfood on "Loading outline".
+- Upgraded-sync cutover is one-way: flag OFF reloads the classic DO (frozen at migrate); Lunora-era edits do not write back. Reverse Lunora→classic is a follow-up ADR, not current behavior.
+- Classic→Lunora migrate must finish KV independently of nodes — Daily identity is `daily-index` KV, so nodes-only / skip-on-nonempty leaves Daily empty. Completion is Lunora `migrateState` (`nodesAt` / `kvAt`); backfill all side-collections until `kvAt` is set.

--- a/docs/adr/0058-lunora-replaces-custom-outline-sync.md
+++ b/docs/adr/0058-lunora-replaces-custom-outline-sync.md
@@ -36,12 +36,13 @@ Dotflowy’s hand-rolled per-user DO sync (`/api/sync` + client-planned `{ops}` 
 
 ## Classic → Lunora migrate completeness (locked)
 
-Daily identity lives in the `daily-index` KV side-collection, not in nodes. A migrate that imports nodes then skips KV (or fails mid-KV) leaves Daily empty forever if the gate is “Lunora already has nodes → skip.”
+Daily identity lives in the `daily-index` KV side-collection, not in nodes. A migrate that imports nodes then skips KV (or fails mid-KV) leaves Daily empty forever if the gate is “Lunora already has nodes → skip.” The same trap applies to **nodes**: a mid-import chunk failure can leave some Lunora rows durable while classic still has missing ids — `lunoraNodeCount > 0` must never mean “node migration complete.”
 
-- **Watermarks:** shard table `migrateState` `{ userId, nodesAt, kvAt }` (timestamps; null/absent = incomplete). Split so a nodes-only partial migrate is recoverable.
-- **Heal:** when Lunora has nodes but `kvAt` is missing → backfill all three classic KV collections (`daily-index`, `tag-colors`, `saved-queries`) via the existing idempotent `importKvRows` path, then set `kvAt`. If classic KV is empty after a **successful** read and Lunora side-collections already have rows — **or both are empty** (nothing to import) — set `kvAt` without re-import so we don't retry forever. Failed classic GETs must not count as empty. **Never skip solely on `nodes.length > 0`.**
+- **Watermarks:** shard table `migrateState` `{ userId, nodesAt, kvAt }` (timestamps; null/absent = incomplete). Split so each half is independently recoverable.
+- **`nodesAt` semantics:** stamped only after the classic node snapshot is fully imported. When `nodesAt` is null and classic still has nodes → run node import even if Lunora is nonempty. `importNodes` is insert-only, so the runner imports **missing classic ids only** (preserves existing Lunora rows / Lunora-era edits). Never stamp `nodesAt` from `kv-only` / `mark-kv-complete` while classic still has nodes.
+- **KV heal:** when `kvAt` is missing → backfill all three classic KV collections (`daily-index`, `tag-colors`, `saved-queries`) via the existing idempotent `importKvRows` path, then set `kvAt`. If classic KV is empty after a **successful** array read and Lunora side-collections already have rows — **or both are empty** (nothing to import) — set `kvAt` without re-import so we don't retry forever. Failed classic GETs **and non-array 200 bodies** must not count as empty. **Never skip solely on `nodes.length > 0`.**
 - **Complete watermarks short-circuit:** when both `nodesAt` and `kvAt` are set, migrate returns noop **without** fetching classic DO (avoids spurious `failed` if classic is down).
-- **Bootstrap for existing prod shards:** no `migrateState` row + Lunora nodes + missing `kvAt` uses the same heal rules above.
+- **Bootstrap for existing prod shards:** no `migrateState` row + Lunora nodes + no classic nodes + missing `kvAt` uses the KV heal rules above (and may stamp `nodesAt` because classic has nothing left to import).
 - **Toggle OFF is one-way:** Settings discloses that turning off returns the last classic snapshot; edits made while upgraded sync is on stay on that backend until turned back on. Reverse Lunora→classic sync is **out of scope** (follow-up ADR later).
 
 ## Sequence (implementation order)

--- a/docs/adr/0058-lunora-replaces-custom-outline-sync.md
+++ b/docs/adr/0058-lunora-replaces-custom-outline-sync.md
@@ -34,6 +34,16 @@ Dotflowy’s hand-rolled per-user DO sync (`/api/sync` + client-planned `{ops}` 
 - **Kill-switch pairing:** the browser reads `isLunoraSyncEnabled()` (`dotflowy:flag:lunora-sync`, mirrored from synced `account-prefs` on load); Worker MCP reads env force first, else the same preference on classic DO (`isLunoraOutlineEnabledForUser`). For local debugging divergence, flip env + client together (`LUNORA_OUTLINE=0` **and** `lunora-sync=off`, or force both ON).
 - **KV side-collections:** phase **2b** after nodes sync is on Lunora — do not block the collection swap on tag-colors/daily-index/saved-queries.
 
+## Classic → Lunora migrate completeness (locked)
+
+Daily identity lives in the `daily-index` KV side-collection, not in nodes. A migrate that imports nodes then skips KV (or fails mid-KV) leaves Daily empty forever if the gate is “Lunora already has nodes → skip.”
+
+- **Watermarks:** shard table `migrateState` `{ userId, nodesAt, kvAt }` (timestamps; null/absent = incomplete). Split so a nodes-only partial migrate is recoverable.
+- **Heal:** when Lunora has nodes but `kvAt` is missing → backfill all three classic KV collections (`daily-index`, `tag-colors`, `saved-queries`) via the existing idempotent `importKvRows` path, then set `kvAt`. If classic KV is empty after a **successful** read and Lunora side-collections already have rows — **or both are empty** (nothing to import) — set `kvAt` without re-import so we don't retry forever. Failed classic GETs must not count as empty. **Never skip solely on `nodes.length > 0`.**
+- **Complete watermarks short-circuit:** when both `nodesAt` and `kvAt` are set, migrate returns noop **without** fetching classic DO (avoids spurious `failed` if classic is down).
+- **Bootstrap for existing prod shards:** no `migrateState` row + Lunora nodes + missing `kvAt` uses the same heal rules above.
+- **Toggle OFF is one-way:** Settings discloses that turning off returns the last classic snapshot; edits made while upgraded sync is on stay on that backend until turned back on. Reverse Lunora→classic sync is **out of scope** (follow-up ADR later).
+
 ## Sequence (implementation order)
 
 1. Spike Phase 0–1 (done): prove mutators/shapes/watermark/bridge/`seedIfEmpty`.

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -530,6 +530,16 @@ export async function seedOutlineLunora(
      *  (`daily-index` / `tag-colors` / `saved-queries`). */
     kv?: Record<string, { key: string; value: unknown }[]>;
     /**
+     * Classic DO source for auto-migrate / KV heal. When set, GET `/api/nodes`
+     * and `/api/kv` serve this data (instead of empty). Pass Lunora `nodes` as
+     * `[]` for a full classic→Lunora import, or seed Lunora nodes + classic KV
+     * (and omit Lunora `kv`) to exercise the partial-migrate heal.
+     */
+    classicSource?: {
+      nodes?: SeedNode[];
+      kv?: Record<string, { key: string; value: unknown }[]>;
+    };
+    /**
      * Skip post-mutation `wholeOutline` WS pokes (RPC still mutates the mock
      * store). Reproduces a missed shape poke to pin Lunora's sticky optimistic
      * hold across its fallback window.
@@ -600,6 +610,13 @@ export async function seedOutlineLunora(
       userId,
     });
   }
+
+  /** Classic→Lunora migrate watermarks (ADR 0058 heal). */
+  let migrateState: { nodesAt: number | null; kvAt: number | null } | null =
+    null;
+
+  const classicNodes = (opts.classicSource?.nodes ?? []).map((n) => toNode(n));
+  const classicKv = opts.classicSource?.kv ?? {};
 
   let clientSeq = 0;
   let pokeN = 0;
@@ -720,19 +737,31 @@ export async function seedOutlineLunora(
       }),
   );
 
-  // Empty classic DO so auto-migrate no-ops (Lunora store is the seed).
+  // Classic DO: empty by default (auto-migrate no-ops). `classicSource` serves
+  // real classic nodes/kv so migrate / KV-heal can run against the mock.
   await page.route(
     (url) => url.pathname === "/api/nodes",
     (route) => {
-      if (route.request().method() === "GET") return reply(route, []);
+      if (route.request().method() === "GET") {
+        return reply(route, classicNodes);
+      }
       return route.fulfill({ status: 404, body: "{}" });
     },
   );
   await page.route(
     (url) => url.pathname === "/api/kv",
     (route) => {
-      if (route.request().method() === "GET") return reply(route, []);
-      return route.fulfill({ status: 404, body: "{}" });
+      if (route.request().method() !== "GET") {
+        return route.fulfill({ status: 404, body: "{}" });
+      }
+      const collection =
+        new URL(route.request().url()).searchParams.get("collection") ?? "";
+      const rows = classicKv[collection] ?? [];
+      // Classic Worker returns the stored values (key embedded in each object).
+      return reply(
+        route,
+        rows.map((r) => r.value),
+      );
     },
   );
 
@@ -913,6 +942,72 @@ export async function seedOutlineLunora(
         const imported = (args.nodes as OutlineNode[] | undefined) ?? [];
         commitOutlinePlan(store, planImportNodes(imported));
         result = { count: imported.length };
+      } else if (path === "mutators:importKvRows") {
+        const rows =
+          (args.rows as
+            | Array<{
+                kind: string;
+                tag?: string;
+                color?: string;
+                id?: string;
+                name?: string;
+                query?: string;
+                createdAt?: number;
+                key?: string;
+                nodeId?: string;
+                touchedAt?: number;
+              }>
+            | undefined) ?? [];
+        const poke = new Set<string>();
+        for (const row of rows) {
+          if (row.kind === "tagColor") {
+            const tag = String(row.tag ?? "");
+            tagColors.set(tag, {
+              _id: tag,
+              tag,
+              color: String(row.color ?? ""),
+              userId,
+            });
+            poke.add("userTagColors");
+          } else if (row.kind === "savedQuery") {
+            const sid = String(row.id ?? "");
+            savedQueries.set(sid, {
+              _id: sid,
+              name: String(row.name ?? ""),
+              query: String(row.query ?? ""),
+              createdAt: Number(row.createdAt ?? 0),
+              userId,
+            });
+            poke.add("userSavedQueries");
+          } else if (row.kind === "dailyIndex") {
+            const key = String(row.key ?? "");
+            dailyIndex.set(key, {
+              _id: key,
+              key,
+              nodeId: String(row.nodeId ?? ""),
+              touchedAt: Number(row.touchedAt ?? Date.now()),
+              userId,
+            });
+            poke.add("userDailyIndex");
+          }
+        }
+        result = { count: rows.length };
+        pokeShapes = poke;
+      } else if (path === "mutators:getMigrateState") {
+        result = migrateState ?? { nodesAt: null, kvAt: null };
+        pokeShapes = new Set();
+      } else if (path === "mutators:setMigrateState") {
+        const prev = migrateState ?? { nodesAt: null, kvAt: null };
+        migrateState = {
+          nodesAt:
+            args.nodesAt !== undefined
+              ? (args.nodesAt as number | null)
+              : prev.nodesAt,
+          kvAt:
+            args.kvAt !== undefined ? (args.kvAt as number | null) : prev.kvAt,
+        };
+        result = migrateState;
+        pokeShapes = new Set();
       } else if (path === "mutators:mirrorNode") {
         commitOutlinePlan(
           store,

--- a/e2e/lunora-migrate-heal.spec.ts
+++ b/e2e/lunora-migrate-heal.spec.ts
@@ -1,0 +1,83 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { localDateKey } from "../src/data/date-links";
+import { seedOutlineLunora, type SeedNode } from "./fixtures";
+
+/**
+ * ADR 0058 migrate heal: Lunora already has outline nodes (partial migrate)
+ * but daily-index never landed. Classic KV still has the mapping — flag ON
+ * must backfill KV so Today is not empty.
+ */
+
+const todayButton = (page: Page) =>
+  page.getByRole("button", { name: "Today's daily note" });
+
+test.describe("Lunora classic→Lunora migrate heal", () => {
+  test("partial migrate backfills daily-index so Today keeps the same node", async ({
+    page,
+  }) => {
+    const dayKey = localDateKey();
+    const year = String(new Date().getFullYear());
+
+    const tree: SeedNode[] = [
+      {
+        id: "daily-container",
+        parentId: null,
+        prevSiblingId: null,
+        text: "Daily",
+      },
+      {
+        id: "today-day",
+        parentId: "daily-container",
+        prevSiblingId: null,
+        text: `Tuesday, July 26, ${year}`,
+      },
+      {
+        id: "migrated-note",
+        parentId: "today-day",
+        prevSiblingId: null,
+        text: "MigratedNote",
+      },
+    ];
+
+    // Lunora has the nodes (bug state: skipped-nonempty) but no Lunora kv.
+    // Classic still holds daily-index → heal must import it.
+    await seedOutlineLunora(page, tree, {
+      classicSource: {
+        nodes: tree,
+        kv: {
+          "daily-index": [
+            {
+              key: "container",
+              value: { key: "container", nodeId: "daily-container" },
+            },
+            {
+              key: dayKey,
+              value: { key: dayKey, nodeId: "today-day" },
+            },
+          ],
+        },
+      },
+    });
+
+    await page.goto("/");
+    // Nodes paint before KV heal finishes — wait for the daily badge that only
+    // appears once classic daily-index has been imported into Lunora.
+    await expect(
+      page.locator(
+        `li[data-node-id="today-day"] [data-daily-date="${dayKey}"]`,
+      ),
+    ).toBeVisible({ timeout: 15_000 });
+
+    await todayButton(page).click();
+    await expect(page).toHaveURL(/\/today-day/);
+    await expect(
+      page.locator(
+        'li[data-node-id="migrated-note"] > .outline-row .node-text',
+      ),
+    ).toHaveText("MigratedNote");
+    await expect(
+      page.locator(`h2.zoomed-title [data-daily-date="${dayKey}"]`),
+    ).toBeVisible();
+  });
+});

--- a/lunora/_generated/dataModel.ts
+++ b/lunora/_generated/dataModel.ts
@@ -33,7 +33,7 @@ export type {
     WhereOperators,
 } from "lunorash/server/data-model";
 
-export type TableName = "nodes" | "tagColors" | "savedQueries" | "dailyIndex" | "ratelimit_buckets";
+export type TableName = "nodes" | "tagColors" | "savedQueries" | "dailyIndex" | "migrateState" | "ratelimit_buckets";
 
 /**
  * The tables **this app declared** — every {@link TableName} except those an add-on
@@ -50,7 +50,7 @@ export type TableName = "nodes" | "tagColors" | "savedQueries" | "dailyIndex" | 
  * const EXPORTED: readonly AppTableName[] = ["nodes", "tagColors"];
  * ```
  */
-export type AppTableName = "nodes" | "tagColors" | "savedQueries" | "dailyIndex";
+export type AppTableName = "nodes" | "tagColors" | "savedQueries" | "dailyIndex" | "migrateState";
 
 export type Id<TName extends string> = string & { readonly __table: TName };
 
@@ -98,6 +98,14 @@ export interface Doc_dailyIndex {
     userId: string;
 }
 
+export interface Doc_migrateState {
+    _id: Id<"migrateState">;
+    _creationTime: number;
+    userId: string;
+    nodesAt: number;
+    kvAt: number;
+}
+
 export interface Doc_ratelimit_buckets {
     _id: Id<"ratelimit_buckets">;
     _creationTime: number;
@@ -112,6 +120,7 @@ export interface DataModel {
     tagColors: Doc_tagColors;
     savedQueries: Doc_savedQueries;
     dailyIndex: Doc_dailyIndex;
+    migrateState: Doc_migrateState;
     ratelimit_buckets: Doc_ratelimit_buckets;
 }
 
@@ -126,6 +135,7 @@ export interface IndexNamesByTable {
     tagColors: "by_tag";
     savedQueries: never;
     dailyIndex: "by_key";
+    migrateState: never;
     ratelimit_buckets: "by_key";
 }
 
@@ -137,6 +147,7 @@ export interface SearchIndexNamesByTable {
     tagColors: never;
     savedQueries: never;
     dailyIndex: never;
+    migrateState: never;
     ratelimit_buckets: never;
 }
 
@@ -148,6 +159,7 @@ export interface RankIndexNamesByTable {
     tagColors: never;
     savedQueries: never;
     dailyIndex: never;
+    migrateState: never;
     ratelimit_buckets: never;
 }
 
@@ -159,6 +171,7 @@ export interface GeoIndexNamesByTable {
     tagColors: never;
     savedQueries: never;
     dailyIndex: never;
+    migrateState: never;
     ratelimit_buckets: never;
 }
 
@@ -211,6 +224,14 @@ export interface Insert_dailyIndex {
     userId: string;
 }
 
+export interface Insert_migrateState {
+    _id?: Id<"migrateState">;
+    _creationTime?: number;
+    userId: string;
+    nodesAt: number;
+    kvAt: number;
+}
+
 export interface Insert_ratelimit_buckets {
     _id?: Id<"ratelimit_buckets">;
     _creationTime?: number;
@@ -226,6 +247,7 @@ export interface InsertModel {
     tagColors: Insert_tagColors;
     savedQueries: Insert_savedQueries;
     dailyIndex: Insert_dailyIndex;
+    migrateState: Insert_migrateState;
     ratelimit_buckets: Insert_ratelimit_buckets;
 }
 
@@ -252,6 +274,7 @@ export interface Relations {
     tagColors: {};
     savedQueries: {};
     dailyIndex: {};
+    migrateState: {};
     ratelimit_buckets: {};
 }
 

--- a/lunora/_generated/drizzle.shard.ts
+++ b/lunora/_generated/drizzle.shard.ts
@@ -53,6 +53,14 @@ export const dailyIndex = sqliteTable("dailyIndex", {
     by_key: index("by_key").on(t.key),
 }));
 
+export const migrateState = sqliteTable("migrateState", {
+    _id: text("_id").primaryKey(),
+    _creationTime: integer("_creationTime").notNull(),
+    userId: text("userId").notNull(),
+    nodesAt: real("nodesAt").notNull(),
+    kvAt: real("kvAt").notNull(),
+});
+
 export const ratelimit_buckets = sqliteTable("ratelimit_buckets", {
     _id: text("_id").primaryKey(),
     _creationTime: integer("_creationTime").notNull(),

--- a/lunora/_generated/functions.ts
+++ b/lunora/_generated/functions.ts
@@ -44,6 +44,7 @@ export const LUNORA_FUNCTIONS: Record<string, RegisteredLunoraFunction> = {
     "mutators:deleteDailyMapping": lunora_mutators_1.deleteDailyMapping as unknown as RegisteredLunoraFunction,
     "mutators:deleteSavedQuery": lunora_mutators_1.deleteSavedQuery as unknown as RegisteredLunoraFunction,
     "mutators:deleteTagColor": lunora_mutators_1.deleteTagColor as unknown as RegisteredLunoraFunction,
+    "mutators:getMigrateState": lunora_mutators_1.getMigrateState as unknown as RegisteredLunoraFunction,
     "mutators:hello": lunora_mutators_1.hello as unknown as RegisteredLunoraFunction,
     "mutators:importKvRows": lunora_mutators_1.importKvRows as unknown as RegisteredLunoraFunction,
     "mutators:importNodes": lunora_mutators_1.importNodes as unknown as RegisteredLunoraFunction,
@@ -67,6 +68,7 @@ export const LUNORA_FUNCTIONS: Record<string, RegisteredLunoraFunction> = {
     "mutators:setCompleted": lunora_mutators_1.setCompleted as unknown as RegisteredLunoraFunction,
     "mutators:setIsTask": lunora_mutators_1.setIsTask as unknown as RegisteredLunoraFunction,
     "mutators:setKind": lunora_mutators_1.setKind as unknown as RegisteredLunoraFunction,
+    "mutators:setMigrateState": lunora_mutators_1.setMigrateState as unknown as RegisteredLunoraFunction,
     "mutators:setText": lunora_mutators_1.setText as unknown as RegisteredLunoraFunction,
     "mutators:splitNode": lunora_mutators_1.splitNode as unknown as RegisteredLunoraFunction,
     "mutators:upsertDailyMapping": lunora_mutators_1.upsertDailyMapping as unknown as RegisteredLunoraFunction,
@@ -121,7 +123,7 @@ export const LUNORA_SHAPES: Record<string, RegisteredShape> = {
  * ShardDO's `isCustomMutator` override routes through the client-watermark push
  * protocol (`x-lunora-client-id`/`x-lunora-client-seq` ordering).
  */
-export const LUNORA_MUTATOR_PATHS: ReadonlySet<string> = new Set(["mutators:appendChild", "mutators:claimDailyMapping", "mutators:deleteDailyMapping", "mutators:deleteSavedQuery", "mutators:deleteTagColor", "mutators:hello", "mutators:importKvRows", "mutators:importNodes", "mutators:indent", "mutators:indentMany", "mutators:insertChildAtStart", "mutators:insertSibling", "mutators:materializeDailyNodes", "mutators:mirrorNode", "mutators:moveMany", "mutators:moveNode", "mutators:outdent", "mutators:outdentMany", "mutators:patchSavedQuery", "mutators:removeMany", "mutators:removeNode", "mutators:restoreNodes", "mutators:seedIfEmpty", "mutators:setBookmarkedAt", "mutators:setCollapsed", "mutators:setCompleted", "mutators:setIsTask", "mutators:setKind", "mutators:setText", "mutators:splitNode", "mutators:upsertDailyMapping", "mutators:upsertSavedQuery", "mutators:upsertTagColor"]);
+export const LUNORA_MUTATOR_PATHS: ReadonlySet<string> = new Set(["mutators:appendChild", "mutators:claimDailyMapping", "mutators:deleteDailyMapping", "mutators:deleteSavedQuery", "mutators:deleteTagColor", "mutators:getMigrateState", "mutators:hello", "mutators:importKvRows", "mutators:importNodes", "mutators:indent", "mutators:indentMany", "mutators:insertChildAtStart", "mutators:insertSibling", "mutators:materializeDailyNodes", "mutators:mirrorNode", "mutators:moveMany", "mutators:moveNode", "mutators:outdent", "mutators:outdentMany", "mutators:patchSavedQuery", "mutators:removeMany", "mutators:removeNode", "mutators:restoreNodes", "mutators:seedIfEmpty", "mutators:setBookmarkedAt", "mutators:setCollapsed", "mutators:setCompleted", "mutators:setIsTask", "mutators:setKind", "mutators:setMigrateState", "mutators:setText", "mutators:splitNode", "mutators:upsertDailyMapping", "mutators:upsertSavedQuery", "mutators:upsertTagColor"]);
 
 /**
  * Connection-lifecycle manifest: the function paths the generated ShardDO

--- a/lunora/_generated/openapi.json
+++ b/lunora/_generated/openapi.json
@@ -58,7 +58,7 @@
   "info": {
     "description": "Auto-generated from @lunora/values-typed functions by @lunora/codegen. Do not edit — run `lunora codegen` to regenerate.",
     "title": "Lunora API",
-    "version": "1.9.1"
+    "version": "1.10.0"
   },
   "openapi": "3.1.0",
   "paths": {},

--- a/lunora/_generated/openapi.ts
+++ b/lunora/_generated/openapi.ts
@@ -61,7 +61,7 @@ export const openApiSpec: Record<string, unknown> = {
     "info": {
         "description": "Auto-generated from @lunora/values-typed functions by @lunora/codegen. Do not edit — run `lunora codegen` to regenerate.",
         "title": "Lunora API",
-        "version": "1.9.1"
+        "version": "1.10.0"
     },
     "openapi": "3.1.0",
     "paths": {},

--- a/lunora/_generated/shard.ts
+++ b/lunora/_generated/shard.ts
@@ -232,6 +232,34 @@ const LUNORA_TABLE_COLUMNS: Record<string, Array<{ isStorage?: boolean; name: st
             "type": "string"
         }
     ],
+    "migrateState": [
+        {
+            "name": "_id",
+            "optional": false,
+            "pk": true,
+            "type": "id"
+        },
+        {
+            "name": "_creationTime",
+            "optional": false,
+            "type": "number"
+        },
+        {
+            "name": "userId",
+            "optional": false,
+            "type": "string"
+        },
+        {
+            "name": "nodesAt",
+            "optional": false,
+            "type": "number"
+        },
+        {
+            "name": "kvAt",
+            "optional": false,
+            "type": "number"
+        }
+    ],
     "ratelimit_buckets": [
         {
             "name": "_id",
@@ -877,6 +905,7 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             facade["tagColors"] = bindTableFacade(db, "tagColors");
             facade["savedQueries"] = bindTableFacade(db, "savedQueries");
             facade["dailyIndex"] = bindTableFacade(db, "dailyIndex");
+            facade["migrateState"] = bindTableFacade(db, "migrateState");
             facade["ratelimit_buckets"] = bindTableFacade(db, "ratelimit_buckets");
 
 

--- a/lunora/mcp.ts
+++ b/lunora/mcp.ts
@@ -170,6 +170,7 @@ const CONTENT_TABLES = [
   "tagColors",
   "savedQueries",
   "dailyIndex",
+  "migrateState",
 ] as const;
 
 /**

--- a/lunora/mutators.ts
+++ b/lunora/mutators.ts
@@ -34,7 +34,12 @@ import {
 } from "../src/data/outline-plans";
 import { resolveDailyClaim } from "../src/plugins/daily/claim-mapping";
 
-type ShardTable = "nodes" | "tagColors" | "savedQueries" | "dailyIndex";
+type ShardTable =
+  | "nodes"
+  | "tagColors"
+  | "savedQueries"
+  | "dailyIndex"
+  | "migrateState";
 
 /** Minimal mutator ctx — defineMutator's ServerContext is the base MutationCtx. */
 type MutatorDb = {
@@ -949,5 +954,68 @@ export const deleteDailyMapping = defineMutator({
     assertOwner(mctx, args.userId);
     const existing = await getDailyByKey(mctx, args.key);
     if (existing) await mctx.db.delete(existing._id as Id<"dailyIndex">);
+  },
+});
+
+// --- migrateState (classic → Lunora watermarks) -----------------------------
+
+async function getMigrateStateRow(
+  ctx: MutatorCtx,
+): Promise<(Record<string, unknown> & { _id: string }) | null> {
+  const rows = await ctx.db.query("migrateState").collect();
+  return rows[0] ?? null;
+}
+
+/** Read migrate watermarks (`null` fields = incomplete). */
+export const getMigrateState = defineMutator({
+  args: { userId: userIdArg },
+  server: async (ctx, args) => {
+    const mctx = ctx as unknown as MutatorCtx;
+    assertOwner(mctx, args.userId);
+    const row = await getMigrateStateRow(mctx);
+    if (!row)
+      return { nodesAt: null as number | null, kvAt: null as number | null };
+    return {
+      nodesAt: typeof row.nodesAt === "number" ? row.nodesAt : null,
+      kvAt: typeof row.kvAt === "number" ? row.kvAt : null,
+    };
+  },
+});
+
+/**
+ * Upsert migrate watermarks. Omitted fields are left unchanged (or null on
+ * first insert). Pass an explicit timestamp to mark that half complete.
+ */
+export const setMigrateState = defineMutator({
+  args: {
+    userId: userIdArg,
+    nodesAt: v.optional(v.number().nullable()),
+    kvAt: v.optional(v.number().nullable()),
+  },
+  server: async (ctx, args) => {
+    const mctx = ctx as unknown as MutatorCtx;
+    assertOwner(mctx, args.userId);
+    const existing = await getMigrateStateRow(mctx);
+    if (existing) {
+      const patch: Record<string, unknown> = {};
+      if (args.nodesAt !== undefined) patch.nodesAt = args.nodesAt;
+      if (args.kvAt !== undefined) patch.kvAt = args.kvAt;
+      if (Object.keys(patch).length > 0) {
+        await mctx.db.patch(existing._id as Id<"migrateState">, patch);
+      }
+      const next = await getMigrateStateRow(mctx);
+      return {
+        nodesAt: typeof next?.nodesAt === "number" ? next.nodesAt : null,
+        kvAt: typeof next?.kvAt === "number" ? next.kvAt : null,
+      };
+    }
+    const nodesAt = args.nodesAt === undefined ? null : args.nodesAt;
+    const kvAt = args.kvAt === undefined ? null : args.kvAt;
+    await mctx.db.insert("migrateState", {
+      userId: args.userId,
+      nodesAt,
+      kvAt,
+    });
+    return { nodesAt, kvAt };
   },
 });

--- a/lunora/schema.ts
+++ b/lunora/schema.ts
@@ -68,4 +68,17 @@ export default defineSchema({
     .shardBy("userId")
     .ownedBy("userId")
     .index("by_key", ["key"]),
+
+  /**
+   * Classic → Lunora migrate watermarks (ADR 0058). One row per shard.
+   * `nodesAt` / `kvAt` are completion timestamps; null/absent = incomplete.
+   * Split so a nodes-only partial migrate can still heal KV (daily-index etc.).
+   */
+  migrateState: defineTable({
+    userId: v.string(),
+    nodesAt: v.number().nullable(),
+    kvAt: v.number().nullable(),
+  })
+    .shardBy("userId")
+    .ownedBy("userId"),
 }).extend(ratelimit.extension);

--- a/src/data/lunora-migrate-plan.test.ts
+++ b/src/data/lunora-migrate-plan.test.ts
@@ -18,7 +18,31 @@ describe("planMigrateSteps", () => {
     ).toBe("full");
   });
 
-  test("nodes present without kvAt → KV-only heal", () => {
+  test("nodesAt null + Lunora partial + classic nodes → full (not kv-only)", () => {
+    // Partial chunk import left some Lunora rows; remaining classic ids must
+    // still import before nodesAt can be stamped.
+    expect(
+      planMigrateSteps({
+        lunoraNodeCount: 5,
+        migrateState: { nodesAt: null, kvAt: null },
+        classicHasNodes: true,
+        classicKvCount: 3,
+        lunoraKvCount: 0,
+      }),
+    ).toBe("full");
+
+    expect(
+      planMigrateSteps({
+        lunoraNodeCount: 5,
+        migrateState: null,
+        classicHasNodes: true,
+        classicKvCount: 0,
+        lunoraKvCount: 0,
+      }),
+    ).toBe("full");
+  });
+
+  test("nodesAt set without kvAt → KV-only heal", () => {
     expect(
       planMigrateSteps({
         lunoraNodeCount: 10,
@@ -28,8 +52,9 @@ describe("planMigrateSteps", () => {
         lunoraKvCount: 0,
       }),
     ).toBe("kv-only");
+  });
 
-    // Prod bootstrap: no migrateState row, nodes already on Lunora.
+  test("prod bootstrap: no migrateState, Lunora nodes, no classic nodes → kv-only", () => {
     expect(
       planMigrateSteps({
         lunoraNodeCount: 10,
@@ -57,7 +82,7 @@ describe("planMigrateSteps", () => {
     expect(
       planMigrateSteps({
         lunoraNodeCount: 5,
-        migrateState: null,
+        migrateState: { nodesAt: 1, kvAt: null },
         classicHasNodes: false,
         classicKvCount: 0,
         lunoraKvCount: 2,
@@ -67,7 +92,7 @@ describe("planMigrateSteps", () => {
 
   // Intentional: successful empty classic GET + empty Lunora KV = nothing to
   // import; stamp kvAt so heal doesn't retry forever (ADR 0058).
-  test("nodes present, classic + Lunora KV both empty → mark-kv-complete", () => {
+  test("nodesAt set, classic + Lunora KV both empty → mark-kv-complete", () => {
     expect(
       planMigrateSteps({
         lunoraNodeCount: 5,

--- a/src/data/lunora-migrate-plan.test.ts
+++ b/src/data/lunora-migrate-plan.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  classicDailyRowToImport,
+  planMigrateSteps,
+} from "./lunora-migrate-plan";
+
+describe("planMigrateSteps", () => {
+  test("empty Lunora shard + classic nodes → full migrate", () => {
+    expect(
+      planMigrateSteps({
+        lunoraNodeCount: 0,
+        migrateState: null,
+        classicHasNodes: true,
+        classicKvCount: 2,
+        lunoraKvCount: 0,
+      }),
+    ).toBe("full");
+  });
+
+  test("nodes present without kvAt → KV-only heal", () => {
+    expect(
+      planMigrateSteps({
+        lunoraNodeCount: 10,
+        migrateState: { nodesAt: 1, kvAt: null },
+        classicHasNodes: true,
+        classicKvCount: 3,
+        lunoraKvCount: 0,
+      }),
+    ).toBe("kv-only");
+
+    // Prod bootstrap: no migrateState row, nodes already on Lunora.
+    expect(
+      planMigrateSteps({
+        lunoraNodeCount: 10,
+        migrateState: null,
+        classicHasNodes: false,
+        classicKvCount: 3,
+        lunoraKvCount: 0,
+      }),
+    ).toBe("kv-only");
+  });
+
+  test("both watermarks set → no-op", () => {
+    expect(
+      planMigrateSteps({
+        lunoraNodeCount: 10,
+        migrateState: { nodesAt: 1, kvAt: 2 },
+        classicHasNodes: true,
+        classicKvCount: 99,
+        lunoraKvCount: 0,
+      }),
+    ).toBe("noop");
+  });
+
+  test("nodes present, classic KV empty, Lunora KV present → mark-kv-complete", () => {
+    expect(
+      planMigrateSteps({
+        lunoraNodeCount: 5,
+        migrateState: null,
+        classicHasNodes: false,
+        classicKvCount: 0,
+        lunoraKvCount: 2,
+      }),
+    ).toBe("mark-kv-complete");
+  });
+
+  // Intentional: successful empty classic GET + empty Lunora KV = nothing to
+  // import; stamp kvAt so heal doesn't retry forever (ADR 0058).
+  test("nodes present, classic + Lunora KV both empty → mark-kv-complete", () => {
+    expect(
+      planMigrateSteps({
+        lunoraNodeCount: 5,
+        migrateState: { nodesAt: 1, kvAt: null },
+        classicHasNodes: true,
+        classicKvCount: 0,
+        lunoraKvCount: 0,
+      }),
+    ).toBe("mark-kv-complete");
+  });
+
+  test("classic KV nonempty → kv-only (heal still imports)", () => {
+    expect(
+      planMigrateSteps({
+        lunoraNodeCount: 8,
+        migrateState: { nodesAt: 1, kvAt: null },
+        classicHasNodes: true,
+        classicKvCount: 4,
+        lunoraKvCount: 0,
+      }),
+    ).toBe("kv-only");
+  });
+
+  test("empty everything → empty-source (seed path)", () => {
+    expect(
+      planMigrateSteps({
+        lunoraNodeCount: 0,
+        migrateState: null,
+        classicHasNodes: false,
+        classicKvCount: 0,
+        lunoraKvCount: 0,
+      }),
+    ).toBe("empty-source");
+  });
+});
+
+describe("classicDailyRowToImport", () => {
+  test("classic /api/kv daily-index row → dailyIndex import shape", () => {
+    expect(
+      classicDailyRowToImport(
+        {
+          key: "2026-07-26",
+          value: { key: "2026-07-26", nodeId: "day-node-1" },
+        },
+        1_700_000_000_000,
+      ),
+    ).toEqual({
+      kind: "dailyIndex",
+      key: "2026-07-26",
+      nodeId: "day-node-1",
+      touchedAt: 1_700_000_000_000,
+    });
+  });
+
+  test("falls back to row.key when value.key missing", () => {
+    expect(
+      classicDailyRowToImport(
+        { key: "container", value: { nodeId: "daily-root" } },
+        42,
+      ),
+    ).toEqual({
+      kind: "dailyIndex",
+      key: "container",
+      nodeId: "daily-root",
+      touchedAt: 42,
+    });
+  });
+
+  test("drops rows without nodeId", () => {
+    expect(
+      classicDailyRowToImport({ key: "x", value: { key: "x" } }, 1),
+    ).toBeNull();
+  });
+});

--- a/src/data/lunora-migrate-plan.ts
+++ b/src/data/lunora-migrate-plan.ts
@@ -26,7 +26,11 @@ export type PlanMigrateStepsInput = {
 
 /**
  * Decide migrate work from counts + watermarks.
- * Never skip solely because `lunoraNodeCount > 0` — KV may still be incomplete.
+ *
+ * - `nodesAt` means the entire classic node snapshot is imported — never
+ *   infer it from `lunoraNodeCount > 0` (a partial chunk import can leave
+ *   some rows durable while classic still has missing ids).
+ * - KV completion stays independent of nodes (Daily = `daily-index` KV).
  */
 export function planMigrateSteps(input: PlanMigrateStepsInput): MigrateStep {
   const nodesAt = input.migrateState?.nodesAt ?? null;
@@ -34,23 +38,29 @@ export function planMigrateSteps(input: PlanMigrateStepsInput): MigrateStep {
 
   if (nodesAt != null && kvAt != null) return "noop";
 
-  if (input.lunoraNodeCount === 0) {
-    if (input.classicHasNodes) return "full";
-    // No classic nodes — still heal orphan classic KV, else seed path.
-    if (kvAt == null) {
-      if (input.classicKvCount > 0) return "kv-only";
-      if (input.lunoraKvCount > 0) return "mark-kv-complete";
+  // Node watermark missing + classic still has the source → finish node
+  // import even when Lunora already has some rows (idempotent missing-id
+  // import in the runner). Never treat lunoraNodeCount > 0 as complete.
+  if (nodesAt == null && input.classicHasNodes) return "full";
+
+  // Node half done (watermark set, or nothing classic to import).
+  if (kvAt == null) {
+    if (input.classicKvCount > 0) return "kv-only";
+    // classicKvCount === 0 means a successful empty classic read (failed GETs
+    // must reject before reaching the planner). Stamp kvAt when Lunora already
+    // has rows / nodesAt is set, or when both sides are empty after a real
+    // outline landed — otherwise we'd retry forever.
+    if (
+      input.lunoraKvCount > 0 ||
+      input.lunoraNodeCount > 0 ||
+      nodesAt != null
+    ) {
+      return "mark-kv-complete";
     }
     return "empty-source";
   }
 
-  // Lunora already has nodes — never treat that as migrate-complete alone.
-  if (kvAt != null) return "noop";
-  if (input.classicKvCount > 0) return "kv-only";
-  // classicKvCount === 0 means a successful empty classic read (failed GETs
-  // must reject before reaching the planner). Stamp kvAt when Lunora already
-  // has side-collection rows, or when both sides are empty (nothing to
-  // import) — otherwise we'd retry forever.
+  // kvAt set, nodesAt null, !classicHasNodes — stamp nodesAt only.
   return "mark-kv-complete";
 }
 

--- a/src/data/lunora-migrate-plan.ts
+++ b/src/data/lunora-migrate-plan.ts
@@ -1,0 +1,142 @@
+/**
+ * Pure migrate planner (ADR 0058) — classic DO → Lunora heal decisions.
+ * Unit-tested without a live store / network.
+ */
+
+export type MigrateStateSnapshot = {
+  nodesAt: number | null;
+  kvAt: number | null;
+};
+
+/** What the migrate runner should do next. */
+export type MigrateStep =
+  | "full"
+  | "kv-only"
+  | "mark-kv-complete"
+  | "noop"
+  | "empty-source";
+
+export type PlanMigrateStepsInput = {
+  lunoraNodeCount: number;
+  migrateState: MigrateStateSnapshot | null;
+  classicHasNodes: boolean;
+  classicKvCount: number;
+  lunoraKvCount: number;
+};
+
+/**
+ * Decide migrate work from counts + watermarks.
+ * Never skip solely because `lunoraNodeCount > 0` — KV may still be incomplete.
+ */
+export function planMigrateSteps(input: PlanMigrateStepsInput): MigrateStep {
+  const nodesAt = input.migrateState?.nodesAt ?? null;
+  const kvAt = input.migrateState?.kvAt ?? null;
+
+  if (nodesAt != null && kvAt != null) return "noop";
+
+  if (input.lunoraNodeCount === 0) {
+    if (input.classicHasNodes) return "full";
+    // No classic nodes — still heal orphan classic KV, else seed path.
+    if (kvAt == null) {
+      if (input.classicKvCount > 0) return "kv-only";
+      if (input.lunoraKvCount > 0) return "mark-kv-complete";
+    }
+    return "empty-source";
+  }
+
+  // Lunora already has nodes — never treat that as migrate-complete alone.
+  if (kvAt != null) return "noop";
+  if (input.classicKvCount > 0) return "kv-only";
+  // classicKvCount === 0 means a successful empty classic read (failed GETs
+  // must reject before reaching the planner). Stamp kvAt when Lunora already
+  // has side-collection rows, or when both sides are empty (nothing to
+  // import) — otherwise we'd retry forever.
+  return "mark-kv-complete";
+}
+
+export type ClassicKvRow = { key: string; value: unknown };
+
+export type ImportKvRow =
+  | { kind: "tagColor"; tag: string; color: string }
+  | {
+      kind: "savedQuery";
+      id: string;
+      name: string;
+      query: string;
+      createdAt: number;
+    }
+  | {
+      kind: "dailyIndex";
+      key: string;
+      nodeId: string;
+      touchedAt: number;
+    };
+
+/** Classic `/api/kv?collection=daily-index` value → Lunora `importKvRows` row. */
+export function classicDailyRowToImport(
+  row: ClassicKvRow,
+  touchedAt: number,
+): Extract<ImportKvRow, { kind: "dailyIndex" }> | null {
+  const value = row.value as { key?: string; nodeId?: string };
+  const key = String(value.key ?? row.key);
+  const nodeId = String(value.nodeId ?? "");
+  if (!key || !nodeId) return null;
+  return { kind: "dailyIndex", key, nodeId, touchedAt };
+}
+
+/** Classic tag-colors row → import shape. */
+export function classicTagColorRowToImport(
+  row: ClassicKvRow,
+): Extract<ImportKvRow, { kind: "tagColor" }> | null {
+  const value = row.value as { tag?: string; color?: string };
+  const tag = String(value.tag ?? row.key);
+  const color = String(value.color ?? "");
+  if (!tag || !color) return null;
+  return { kind: "tagColor", tag, color };
+}
+
+/** Classic saved-queries row → import shape. */
+export function classicSavedQueryRowToImport(
+  row: ClassicKvRow,
+  touchedAt: number,
+): Extract<ImportKvRow, { kind: "savedQuery" }> | null {
+  const value = row.value as {
+    id?: string;
+    name?: string;
+    query?: string;
+    createdAt?: number;
+  };
+  const id = String(value.id ?? row.key);
+  if (!id) return null;
+  return {
+    kind: "savedQuery",
+    id,
+    name: String(value.name ?? value.query ?? id),
+    query: String(value.query ?? ""),
+    createdAt: Number(value.createdAt ?? touchedAt),
+  };
+}
+
+/** Build the full importKvRows payload from classic side-collection fetches. */
+export function planClassicKvImportRows(input: {
+  tagColors: ClassicKvRow[];
+  savedQueries: ClassicKvRow[];
+  dailyIndex: ClassicKvRow[];
+  touchedAt: number;
+}): ImportKvRow[] {
+  const { touchedAt } = input;
+  return [
+    ...input.tagColors.flatMap((row) => {
+      const mapped = classicTagColorRowToImport(row);
+      return mapped ? [mapped] : [];
+    }),
+    ...input.savedQueries.flatMap((row) => {
+      const mapped = classicSavedQueryRowToImport(row, touchedAt);
+      return mapped ? [mapped] : [];
+    }),
+    ...input.dailyIndex.flatMap((row) => {
+      const mapped = classicDailyRowToImport(row, touchedAt);
+      return mapped ? [mapped] : [];
+    }),
+  ];
+}

--- a/src/data/lunora-migrate.test.ts
+++ b/src/data/lunora-migrate.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import type { OutlineStore } from "./lunora-outline-store";
+
+import {
+  fetchClassicKvBundles,
+  migrateClassicToLunora,
+} from "./lunora-migrate";
+
+const realFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+function jsonOk(body: unknown): Response {
+  return new Response(JSON.stringify(body), { status: 200 });
+}
+
+function installKvFetch(
+  handlers: Record<string, () => Response | Promise<Response>>,
+): void {
+  globalThis.fetch = ((url: string) => {
+    const u = String(url);
+    const collection = new URL(u, "http://local").searchParams.get(
+      "collection",
+    );
+    if (!collection || !(collection in handlers)) {
+      return Promise.reject(new Error(`unexpected fetch ${u}`));
+    }
+    return Promise.resolve(handlers[collection]!());
+  }) as unknown as typeof fetch;
+}
+
+function readyCollection(rows: unknown[]) {
+  return {
+    toArray: rows,
+    toArrayWhenReady: () => Promise.resolve(rows),
+  };
+}
+
+/** Minimal store stub for migrateClassicToLunora unit tests. */
+function stubStore(opts: {
+  nodes?: unknown[];
+  tagColors?: unknown[];
+  savedQueries?: unknown[];
+  dailyIndex?: unknown[];
+  migrateState?: { nodesAt: number | null; kvAt: number | null } | null;
+}): OutlineStore {
+  const migrateState = opts.migrateState ?? null;
+  return {
+    client: {
+      callMutator: async (ref: string) => {
+        if (ref === "mutators:getMigrateState") {
+          return { result: migrateState };
+        }
+        if (ref === "mutators:setMigrateState") {
+          return { result: null };
+        }
+        throw new Error(`unexpected mutator ${ref}`);
+      },
+      importRows: async () => ({ imported: 0 }),
+    },
+    collection: readyCollection(opts.nodes ?? [{ id: "n1" }]),
+    tagColors: readyCollection(opts.tagColors ?? []),
+    savedQueries: readyCollection(opts.savedQueries ?? []),
+    dailyIndex: readyCollection(opts.dailyIndex ?? []),
+    mutators: {},
+  } as unknown as OutlineStore;
+}
+
+describe("fetchClassicKvBundles", () => {
+  test("count 0 only when every GET succeeds with []", async () => {
+    installKvFetch({
+      "tag-colors": () => jsonOk([]),
+      "saved-queries": () => jsonOk([]),
+      "daily-index": () => jsonOk([]),
+    });
+    const bundles = await fetchClassicKvBundles();
+    expect(bundles.count).toBe(0);
+    expect(bundles.tagColors).toEqual([]);
+    expect(bundles.savedQueries).toEqual([]);
+    expect(bundles.dailyIndex).toEqual([]);
+  });
+
+  test("rejects when any /api/kv GET fails (never treats failure as empty)", async () => {
+    installKvFetch({
+      "tag-colors": () => jsonOk([]),
+      "saved-queries": () =>
+        new Response("boom", { status: 500, statusText: "Internal" }),
+      "daily-index": () => jsonOk([{ key: "container", nodeId: "d" }]),
+    });
+    await expect(fetchClassicKvBundles()).rejects.toThrow(
+      /GET \/api\/kv saved-queries 500/,
+    );
+  });
+
+  test("rejects on network failure for a collection", async () => {
+    installKvFetch({
+      "tag-colors": () => {
+        throw new Error("network down");
+      },
+      "saved-queries": () => jsonOk([]),
+      "daily-index": () => jsonOk([]),
+    });
+    await expect(fetchClassicKvBundles()).rejects.toThrow("network down");
+  });
+});
+
+describe("migrateClassicToLunora", () => {
+  test("both watermarks set → skipped-complete without classic fetch", async () => {
+    let fetchCalls = 0;
+    globalThis.fetch = (() => {
+      fetchCalls += 1;
+      return Promise.reject(new Error("classic fetch must not run"));
+    }) as unknown as typeof fetch;
+
+    const result = await migrateClassicToLunora(
+      stubStore({
+        nodes: [{ id: "a" }, { id: "b" }],
+        migrateState: { nodesAt: 100, kvAt: 200 },
+      }),
+      "user-1",
+    );
+
+    expect(result).toEqual({ status: "skipped-complete", nodes: 2 });
+    expect(fetchCalls).toBe(0);
+  });
+});

--- a/src/data/lunora-migrate.test.ts
+++ b/src/data/lunora-migrate.test.ts
@@ -32,12 +32,35 @@ function installKvFetch(
   }) as unknown as typeof fetch;
 }
 
+function installClassicFetch(opts: {
+  nodes?: unknown;
+  kv?: Record<string, unknown>;
+}): void {
+  globalThis.fetch = ((url: string) => {
+    const u = String(url);
+    if (u.includes("/api/nodes")) {
+      return Promise.resolve(jsonOk(opts.nodes ?? []));
+    }
+    const collection = new URL(u, "http://local").searchParams.get(
+      "collection",
+    );
+    if (collection && opts.kv && collection in opts.kv) {
+      return Promise.resolve(jsonOk(opts.kv[collection]));
+    }
+    if (collection) return Promise.resolve(jsonOk([]));
+    return Promise.reject(new Error(`unexpected fetch ${u}`));
+  }) as unknown as typeof fetch;
+}
+
 function readyCollection(rows: unknown[]) {
   return {
     toArray: rows,
     toArrayWhenReady: () => Promise.resolve(rows),
   };
 }
+
+type MutatorCall = { ref: string; args: Record<string, unknown> };
+type ImportCall = { kind: "nodes" | "kv"; count: number };
 
 /** Minimal store stub for migrateClassicToLunora unit tests. */
 function stubStore(opts: {
@@ -46,27 +69,67 @@ function stubStore(opts: {
   savedQueries?: unknown[];
   dailyIndex?: unknown[];
   migrateState?: { nodesAt: number | null; kvAt: number | null } | null;
+  onMutator?: (call: MutatorCall) => void;
+  onImport?: (call: ImportCall) => void;
 }): OutlineStore {
-  const migrateState = opts.migrateState ?? null;
+  let migrateState = opts.migrateState ?? null;
   return {
     client: {
-      callMutator: async (ref: string) => {
+      callMutator: async (ref: string, args: Record<string, unknown>) => {
+        opts.onMutator?.({ ref, args });
         if (ref === "mutators:getMigrateState") {
           return { result: migrateState };
         }
         if (ref === "mutators:setMigrateState") {
-          return { result: null };
+          migrateState = {
+            nodesAt:
+              args.nodesAt === undefined
+                ? (migrateState?.nodesAt ?? null)
+                : (args.nodesAt as number | null),
+            kvAt:
+              args.kvAt === undefined
+                ? (migrateState?.kvAt ?? null)
+                : (args.kvAt as number | null),
+          };
+          return { result: migrateState };
         }
         throw new Error(`unexpected mutator ${ref}`);
       },
-      importRows: async () => ({ imported: 0 }),
+      importRows: async (
+        _ref: unknown,
+        rows: unknown[],
+        options: { toArgs: (chunk: unknown[]) => { nodes?: unknown[] } },
+      ) => {
+        const args = options.toArgs(rows);
+        const kind = Array.isArray(args.nodes) ? "nodes" : "kv";
+        opts.onImport?.({ kind, count: rows.length });
+        return { imported: rows.length };
+      },
     },
-    collection: readyCollection(opts.nodes ?? [{ id: "n1" }]),
+    collection: readyCollection(opts.nodes ?? [{ _id: "n1" }]),
     tagColors: readyCollection(opts.tagColors ?? []),
     savedQueries: readyCollection(opts.savedQueries ?? []),
     dailyIndex: readyCollection(opts.dailyIndex ?? []),
     mutators: {},
   } as unknown as OutlineStore;
+}
+
+function classicNode(id: string, prev: string | null = null) {
+  return {
+    id,
+    parentId: null,
+    prevSiblingId: prev,
+    text: id,
+    isTask: false,
+    completed: false,
+    collapsed: false,
+    bookmarkedAt: null,
+    mirrorOf: null,
+    createdAt: 1,
+    updatedAt: 1,
+    origin: null,
+    kind: null,
+  };
 }
 
 describe("fetchClassicKvBundles", () => {
@@ -105,6 +168,17 @@ describe("fetchClassicKvBundles", () => {
     });
     await expect(fetchClassicKvBundles()).rejects.toThrow("network down");
   });
+
+  test("rejects malformed 200 body (non-array) — never treats as empty", async () => {
+    installKvFetch({
+      "tag-colors": () => jsonOk([]),
+      "saved-queries": () => jsonOk({ not: "an-array" }),
+      "daily-index": () => jsonOk([]),
+    });
+    await expect(fetchClassicKvBundles()).rejects.toThrow(
+      /GET \/api\/kv saved-queries returned a non-array body/,
+    );
+  });
 });
 
 describe("migrateClassicToLunora", () => {
@@ -117,7 +191,7 @@ describe("migrateClassicToLunora", () => {
 
     const result = await migrateClassicToLunora(
       stubStore({
-        nodes: [{ id: "a" }, { id: "b" }],
+        nodes: [{ _id: "a" }, { _id: "b" }],
         migrateState: { nodesAt: 100, kvAt: 200 },
       }),
       "user-1",
@@ -125,5 +199,70 @@ describe("migrateClassicToLunora", () => {
 
     expect(result).toEqual({ status: "skipped-complete", nodes: 2 });
     expect(fetchCalls).toBe(0);
+  });
+
+  test("partial Lunora nodes + classic remainder → imports missing ids before nodesAt", async () => {
+    const imports: ImportCall[] = [];
+    const patches: MutatorCall[] = [];
+    installClassicFetch({
+      nodes: [classicNode("a"), classicNode("b", "a"), classicNode("c", "b")],
+      kv: {
+        "tag-colors": [],
+        "saved-queries": [],
+        "daily-index": [{ key: "container", nodeId: "daily" }],
+      },
+    });
+
+    const result = await migrateClassicToLunora(
+      stubStore({
+        // Partial prior import: only `a` landed.
+        nodes: [{ _id: "a" }],
+        migrateState: { nodesAt: null, kvAt: null },
+        onImport: (c) => imports.push(c),
+        onMutator: (c) => {
+          if (c.ref === "mutators:setMigrateState") patches.push(c);
+        },
+      }),
+      "user-1",
+    );
+
+    expect(result.status).toBe("migrated");
+    if (result.status !== "migrated") return;
+    expect(result.nodes).toBe(2); // b + c only
+    expect(imports.filter((i) => i.kind === "nodes")).toEqual([
+      { kind: "nodes", count: 2 },
+    ]);
+    // nodesAt stamped before/with kv — never skipped over a partial set.
+    expect(patches[0]?.args.nodesAt).toEqual(expect.any(Number));
+    expect(patches[0]?.args.kvAt).toBeUndefined();
+    expect(patches.some((p) => typeof p.args.kvAt === "number")).toBe(true);
+  });
+
+  test("malformed KV 200 → failed migrate, no kvAt stamp", async () => {
+    const patches: MutatorCall[] = [];
+    installClassicFetch({
+      nodes: [classicNode("a")],
+      kv: {
+        "tag-colors": [],
+        "saved-queries": { bad: true },
+        "daily-index": [],
+      },
+    });
+
+    const result = await migrateClassicToLunora(
+      stubStore({
+        nodes: [],
+        migrateState: null,
+        onMutator: (c) => {
+          if (c.ref === "mutators:setMigrateState") patches.push(c);
+        },
+      }),
+      "user-1",
+    );
+
+    expect(result.status).toBe("failed");
+    if (result.status !== "failed") return;
+    expect(String(result.error)).toMatch(/non-array body/);
+    expect(patches).toEqual([]);
   });
 });

--- a/src/data/lunora-migrate.ts
+++ b/src/data/lunora-migrate.ts
@@ -1,11 +1,12 @@
 /**
  * One-shot UserOutlineDO → Lunora shard migrate (ADR 0058).
  *
- * Safe default: if Lunora already has nodes, skip (do not replace).
- * Classic DO data is left untouched.
+ * Completeness is tracked in Lunora `migrateState` (`nodesAt` / `kvAt`).
+ * Nodes alone never skip KV — a partial migrate (nodes landed, daily-index
+ * missing) heals on the next flag-ON / `__dotflowyMigrateToLunora` pass.
  *
- * Auto-runs from `lunora-sync` when flag ON + Lunora empty + classic has data.
- * Manual: `await window.__dotflowyMigrateToLunora()` or More menu.
+ * Auto-runs from `lunora-sync` when flag ON.
+ * Manual: `await window.__dotflowyMigrateToLunora()`.
  */
 
 import type { FunctionReference } from "lunorash/client";
@@ -14,11 +15,18 @@ import type { OutlineStore } from "./lunora-outline-store";
 import type { OutlineNode } from "./outline-plans";
 
 import { api } from "../../lunora/_generated/api";
+import {
+  planClassicKvImportRows,
+  planMigrateSteps,
+  type ClassicKvRow,
+  type ImportKvRow,
+  type MigrateStateSnapshot,
+} from "./lunora-migrate-plan";
 import { notifySaveFailed } from "./save-failure";
 
 export type MigrateResult =
   | { status: "migrated"; nodes: number; kv: number }
-  | { status: "skipped-nonempty"; nodes: number }
+  | { status: "skipped-complete"; nodes: number }
   | { status: "skipped-empty-source" }
   | { status: "failed"; error: unknown };
 
@@ -38,24 +46,7 @@ type ClassicNode = {
   kind: "paragraph" | null;
 };
 
-type KvRow = { key: string; value: unknown };
-
 type ImportNodesArgs = { userId: string; nodes: ReadonlyArray<OutlineNode> };
-type ImportKvRow =
-  | { kind: "tagColor"; tag: string; color: string }
-  | {
-      kind: "savedQuery";
-      id: string;
-      name: string;
-      query: string;
-      createdAt: number;
-    }
-  | {
-      kind: "dailyIndex";
-      key: string;
-      nodeId: string;
-      touchedAt: number;
-    };
 type MigrationApi = {
   mutators: {
     importNodes: FunctionReference<"mutation", ImportNodesArgs, unknown>;
@@ -95,7 +86,7 @@ async function fetchClassicNodes(): Promise<ClassicNode[]> {
   return Array.isArray(body) ? body : [];
 }
 
-async function fetchKv(collection: string): Promise<KvRow[]> {
+async function fetchKv(collection: string): Promise<ClassicKvRow[]> {
   const res = await fetch(
     `/api/kv?collection=${encodeURIComponent(collection)}`,
     { credentials: "include" },
@@ -119,6 +110,34 @@ async function fetchKv(collection: string): Promise<KvRow[]> {
   });
 }
 
+async function readMigrateState(
+  store: OutlineStore,
+  userId: string,
+): Promise<MigrateStateSnapshot> {
+  const { result } = await store.client.callMutator(
+    "mutators:getMigrateState",
+    { userId },
+    { shardKey: userId },
+  );
+  const row = result as MigrateStateSnapshot | null | undefined;
+  return {
+    nodesAt: typeof row?.nodesAt === "number" ? row.nodesAt : null,
+    kvAt: typeof row?.kvAt === "number" ? row.kvAt : null,
+  };
+}
+
+async function writeMigrateState(
+  store: OutlineStore,
+  userId: string,
+  patch: { nodesAt?: number | null; kvAt?: number | null },
+): Promise<void> {
+  await store.client.callMutator(
+    "mutators:setMigrateState",
+    { userId, ...patch },
+    { shardKey: userId },
+  );
+}
+
 async function importNodes(
   store: OutlineStore,
   userId: string,
@@ -131,64 +150,68 @@ async function importNodes(
   });
 }
 
-async function importKv(store: OutlineStore, userId: string): Promise<number> {
-  const t = Date.now();
+/**
+ * Fetch classic DO side-collections. Empty arrays are only valid when GET
+ * succeeds with `[]` — a failed fetch must reject so migrate leaves `kvAt`
+ * null and can heal on retry (never stamp mark-kv-complete from a 5xx/network
+ * miss).
+ */
+export async function fetchClassicKvBundles(): Promise<{
+  tagColors: ClassicKvRow[];
+  savedQueries: ClassicKvRow[];
+  dailyIndex: ClassicKvRow[];
+  count: number;
+}> {
+  const [tagColors, savedQueries, dailyIndex] = await Promise.all([
+    fetchKv("tag-colors"),
+    fetchKv("saved-queries"),
+    fetchKv("daily-index"),
+  ]);
+  return {
+    tagColors,
+    savedQueries,
+    dailyIndex,
+    count: tagColors.length + savedQueries.length + dailyIndex.length,
+  };
+}
 
-  const tags = await fetchKv("tag-colors").catch(() => [] as KvRow[]);
-  const tagRows = tags.flatMap((row) => {
-    const value = row.value as { tag?: string; color?: string };
-    const tag = String(value.tag ?? row.key);
-    const color = String(value.color ?? "");
-    return tag && color ? [{ kind: "tagColor" as const, tag, color }] : [];
-  });
+function lunoraKvCount(store: OutlineStore): number {
+  return (
+    store.tagColors.toArray.length +
+    store.savedQueries.toArray.length +
+    store.dailyIndex.toArray.length
+  );
+}
 
-  const saved = await fetchKv("saved-queries").catch(() => [] as KvRow[]);
-  const savedRows = saved.flatMap((row) => {
-    const value = row.value as {
-      id?: string;
-      name?: string;
-      query?: string;
-      createdAt?: number;
-    };
-    const id = String(value.id ?? row.key);
-    return id
-      ? [
-          {
-            kind: "savedQuery" as const,
-            id,
-            name: String(value.name ?? value.query ?? id),
-            query: String(value.query ?? ""),
-            createdAt: Number(value.createdAt ?? t),
-          },
-        ]
-      : [];
+async function importKv(
+  store: OutlineStore,
+  userId: string,
+  bundles: {
+    tagColors: ClassicKvRow[];
+    savedQueries: ClassicKvRow[];
+    dailyIndex: ClassicKvRow[];
+  },
+): Promise<number> {
+  const rows = planClassicKvImportRows({
+    ...bundles,
+    touchedAt: Date.now(),
   });
-
-  const daily = await fetchKv("daily-index").catch(() => [] as KvRow[]);
-  const dailyRows = daily.flatMap((row) => {
-    const value = row.value as { key?: string; nodeId?: string };
-    const key = String(value.key ?? row.key);
-    const nodeId = String(value.nodeId ?? "");
-    return key && nodeId
-      ? [{ kind: "dailyIndex" as const, key, nodeId, touchedAt: t }]
-      : [];
-  });
+  if (rows.length === 0) return 0;
   const result = await store.client.importRows(
     migrationApi.mutators.importKvRows,
-    [...tagRows, ...savedRows, ...dailyRows],
+    rows,
     {
       importId: `classic-${userId}-kv`,
       shardKey: userId,
-      toArgs: (rows) => ({ userId, rows }),
+      toArgs: (chunk) => ({ userId, rows: chunk }),
     },
   );
-
   return result.imported;
 }
 
 /**
- * Import classic DO outline (+ kv) into an empty Lunora shard.
- * @param force — unused for replace (replace is out of scope); reserved.
+ * Import classic DO outline (+ kv) into Lunora, healing incomplete KV when
+ * nodes already exist. Classic DO data is left untouched.
  */
 export async function migrateClassicToLunora(
   store: OutlineStore,
@@ -196,26 +219,71 @@ export async function migrateClassicToLunora(
   opts: { force?: boolean } = {},
 ): Promise<MigrateResult> {
   void opts.force;
-  const lunoraCount = store.collection.toArray.length;
-  if (lunoraCount > 0) {
-    return { status: "skipped-nonempty", nodes: lunoraCount };
-  }
-
   try {
-    const classic = await fetchClassicNodes();
-    if (classic.length === 0) {
-      return { status: "skipped-empty-source" };
+    // Wait for side-collections so lunoraKvCount is accurate for mark-complete.
+    await Promise.all([
+      store.collection.toArrayWhenReady(),
+      store.tagColors.toArrayWhenReady(),
+      store.savedQueries.toArrayWhenReady(),
+      store.dailyIndex.toArrayWhenReady(),
+    ]);
+
+    const migrateState = await readMigrateState(store, userId);
+    const lunoraNodes = store.collection.toArray.length;
+
+    // Both watermarks set → complete. Do not fetch classic: a 5xx/network
+    // error would spuriously fail an already-finished migrate.
+    if (migrateState.nodesAt != null && migrateState.kvAt != null) {
+      return { status: "skipped-complete", nodes: lunoraNodes };
     }
-    const nodes = classic.map((n) => asOutlineNode(n, userId));
-    await importNodes(store, userId, nodes);
-    const kv = await importKv(store, userId);
-    return { status: "migrated", nodes: nodes.length, kv };
+
+    const classic = await fetchClassicNodes();
+    const classicKv = await fetchClassicKvBundles();
+    const step = planMigrateSteps({
+      lunoraNodeCount: lunoraNodes,
+      migrateState,
+      classicHasNodes: classic.length > 0,
+      classicKvCount: classicKv.count,
+      lunoraKvCount: lunoraKvCount(store),
+    });
+
+    const now = Date.now();
+
+    switch (step) {
+      case "noop":
+        return { status: "skipped-complete", nodes: lunoraNodes };
+      case "empty-source":
+        return { status: "skipped-empty-source" };
+      case "mark-kv-complete": {
+        await writeMigrateState(store, userId, {
+          nodesAt: migrateState.nodesAt ?? now,
+          kvAt: now,
+        });
+        return { status: "migrated", nodes: 0, kv: 0 };
+      }
+      case "kv-only": {
+        const kv = await importKv(store, userId, classicKv);
+        await writeMigrateState(store, userId, {
+          nodesAt: migrateState.nodesAt ?? now,
+          kvAt: now,
+        });
+        return { status: "migrated", nodes: 0, kv };
+      }
+      case "full": {
+        const nodes = classic.map((n) => asOutlineNode(n, userId));
+        await importNodes(store, userId, nodes);
+        await writeMigrateState(store, userId, { nodesAt: now });
+        const kv = await importKv(store, userId, classicKv);
+        await writeMigrateState(store, userId, { kvAt: Date.now() });
+        return { status: "migrated", nodes: nodes.length, kv };
+      }
+    }
   } catch (error) {
     return { status: "failed", error };
   }
 }
 
-/** Auto path: migrate when Lunora empty; returns whether seedIfEmpty should run. */
+/** Auto path: migrate / heal; returns whether seedIfEmpty should run. */
 export async function maybeAutoMigrateToLunora(
   store: OutlineStore,
   userId: string,
@@ -227,7 +295,7 @@ export async function maybeAutoMigrateToLunora(
         `[lunora-migrate] imported ${result.nodes} nodes + ${result.kv} kv rows from classic DO`,
       );
       return "ready";
-    case "skipped-nonempty":
+    case "skipped-complete":
       return "ready";
     case "skipped-empty-source":
       return "seed";
@@ -240,7 +308,7 @@ export async function maybeAutoMigrateToLunora(
   }
 }
 
-/** DevTools / More-menu entry. */
+/** DevTools entry. */
 export function installMigrateConsoleHelper(
   getStore: () => { store: OutlineStore; userId: string } | null,
 ): void {

--- a/src/data/lunora-migrate.ts
+++ b/src/data/lunora-migrate.ts
@@ -2,6 +2,8 @@
  * One-shot UserOutlineDO → Lunora shard migrate (ADR 0058).
  *
  * Completeness is tracked in Lunora `migrateState` (`nodesAt` / `kvAt`).
+ * `nodesAt` is stamped only after the classic node snapshot is fully
+ * imported (missing-id chunks when Lunora already has a partial set).
  * Nodes alone never skip KV — a partial migrate (nodes landed, daily-index
  * missing) heals on the next flag-ON / `__dotflowyMigrateToLunora` pass.
  *
@@ -12,7 +14,6 @@
 import type { FunctionReference } from "lunorash/client";
 
 import type { OutlineStore } from "./lunora-outline-store";
-import type { OutlineNode } from "./outline-plans";
 
 import { api } from "../../lunora/_generated/api";
 import {
@@ -22,6 +23,7 @@ import {
   type ImportKvRow,
   type MigrateStateSnapshot,
 } from "./lunora-migrate-plan";
+import { rowToNode, type OutlineNode } from "./outline-plans";
 import { notifySaveFailed } from "./save-failure";
 
 export type MigrateResult =
@@ -92,8 +94,10 @@ async function fetchKv(collection: string): Promise<ClassicKvRow[]> {
     { credentials: "include" },
   );
   if (!res.ok) throw new Error(`GET /api/kv ${collection} ${res.status}`);
-  const body = (await res.json()) as unknown[];
-  if (!Array.isArray(body)) return [];
+  const body = (await res.json()) as unknown;
+  if (!Array.isArray(body)) {
+    throw new Error(`GET /api/kv ${collection} returned a non-array body`);
+  }
   // /api/kv GET returns the stored values; daily-index/tag-colors/saved-queries
   // each embed their key inside the value object.
   return body.map((value) => {
@@ -143,6 +147,7 @@ async function importNodes(
   userId: string,
   nodes: OutlineNode[],
 ): Promise<void> {
+  if (nodes.length === 0) return;
   await store.client.importRows(migrationApi.mutators.importNodes, nodes, {
     importId: `classic-${userId}-nodes`,
     shardKey: userId,
@@ -209,16 +214,29 @@ async function importKv(
   return result.imported;
 }
 
+/** Classic ids not yet on the Lunora shard — importNodes is insert-only. */
+function missingClassicNodes(
+  store: OutlineStore,
+  classic: ClassicNode[],
+  userId: string,
+): OutlineNode[] {
+  const existing = new Set(
+    store.collection.toArray.map((n) => rowToNode(n).id),
+  );
+  return classic
+    .filter((n) => !existing.has(n.id))
+    .map((n) => asOutlineNode(n, userId));
+}
+
 /**
- * Import classic DO outline (+ kv) into Lunora, healing incomplete KV when
- * nodes already exist. Classic DO data is left untouched.
+ * Import classic DO outline (+ kv) into Lunora, healing incomplete node/KV
+ * halves independently. Classic DO data is left untouched. Existing Lunora
+ * rows are preserved (missing-id node import; KV upsert).
  */
 export async function migrateClassicToLunora(
   store: OutlineStore,
   userId: string,
-  opts: { force?: boolean } = {},
 ): Promise<MigrateResult> {
-  void opts.force;
   try {
     // Wait for side-collections so lunoraKvCount is accurate for mark-complete.
     await Promise.all([
@@ -255,26 +273,38 @@ export async function migrateClassicToLunora(
       case "empty-source":
         return { status: "skipped-empty-source" };
       case "mark-kv-complete": {
-        await writeMigrateState(store, userId, {
-          nodesAt: migrateState.nodesAt ?? now,
-          kvAt: now,
-        });
+        // Stamp nodesAt only when classic has nothing left to import for
+        // nodes — never invent completeness over a partial node import.
+        const patch: { nodesAt?: number; kvAt?: number } = {};
+        if (migrateState.nodesAt == null && classic.length === 0) {
+          patch.nodesAt = now;
+        }
+        if (migrateState.kvAt == null) patch.kvAt = now;
+        if (Object.keys(patch).length > 0) {
+          await writeMigrateState(store, userId, patch);
+        }
         return { status: "migrated", nodes: 0, kv: 0 };
       }
       case "kv-only": {
         const kv = await importKv(store, userId, classicKv);
-        await writeMigrateState(store, userId, {
-          nodesAt: migrateState.nodesAt ?? now,
-          kvAt: now,
-        });
+        const patch: { nodesAt?: number; kvAt: number } = { kvAt: now };
+        if (migrateState.nodesAt == null && classic.length === 0) {
+          patch.nodesAt = now;
+        }
+        await writeMigrateState(store, userId, patch);
         return { status: "migrated", nodes: 0, kv };
       }
       case "full": {
-        const nodes = classic.map((n) => asOutlineNode(n, userId));
+        // importNodes is insert-only — skip ids already on the shard so a
+        // partial prior import can top up without clobbering Lunora-era edits.
+        const nodes = missingClassicNodes(store, classic, userId);
         await importNodes(store, userId, nodes);
         await writeMigrateState(store, userId, { nodesAt: now });
-        const kv = await importKv(store, userId, classicKv);
-        await writeMigrateState(store, userId, { kvAt: Date.now() });
+        let kv = 0;
+        if (migrateState.kvAt == null) {
+          kv = await importKv(store, userId, classicKv);
+          await writeMigrateState(store, userId, { kvAt: Date.now() });
+        }
         return { status: "migrated", nodes: nodes.length, kv };
       }
     }

--- a/src/data/lunora-sync.ts
+++ b/src/data/lunora-sync.ts
@@ -126,9 +126,9 @@ export function startLunoraOutlineSync(userId: string): void {
     .then(async () => {
       if (!ctx || ctx.store !== store) return;
       feedTreeFromCollection(store);
-      // One-shot classic DO → Lunora when shard empty (skip if already has rows).
-      // Shell stays gated until migrate settles — otherwise the user can edit/
-      // seed into an empty shard while import chunks land.
+      // Classic DO → Lunora migrate / KV heal (ADR 0058 watermarks). Shell stays
+      // gated until migrate settles — otherwise the user can edit/seed into an
+      // empty shard while import chunks land.
       const next = await maybeAutoMigrateToLunora(store, userId);
       if (!ctx || ctx.store !== store) return;
       feedTreeFromCollection(store);

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -767,7 +767,10 @@ function BetaSection() {
               Try Dotflowy&apos;s next sync engine. Your outline stays yours —
               we never claim your data. Opting in helps us harden it before
               everyone gets it. May have rough edges; your choice syncs across
-              devices, and toggling reloads the app.
+              devices, and toggling reloads the app. Turning it off returns you
+              to your last classic snapshot — edits you make while this is on
+              stay on the upgraded backend until you turn it back on (one-way
+              for now; they do not copy back automatically).
             </>
           }
           action={


### PR DESCRIPTION
## Summary

Turning on upgraded outline sync could leave Daily empty: nodes imported while `daily-index` never retried once the Lunora shard was non-empty. Classic DO stayed intact, so flipping the flag off looked like a restore. Follow-up also stops partial node imports from falsely stamping `nodesAt`.

## Changes

1. Partial classic→Lunora cutovers backfill side-collections (daily-index, tag colors, saved filters) when nodes already landed but KV never finished.
2. Shard `migrateState` watermarks (`nodesAt` / `kvAt`) stop re-import loops and short-circuit classic fetches once both halves are done.
3. Failed classic `/api/kv` GETs (and non-array 200 bodies) no longer look empty — migrate fails without stamping `kvAt`, so a later retry can heal.
4. `nodesAt` means the full classic node snapshot: when null and classic still has nodes, import missing ids even if Lunora is nonempty; never stamp `nodesAt` from kv-only/mark paths over a partial set.
5. Settings discloses the one-way toggle: OFF returns the last classic snapshot; upgraded-sync edits stay on that backend.
6. ADR 0058 records migrate completeness + one-way OFF; reverse Lunora→classic deferred.

**Start here:** change 1 — the skip-on-nodes-only gate is what stranded Daily in prod. Change 4 is the matching node-half trap.

## Flow

```mermaid
flowchart TD
  start[Flag ON / auto-migrate] --> wm{nodesAt and kvAt set?}
  wm -->|yes| noop[skipped-complete]
  wm -->|no| fetch[Fetch classic nodes + KV]
  fetch --> plan[planMigrateSteps]
  plan --> full[full: missing-id node import]
  plan --> kv[kv-only backfill]
  plan --> mark[mark-kv-complete]
  plan --> empty[empty-source → seed]
  full --> nodesAt[Set nodesAt after import]
  nodesAt --> kvFull[KV if kvAt null]
  kvFull --> done[Set kvAt]
  kv --> doneK[Set kvAt; nodesAt only if classic empty]
  mark --> doneK
```

## Breaking / Migration

Deploy before relying on heal (new `migrateState` table + mutators). Existing Lunora shards with nodes but missing daily-index heal on next flag-ON / `__dotflowyMigrateToLunora()`. Partial node imports with `nodesAt` null re-import missing classic ids on the next pass.

## Test plan

- `bun test src/data/lunora-migrate-plan.test.ts src/data/lunora-migrate.test.ts` (19 pass) — includes partial Lunora + classic remainder → missing-id import before `nodesAt`, and malformed KV 200 → failed / no `kvAt`
- `bun run typecheck` / `typecheck:test` / `lint` / `test` (989 pass)
- `e2e/lunora-migrate-heal.spec.ts` — classic Daily + daily-index → Lunora ON → Today maps same nodeId
- **Needs manual check:** prod shard — deploy, toggle Upgraded outline sync ON, confirm Today remounts on prior day ids

Made with [Cursor](https://cursor.com)