### PR TITLE
fix(lunora): persist markdown paste as a delta

### DIFF
--- a/.changeset/lunora-paste-delta.md
+++ b/.changeset/lunora-paste-delta.md
@@ -1,0 +1,5 @@
+---
+"dotflowy": patch
+---
+
+Fix multi-paragraph paste on upgraded sync: send a small change-ops delta instead of a full-outline restore that hit "Body too large", and keep pasted sibling order when a corrupted sibling-chain fan would otherwise scramble orphans after refresh.

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -13,11 +13,13 @@ import {
   planMirrorNode,
   planMoveMany,
   planMoveNode,
+  planFromChangeOps,
   planOutdent,
   planOutdentMany,
   planRemoveMany,
   planRemoveNode,
   planRestoreNodes,
+  type ChangeOpLike,
   planSetBookmarkedAt,
   planSetCollapsed,
   planSetCompleted,
@@ -934,6 +936,16 @@ export async function seedOutlineLunora(
             expandIds: args.expandIds as string[] | undefined,
           }),
         );
+      } else if (path === "mutators:applyChangeOps") {
+        const ops = (args.ops as ChangeOpLike[] | undefined) ?? [];
+        const uid = String(args.userId ?? "e2e-user");
+        commitOutlinePlan(store, planFromChangeOps(uid, ops));
+        result = {
+          count: ops.length,
+          deletes: 0,
+          inserts: 0,
+          patches: 0,
+        };
       } else if (path === "mutators:restoreNodes") {
         const target = (args.nodes as OutlineNode[] | undefined) ?? [];
         commitOutlinePlan(store, planRestoreNodes(liveNodes(), target));

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -939,12 +939,13 @@ export async function seedOutlineLunora(
       } else if (path === "mutators:applyChangeOps") {
         const ops = (args.ops as ChangeOpLike[] | undefined) ?? [];
         const uid = String(args.userId ?? "e2e-user");
-        commitOutlinePlan(store, planFromChangeOps(uid, ops));
+        const plan = planFromChangeOps(uid, ops);
+        commitOutlinePlan(store, plan);
         result = {
           count: ops.length,
-          deletes: 0,
-          inserts: 0,
-          patches: 0,
+          deletes: plan.deletes.length,
+          inserts: plan.inserts.length,
+          patches: plan.patches.length,
         };
       } else if (path === "mutators:restoreNodes") {
         const target = (args.nodes as OutlineNode[] | undefined) ?? [];

--- a/lunora/_generated/functions.ts
+++ b/lunora/_generated/functions.ts
@@ -40,6 +40,7 @@ export const LUNORA_FUNCTIONS: Record<string, RegisteredLunoraFunction> = {
     "mcp:listNodes": lunora_mcp_0.listNodes as unknown as RegisteredLunoraFunction,
     "mcp:wipeUserShard": lunora_mcp_0.wipeUserShard as unknown as RegisteredLunoraFunction,
     "mutators:appendChild": lunora_mutators_1.appendChild as unknown as RegisteredLunoraFunction,
+    "mutators:applyChangeOps": lunora_mutators_1.applyChangeOps as unknown as RegisteredLunoraFunction,
     "mutators:claimDailyMapping": lunora_mutators_1.claimDailyMapping as unknown as RegisteredLunoraFunction,
     "mutators:deleteDailyMapping": lunora_mutators_1.deleteDailyMapping as unknown as RegisteredLunoraFunction,
     "mutators:deleteSavedQuery": lunora_mutators_1.deleteSavedQuery as unknown as RegisteredLunoraFunction,
@@ -123,7 +124,7 @@ export const LUNORA_SHAPES: Record<string, RegisteredShape> = {
  * ShardDO's `isCustomMutator` override routes through the client-watermark push
  * protocol (`x-lunora-client-id`/`x-lunora-client-seq` ordering).
  */
-export const LUNORA_MUTATOR_PATHS: ReadonlySet<string> = new Set(["mutators:appendChild", "mutators:claimDailyMapping", "mutators:deleteDailyMapping", "mutators:deleteSavedQuery", "mutators:deleteTagColor", "mutators:getMigrateState", "mutators:hello", "mutators:importKvRows", "mutators:importNodes", "mutators:indent", "mutators:indentMany", "mutators:insertChildAtStart", "mutators:insertSibling", "mutators:materializeDailyNodes", "mutators:mirrorNode", "mutators:moveMany", "mutators:moveNode", "mutators:outdent", "mutators:outdentMany", "mutators:patchSavedQuery", "mutators:removeMany", "mutators:removeNode", "mutators:restoreNodes", "mutators:seedIfEmpty", "mutators:setBookmarkedAt", "mutators:setCollapsed", "mutators:setCompleted", "mutators:setIsTask", "mutators:setKind", "mutators:setMigrateState", "mutators:setText", "mutators:splitNode", "mutators:upsertDailyMapping", "mutators:upsertSavedQuery", "mutators:upsertTagColor"]);
+export const LUNORA_MUTATOR_PATHS: ReadonlySet<string> = new Set(["mutators:appendChild", "mutators:applyChangeOps", "mutators:claimDailyMapping", "mutators:deleteDailyMapping", "mutators:deleteSavedQuery", "mutators:deleteTagColor", "mutators:getMigrateState", "mutators:hello", "mutators:importKvRows", "mutators:importNodes", "mutators:indent", "mutators:indentMany", "mutators:insertChildAtStart", "mutators:insertSibling", "mutators:materializeDailyNodes", "mutators:mirrorNode", "mutators:moveMany", "mutators:moveNode", "mutators:outdent", "mutators:outdentMany", "mutators:patchSavedQuery", "mutators:removeMany", "mutators:removeNode", "mutators:restoreNodes", "mutators:seedIfEmpty", "mutators:setBookmarkedAt", "mutators:setCollapsed", "mutators:setCompleted", "mutators:setIsTask", "mutators:setKind", "mutators:setMigrateState", "mutators:setText", "mutators:splitNode", "mutators:upsertDailyMapping", "mutators:upsertSavedQuery", "mutators:upsertTagColor"]);
 
 /**
  * Connection-lifecycle manifest: the function paths the generated ShardDO

--- a/lunora/_generated/openapi.json
+++ b/lunora/_generated/openapi.json
@@ -58,7 +58,7 @@
   "info": {
     "description": "Auto-generated from @lunora/values-typed functions by @lunora/codegen. Do not edit — run `lunora codegen` to regenerate.",
     "title": "Lunora API",
-    "version": "1.10.0"
+    "version": "1.10.4"
   },
   "openapi": "3.1.0",
   "paths": {},

--- a/lunora/_generated/openapi.ts
+++ b/lunora/_generated/openapi.ts
@@ -61,7 +61,7 @@ export const openApiSpec: Record<string, unknown> = {
     "info": {
         "description": "Auto-generated from @lunora/values-typed functions by @lunora/codegen. Do not edit — run `lunora codegen` to regenerate.",
         "title": "Lunora API",
-        "version": "1.10.0"
+        "version": "1.10.4"
     },
     "openapi": "3.1.0",
     "paths": {},

--- a/lunora/_generated/shard.ts
+++ b/lunora/_generated/shard.ts
@@ -304,22 +304,6 @@ const LUNORA_TTL_SWEEPS: Array<{ after?: number; field: string; softDeleteField?
 /** Static schema advisories (computed by @lunora/advisor at codegen time) served via `__lunora_admin__:getAdvisories`. */
 const LUNORA_ADVISORIES: AdvisoryFinding[] = [
     {
-        "cacheKey": "table_without_insert:nodes",
-        "categories": [
-            "SCHEMA"
-        ],
-        "description": "No function inserts into this table via `ctx.db.insert(\"<table>\", …)`. It may be read-only by design (seeded by a migration, replicated, or written through a path the advisor can't see) — or it may be dead schema.",
-        "detail": "No function calls `ctx.db.insert(\"nodes\", …)` — table \"nodes\" has no discovered insert path.",
-        "facing": "INTERNAL",
-        "level": "INFO",
-        "metadata": {
-            "table": "nodes"
-        },
-        "name": "table_without_insert",
-        "remediation": "If the table should be writable, add a mutation that calls `ctx.db.insert(\"<table>\", …)`. If it is read-only or seeded elsewhere, this advisory can be ignored.",
-        "title": "Table has no insert path"
-    },
-    {
         "cacheKey": "plaintext_secret_in_wrangler_vars:wrangler.jsonc:SENTRY_DSN",
         "categories": [
             "SECURITY"

--- a/lunora/mcp.ts
+++ b/lunora/mcp.ts
@@ -20,6 +20,7 @@ import {
   type QueryCtx,
   v,
 } from "./_generated/server";
+import { changeOpArg } from "./wire-args";
 
 /** Wire node shape for MCP (no Lunora `userId`) — keeps codegen out of `src/`. */
 type McpNode = {
@@ -63,28 +64,6 @@ async function commitPlan(ctx: MutationCtx, plan: OutlinePlan): Promise<void> {
     });
   }
 }
-
-const wireNodeArg = v.object({
-  id: v.string(),
-  parentId: v.string().nullable(),
-  prevSiblingId: v.string().nullable(),
-  text: v.string(),
-  isTask: v.boolean(),
-  completed: v.boolean(),
-  collapsed: v.boolean(),
-  bookmarkedAt: v.number().nullable(),
-  mirrorOf: v.string().nullable(),
-  createdAt: v.number(),
-  updatedAt: v.number(),
-  origin: v.string().nullable(),
-  kind: v.literal("paragraph").nullable(),
-});
-
-const changeOpArg = v.union(
-  v.object({ op: v.literal("insert"), value: wireNodeArg }),
-  v.object({ op: v.literal("update"), value: wireNodeArg }),
-  v.object({ op: v.literal("delete"), key: v.string() }),
-);
 
 /** Full outline for MCP get_outline / search_nodes. */
 export const listNodes = internalQuery

--- a/lunora/mcp.ts
+++ b/lunora/mcp.ts
@@ -47,15 +47,15 @@ function assertOwner(ctx: QueryCtx | MutationCtx, userId: string): void {
 
 async function commitPlan(ctx: MutationCtx, plan: OutlinePlan): Promise<void> {
   for (const id of plan.deletes) {
-    // expectedTable avoids cross-table UNION ALL id lookup (Workerd SQLite
-    // compound-SELECT limit — same footgun as lunora/mutators.ts).
-    await ctx.db.delete(ctx.db.asId("nodes", id), "nodes");
+    // asId scopes the delete to `nodes` (avoids cross-table UNION ALL lookup —
+    // Workerd SQLite compound-SELECT limit). MutationCtx's typed delete/patch
+    // take no expectedTable arg; mutators pass it because MutatorCtx is looser.
+    await ctx.db.delete(ctx.db.asId("nodes", id));
   }
   for (const patch of plan.patches) {
     await ctx.db.patch(
       ctx.db.asId("nodes", patch.id),
       patch.fields as Record<string, unknown>,
-      "nodes",
     );
   }
   for (const node of plan.inserts) {
@@ -132,14 +132,10 @@ export const claimDailyMapping = internalMutation
       existing && typeof existing.nodeId === "string" ? existing.nodeId : null;
     const { winner, won } = resolveDailyClaim(current, args.nodeId);
     if (existing) {
-      await ctx.db.patch(
-        ctx.db.asId("dailyIndex", existing._id),
-        {
-          nodeId: winner,
-          touchedAt: args.touchedAt,
-        },
-        "dailyIndex",
-      );
+      await ctx.db.patch(ctx.db.asId("dailyIndex", existing._id), {
+        nodeId: winner,
+        touchedAt: args.touchedAt,
+      });
     } else {
       await ctx.db.insert("dailyIndex", {
         key: args.key,

--- a/lunora/mutators.ts
+++ b/lunora/mutators.ts
@@ -7,6 +7,7 @@ import {
   docToNode,
   nodeToInsertFields,
   planAppendChild,
+  planFromChangeOps,
   planIndent,
   planIndentMany,
   planInsertChildAtStart,
@@ -515,6 +516,56 @@ const nodeSnapshotArg = v.object({
   updatedAt: tsArg,
   origin: v.string().nullable(),
   kind: v.literal("paragraph").nullable(),
+});
+
+/** Wire node for delta batches (classic ChangeOp value; no userId — server stamps). */
+const wireNodeArg = v.object({
+  id: idArg,
+  parentId: v.string().nullable(),
+  prevSiblingId: v.string().nullable(),
+  text: v.string(),
+  isTask: v.boolean(),
+  completed: v.boolean(),
+  collapsed: v.boolean(),
+  bookmarkedAt: v.number().nullable(),
+  mirrorOf: v.string().nullable(),
+  createdAt: tsArg,
+  updatedAt: tsArg,
+  origin: v.string().nullable(),
+  kind: v.literal("paragraph").nullable(),
+});
+
+const changeOpArg = v.union(
+  v.object({ op: v.literal("insert"), value: wireNodeArg }),
+  v.object({ op: v.literal("update"), value: wireNodeArg }),
+  v.object({ op: v.literal("delete"), key: v.string() }),
+);
+
+/**
+ * Classic-style `{ops}` delta batch — one watermark for insert/update/delete
+ * without shipping the whole outline (markdown paste, structural batches).
+ * `restoreNodes` stays for undo/redo snapshots that already carry a full target.
+ */
+export const applyChangeOps = defineMutator({
+  args: {
+    userId: userIdArg,
+    ops: v.array(changeOpArg),
+  },
+  server: async (ctx, args) => {
+    const mctx = ctx as unknown as MutatorCtx;
+    assertOwner(mctx, args.userId);
+    if (args.ops.length === 0) {
+      return { count: 0, deletes: 0, inserts: 0, patches: 0 };
+    }
+    const plan = planFromChangeOps(args.userId, args.ops);
+    await commitPlan(mctx, plan);
+    return {
+      count: args.ops.length,
+      deletes: plan.deletes.length,
+      inserts: plan.inserts.length,
+      patches: plan.patches.length,
+    };
+  },
 });
 
 /**

--- a/lunora/mutators.ts
+++ b/lunora/mutators.ts
@@ -33,6 +33,7 @@ import {
   type OutlinePlan,
 } from "../src/data/outline-plans";
 import { resolveDailyClaim } from "../src/plugins/daily/claim-mapping";
+import { changeOpArg } from "./wire-args";
 
 type ShardTable =
   | "nodes"
@@ -517,29 +518,6 @@ const nodeSnapshotArg = v.object({
   origin: v.string().nullable(),
   kind: v.literal("paragraph").nullable(),
 });
-
-/** Wire node for delta batches (classic ChangeOp value; no userId — server stamps). */
-const wireNodeArg = v.object({
-  id: idArg,
-  parentId: v.string().nullable(),
-  prevSiblingId: v.string().nullable(),
-  text: v.string(),
-  isTask: v.boolean(),
-  completed: v.boolean(),
-  collapsed: v.boolean(),
-  bookmarkedAt: v.number().nullable(),
-  mirrorOf: v.string().nullable(),
-  createdAt: tsArg,
-  updatedAt: tsArg,
-  origin: v.string().nullable(),
-  kind: v.literal("paragraph").nullable(),
-});
-
-const changeOpArg = v.union(
-  v.object({ op: v.literal("insert"), value: wireNodeArg }),
-  v.object({ op: v.literal("update"), value: wireNodeArg }),
-  v.object({ op: v.literal("delete"), key: v.string() }),
-);
 
 /**
  * Classic-style `{ops}` delta batch — one watermark for insert/update/delete

--- a/lunora/wire-args.ts
+++ b/lunora/wire-args.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared Lunora wire validators for classic `ChangeOp[]` batches (ADR 0014 /
+ * ADR 0058). Browser mutators and Worker MCP both consume these — one source
+ * so the trust boundary can't drift.
+ */
+import { v } from "lunorash/server";
+
+/** Wire node for delta batches (classic ChangeOp value; no userId — server stamps). */
+export const wireNodeArg = v.object({
+  id: v.string(),
+  parentId: v.string().nullable(),
+  prevSiblingId: v.string().nullable(),
+  text: v.string(),
+  isTask: v.boolean(),
+  completed: v.boolean(),
+  collapsed: v.boolean(),
+  bookmarkedAt: v.number().nullable(),
+  mirrorOf: v.string().nullable(),
+  createdAt: v.number(),
+  updatedAt: v.number(),
+  origin: v.string().nullable(),
+  kind: v.literal("paragraph").nullable(),
+});
+
+export const changeOpArg = v.union(
+  v.object({ op: v.literal("insert"), value: wireNodeArg }),
+  v.object({ op: v.literal("update"), value: wireNodeArg }),
+  v.object({ op: v.literal("delete"), key: v.string() }),
+);

--- a/src/components/markdown-paste.ts
+++ b/src/components/markdown-paste.ts
@@ -134,9 +134,10 @@ export function pasteMarkdownTree(args: MarkdownPasteArgs): boolean {
     return true;
 
   const timestamp = now();
+  const opCount = 1 + plan.insertCount + plan.repoints.length;
 
-  // Lunora flag-ON: classic `nodesCollection` is idle — land via one
-  // `applyChangeOps` watermark (delta only: anchor + inserts + repoints). A
+  // Lunora flag-ON: classic `nodesCollection` is idle — land via
+  // `applyChangeOps` watermarks (delta only: anchor + inserts + repoints). A
   // full-outline `restoreNodes` payload hits "Body too large" on real outlines.
   if (isLunoraSyncEnabled()) {
     const lunora = getLunoraOutlineContext();
@@ -145,34 +146,33 @@ export function pasteMarkdownTree(args: MarkdownPasteArgs): boolean {
       return true;
     }
     capture(index, activeKey);
-    let landed = false;
-    try {
-      landed = runStructural(() =>
-        applyMarkdownPasteViaChangeOps(plan, anchorId, timestamp, lunora),
-      );
-    } catch {
-      drop();
-      toast.error("Couldn't paste there — try again.");
+    if (opCount < RESTORE_SLICE_OPS) {
+      let landed = false;
+      try {
+        landed = runStructural(() =>
+          applyMarkdownPasteViaChangeOps(plan, anchorId, timestamp, lunora),
+        );
+      } catch {
+        drop();
+        toast.error("Couldn't paste there — try again.");
+        return true;
+      }
+      if (!landed) {
+        drop();
+        toast.error("Couldn't paste there — try again.");
+        return true;
+      }
+      const seam = resolveSeam(plan, anchorId, count);
+      if (seam.id === anchorId)
+        focus.placeCaretHere(plan.anchor.text, seam.offset);
+      else {
+        const key = focusKeyFor(seam.id, activeKey);
+        focus.setPendingFocus(key, seam.offset);
+        scrollRowIntoView(key);
+      }
       return true;
     }
-    // `plan` was built from `getTreeIndex()` while the write reads
-    // `getLiveOutlineNodes()`, so the two CAN disagree on the anchor. Without
-    // this the paste would burn the undo point just captured, move the caret,
-    // and write nothing — a silent no-op is the one outcome a paste must never
-    // have (ADR 0044).
-    if (!landed) {
-      drop();
-      toast.error("Couldn't paste there — try again.");
-      return true;
-    }
-    const seam = resolveSeam(plan, anchorId, count);
-    if (seam.id === anchorId)
-      focus.placeCaretHere(plan.anchor.text, seam.offset);
-    else {
-      const key = focusKeyFor(seam.id, activeKey);
-      focus.setPendingFocus(key, seam.offset);
-      scrollRowIntoView(key);
-    }
+    void runLunoraSlicedPaste(plan, anchorId, timestamp, lunora, count);
     return true;
   }
 
@@ -209,7 +209,6 @@ export function pasteMarkdownTree(args: MarkdownPasteArgs): boolean {
     }
   };
 
-  const opCount = 1 + plan.insertCount + plan.repoints.length;
   // ONE undo point BEFORE the batch: a single Cmd+Z removes the whole paste.
   capture(index, activeKey);
 
@@ -275,12 +274,28 @@ function applyMarkdownPasteViaChangeOps(
   timestamp: number,
   lunora: LunoraOutlineContext,
 ): boolean {
-  const userId = lunora.userId;
+  const ops = buildMarkdownPasteOps(plan, anchorId, timestamp);
+  if (!ops) return false;
+  trackLunoraMutation(
+    lunora.store.mutators.applyChangeOps({
+      userId: lunora.userId,
+      ops,
+    }),
+  );
+  return true;
+}
+
+/** Build classic-shaped `{ops}` for a markdown paste, or null if anchor gone. */
+function buildMarkdownPasteOps(
+  plan: MdPastePlan,
+  anchorId: string,
+  timestamp: number,
+): ChangeOpLike[] | null {
   const byId = new Map(
     getLiveOutlineNodes().map((n) => [n.id, { ...n } as OutlineNode]),
   );
   const anchor = byId.get(anchorId);
-  if (!anchor) return false;
+  if (!anchor) return null;
 
   const nextAnchor: OutlineNode = {
     ...anchor,
@@ -331,14 +346,79 @@ function applyMarkdownPasteViaChangeOps(
       }),
     });
   }
+  return ops;
+}
 
-  trackLunoraMutation(
-    lunora.store.mutators.applyChangeOps({
-      userId,
-      ops,
-    }),
-  );
-  return true;
+/** Slice paste ops for yielding apply — anchor, insert chunks, repoints last. */
+function slicePasteOps(
+  ops: ChangeOpLike[],
+  insertCount: number,
+): ChangeOpLike[][] {
+  const slices: ChangeOpLike[][] = [[ops[0]!]];
+  const insertOps = ops.slice(1, 1 + insertCount);
+  for (let i = 0; i < insertOps.length; i += RESTORE_SLICE_OPS) {
+    slices.push(insertOps.slice(i, i + RESTORE_SLICE_OPS));
+  }
+  const repointOps = ops.slice(1 + insertCount);
+  if (repointOps.length > 0) slices.push(repointOps);
+  return slices;
+}
+
+/**
+ * Large Lunora paste: sequential `applyChangeOps` chunks behind the shared
+ * progress modal (ADR 0044). Chunks persist independently — partial failure
+ * keeps the undo point when anything landed (OPML import pattern).
+ */
+async function runLunoraSlicedPaste(
+  plan: MdPastePlan,
+  anchorId: string,
+  timestamp: number,
+  lunora: LunoraOutlineContext,
+  count: number,
+): Promise<void> {
+  const ops = buildMarkdownPasteOps(plan, anchorId, timestamp);
+  if (!ops) {
+    drop();
+    toast.error("Couldn't paste there — try again.");
+    return;
+  }
+
+  const opCount = ops.length;
+  const slices = slicePasteOps(ops, plan.insertCount);
+  let applied = 0;
+
+  const show = () =>
+    setRestoreProgress({
+      kind: "restoring",
+      label: "Pasting",
+      total: opCount,
+      applied,
+    });
+  show();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  try {
+    for (const chunk of slices) {
+      const tx = lunora.store.mutators.applyChangeOps({
+        userId: lunora.userId,
+        ops: chunk,
+      });
+      await tx.isPersisted.promise;
+      applied += chunk.length;
+      show();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+    setRestoreProgress({ kind: "closed" });
+    toast.success(`Pasted ${count.toLocaleString()} bullets.`);
+  } catch {
+    if (applied === 0) drop();
+    setRestoreProgress({ kind: "closed" });
+    toast.error(
+      applied === 0
+        ? "The paste could not be saved. Nothing was pasted."
+        : "The paste could not be fully saved. Earlier chunks landed — press Cmd+Z to remove them.",
+    );
+  }
 }
 
 /**

--- a/src/components/markdown-paste.ts
+++ b/src/components/markdown-paste.ts
@@ -11,7 +11,7 @@
 
 import { toast } from "sonner";
 
-import type { OutlineNode } from "../data/outline-plans";
+import type { ChangeOpLike, OutlineNode } from "../data/outline-plans";
 
 import { nodesCollection } from "../data/collection";
 import { isLunoraSyncEnabled, isMirrorsEnabled } from "../data/flags";
@@ -136,8 +136,8 @@ export function pasteMarkdownTree(args: MarkdownPasteArgs): boolean {
   const timestamp = now();
 
   // Lunora flag-ON: classic `nodesCollection` is idle — land via one
-  // `restoreNodes` watermark (anchor patch + inserts + repoints) so paste
-  // doesn't throw CollectionOperationError on a missing classic key.
+  // `applyChangeOps` watermark (delta only: anchor + inserts + repoints). A
+  // full-outline `restoreNodes` payload hits "Body too large" on real outlines.
   if (isLunoraSyncEnabled()) {
     const lunora = getLunoraOutlineContext();
     if (!lunora) {
@@ -145,9 +145,16 @@ export function pasteMarkdownTree(args: MarkdownPasteArgs): boolean {
       return true;
     }
     capture(index, activeKey);
-    const landed = runStructural(() =>
-      applyMarkdownPasteViaRestore(plan, anchorId, timestamp, lunora),
-    );
+    let landed = false;
+    try {
+      landed = runStructural(() =>
+        applyMarkdownPasteViaChangeOps(plan, anchorId, timestamp, lunora),
+      );
+    } catch {
+      drop();
+      toast.error("Couldn't paste there — try again.");
+      return true;
+    }
     // `plan` was built from `getTreeIndex()` while the write reads
     // `getLiveOutlineNodes()`, so the two CAN disagree on the anchor. Without
     // this the paste would burn the undo point just captured, move the caret,
@@ -210,11 +217,16 @@ export function pasteMarkdownTree(args: MarkdownPasteArgs): boolean {
     // The keystroke-adjacent path. It must stay synchronous: no confirm step, no
     // modal, no await. `DELETE_CONFIRM_THRESHOLD` exists because deletion is
     // destructive; a paste is additive and one Cmd+Z away.
-    runStructural(() => {
-      writeAnchor();
-      for (let i = 0; i < plan.inserts.length; i++) writeInsert(i);
-      writeRepoints();
-    });
+    try {
+      runStructural(() => {
+        writeAnchor();
+        for (let i = 0; i < plan.inserts.length; i++) writeInsert(i);
+        writeRepoints();
+      });
+    } catch (err) {
+      drop();
+      throw err;
+    }
     const seam = resolveSeam(plan, anchorId, count);
     if (seam.id === anchorId)
       focus.placeCaretHere(plan.anchor.text, seam.offset);
@@ -240,8 +252,16 @@ export function pasteMarkdownTree(args: MarkdownPasteArgs): boolean {
   return true;
 }
 
+/** Drop Lunora `userId` for the wire ChangeOp value validator. */
+function toWireNode(n: OutlineNode): Omit<OutlineNode, "userId"> {
+  const { userId: _u, ...wire } = n;
+  return wire;
+}
+
 /**
- * Build the post-paste outline and commit via Lunora `restoreNodes`.
+ * Commit a markdown paste as a classic-shaped `{ops}` delta via Lunora
+ * `applyChangeOps` (one watermark). O(touched rows), not O(outline) — a
+ * full-outline `restoreNodes` hit "Body too large" on ~5k-node dogfood outlines.
  *
  * Returns whether anything was written — `false` means the anchor vanished
  * between planning and writing, and the caller owns the disclosure (see the
@@ -249,7 +269,7 @@ export function pasteMarkdownTree(args: MarkdownPasteArgs): boolean {
  * re-read: the caller already resolved it, and re-reading here would invent a
  * second, silent failure mode for the same condition.
  */
-function applyMarkdownPasteViaRestore(
+function applyMarkdownPasteViaChangeOps(
   plan: MdPastePlan,
   anchorId: string,
   timestamp: number,
@@ -276,46 +296,46 @@ function applyMarkdownPasteViaRestore(
         ? { kind: null }
         : {}),
   };
-  byId.set(anchorId, nextAnchor);
+
+  const ops: ChangeOpLike[] = [{ op: "update", value: toWireNode(nextAnchor) }];
 
   for (const ins of plan.inserts) {
-    byId.set(ins.id, {
-      id: ins.id,
-      userId,
-      parentId: ins.parentId,
-      prevSiblingId: ins.prevSiblingId,
-      text: ins.text,
-      isTask: ins.isTask,
-      completed: ins.completed,
-      collapsed: false,
-      bookmarkedAt: null,
-      mirrorOf: null,
-      createdAt: timestamp,
-      updatedAt: timestamp,
-      origin: null,
-      kind: ins.kind,
+    ops.push({
+      op: "insert",
+      value: {
+        id: ins.id,
+        parentId: ins.parentId,
+        prevSiblingId: ins.prevSiblingId,
+        text: ins.text,
+        isTask: ins.isTask,
+        completed: ins.completed,
+        collapsed: false,
+        bookmarkedAt: null,
+        mirrorOf: null,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+        origin: null,
+        kind: ins.kind,
+      },
     });
   }
   for (const r of plan.repoints) {
     const n = byId.get(r.id);
     if (!n) continue;
-    byId.set(r.id, {
-      ...n,
-      prevSiblingId: r.prevSiblingId,
-      updatedAt: timestamp,
+    ops.push({
+      op: "update",
+      value: toWireNode({
+        ...n,
+        prevSiblingId: r.prevSiblingId,
+        updatedAt: timestamp,
+      }),
     });
   }
 
-  // KNOWN LIMIT (Lunora alpha): this ships the whole outline as the restore
-  // target, not just the touched rows. `planRestoreNodes` diffs server-side so
-  // untouched rows emit no patch, but the payload is still O(outline) and a
-  // row another device changed inside this read/write window gets diffed back
-  // to our stale copy. The fix is a delta mutator (anchor patch + inserts +
-  // repoints), matching what the classic branch sends.
   trackLunoraMutation(
-    lunora.store.mutators.restoreNodes({
+    lunora.store.mutators.applyChangeOps({
       userId,
-      nodes: [...byId.values()],
+      ops,
     }),
   );
   return true;

--- a/src/data/lunora-outline-store.ts
+++ b/src/data/lunora-outline-store.ts
@@ -25,6 +25,7 @@ import {
   buildTreeIndex,
   nodeToRow,
   planAppendChild,
+  planFromChangeOps,
   planImportNodes,
   planIndent,
   planIndentMany,
@@ -40,6 +41,7 @@ import {
   planRemoveNode,
   planRestoreNodes,
   planSeedIfEmpty,
+  type ChangeOpLike,
   planSetBookmarkedAt,
   planSetCollapsed,
   planSetCompleted,
@@ -342,6 +344,16 @@ function bindOutlineMutators(
             args.updatedAt,
           );
           if (plan) applyPlanToCollection(collection, plan);
+        },
+      }),
+      applyChangeOps: defineMutator<{
+        userId: string;
+        ops: ChangeOpLike[];
+      }>({
+        serverRef: "mutators:applyChangeOps",
+        apply: (_ctx, args) => {
+          const plan = planFromChangeOps(args.userId, args.ops);
+          applyPlanToCollection(collection, plan);
         },
       }),
       restoreNodes: defineMutator<{

--- a/src/data/sibling-chain.test.ts
+++ b/src/data/sibling-chain.test.ts
@@ -43,6 +43,48 @@ describe("orderSiblings", () => {
     expect(ordered.length).toBe(2);
     expect(new Set(ordered.map((n) => n.id))).toEqual(new Set(["a", "b"]));
   });
+
+  test("orphan subchains keep paste order when a fan steals the null head", () => {
+    // d wins the null-prev fan (last in the multimap's arrival list among heads
+    // is not what matters — a is first among null claimants in this feed, but
+    // d appears first so d wins). The a→b→n1→n2→c paste block must still read
+    // in link order, not scrambled collection order.
+    const nodes = [
+      makeNode({ id: "d", prevSiblingId: null, text: "other-head" }),
+      makeNode({ id: "n2", prevSiblingId: "n1", text: "paste2" }),
+      makeNode({ id: "c", prevSiblingId: "n2", text: "after" }),
+      makeNode({ id: "n1", prevSiblingId: "b", text: "paste1" }),
+      makeNode({ id: "a", prevSiblingId: null, text: "anchor" }),
+      makeNode({ id: "b", prevSiblingId: "a", text: "anchor-next" }),
+    ];
+    expect(orderSiblings(nodes).map((n) => n.id)).toEqual([
+      "d",
+      "a",
+      "b",
+      "n1",
+      "n2",
+      "c",
+    ]);
+  });
+
+  test("orphan subchains survive when the fan winner is last in arrival order", () => {
+    const nodes = [
+      makeNode({ id: "n2", prevSiblingId: "n1", text: "paste2" }),
+      makeNode({ id: "c", prevSiblingId: "n2", text: "after" }),
+      makeNode({ id: "n1", prevSiblingId: "b", text: "paste1" }),
+      makeNode({ id: "a", prevSiblingId: null, text: "anchor" }),
+      makeNode({ id: "b", prevSiblingId: "a", text: "anchor-next" }),
+      makeNode({ id: "d", prevSiblingId: null, text: "other-head" }),
+    ];
+    expect(orderSiblings(nodes).map((n) => n.id)).toEqual([
+      "a",
+      "b",
+      "n1",
+      "n2",
+      "c",
+      "d",
+    ]);
+  });
 });
 
 describe("chainDisagreements", () => {

--- a/src/data/sibling-chain.ts
+++ b/src/data/sibling-chain.ts
@@ -18,32 +18,84 @@ import type { Node } from "./schema";
 /**
  * Order one parent's children by following the `prevSiblingId` chain from the
  * head. Nodes orphaned by a broken pointer (a fan — two siblings sharing one
- * prev; a dangle — a pointer to a missing/foreign id) are appended in arrival
- * order rather than dropped: a visible, movable bullet beats a vanished one.
+ * prev; a dangle — a pointer to a missing/foreign id) are still kept — a
+ * visible, movable bullet beats a vanished one.
+ *
+ * After the primary walk from `null`, remaining orphans are stitched by
+ * following *their* `prevSiblingId` links as subchains (arrival order only as a
+ * last resort). A fan that leaves a paste block off the winning head must not
+ * scramble that block into collection order — that is what made Lunora
+ * multi-paragraph paste look "scattered" after refresh on a corrupted
+ * top-level chain.
+ *
  * The iteration cap makes a cyclic chain terminate. Pass the children of a
  * single parent; a list of 0 or 1 is returned unchanged.
  */
 export function orderSiblings(unordered: Node[]): Node[] {
   if (unordered.length <= 1) return unordered;
 
-  const byPrev = new Map<string | null, Node>();
-  for (const n of unordered) byPrev.set(n.prevSiblingId, n);
+  // Multimap: fans keep every claimant (Map.set would drop all but the last).
+  const byPrev = new Map<string | null, Node[]>();
+  for (const n of unordered) {
+    const key = n.prevSiblingId ?? null;
+    const list = byPrev.get(key);
+    if (list) list.push(n);
+    else byPrev.set(key, [n]);
+  }
 
   const ordered: Node[] = [];
-  const idsInChain = new Set<string>();
-  let cursor: string | null = null;
-  // Guard against cycles / corruption with an iteration cap.
+  const seen = new Set<string>();
+
+  const walkFrom = (startPrev: string | null): void => {
+    let cursor: string | null = startPrev;
+    let guard = unordered.length + 1;
+    while (guard-- > 0) {
+      const claimants = byPrev.get(cursor);
+      if (!claimants) break;
+      const next = claimants.find((n) => !seen.has(n.id));
+      if (!next) break;
+      ordered.push(next);
+      seen.add(next.id);
+      cursor = next.id;
+    }
+  };
+
+  // Primary walk from the true head (null). On a fan of heads, arrival order
+  // among null-prev claimants picks the winner — stable for a given input list.
+  walkFrom(null);
+
+  // Stitch orphan subchains: extend from the current tip when possible, else
+  // start a local head (prev missing / already placed / not among remaining).
   let guard = unordered.length + 1;
-  while (guard-- > 0) {
-    const next = byPrev.get(cursor);
-    if (!next) break;
-    ordered.push(next);
-    idsInChain.add(next.id);
-    cursor = next.id;
+  while (seen.size < unordered.length && guard-- > 0) {
+    const before = ordered.length;
+    const tip = ordered.length > 0 ? ordered[ordered.length - 1]!.id : null;
+    if (tip !== null) walkFrom(tip);
+    if (ordered.length > before) continue;
+
+    const remaining = unordered.filter((n) => !seen.has(n.id));
+    if (remaining.length === 0) break;
+    const remainingIds = new Set(remaining.map((n) => n.id));
+    const localHead =
+      remaining.find((n) => {
+        const prev = n.prevSiblingId;
+        return prev == null || !remainingIds.has(prev);
+      }) ?? remaining[0]!;
+
+    if (localHead.prevSiblingId && seen.has(localHead.prevSiblingId)) {
+      walkFrom(localHead.prevSiblingId);
+      if (ordered.length > before) continue;
+    }
+
+    if (!seen.has(localHead.id)) {
+      ordered.push(localHead);
+      seen.add(localHead.id);
+      walkFrom(localHead.id);
+    }
   }
 
   for (const n of unordered) {
-    if (!idsInChain.has(n.id)) ordered.push(n);
+    if (!seen.has(n.id)) ordered.push(n);
   }
 
   return ordered;


### PR DESCRIPTION
## Summary

Multi-paragraph markdown paste on upgraded sync no longer dies on a full-outline body or scrambles after refresh. Paste ships as a classic-style `{ops}` delta (sliced past 500 ops), and sibling fans stitch orphan subchains by `prevSiblingId` so order survives reload.

## Changes

1. Large Lunora markdown pastes persist as an ops delta instead of a full-outline restore (avoids body-too-large desync).
2. Sibling order after refresh keeps pasted blocks in place when the chain has a fan (orphan subchains stitch by prev link).
3. e2e Lunora mock accepts the new applyChangeOps mutator path (returns real plan counts).
4. Patch changeset for the paste/order fix.
5. Pastes at or over 500 ops on upgraded sync stream as chunked `applyChangeOps` behind the same progress modal as classic (ADR 0044 parity).
6. Shared ChangeOp wire validators for mutators and MCP (one `wire-args` source).
7. MCP outline writes match MutationCtx typed `delete`/`patch` (no extra table arg; unblocks `typecheck:worker`).

**Start here:** change 2 — fan healing is easy to regress if orderSiblings goes back to “one null-prev head + append orphans by collection order.”

## Flow

```mermaid
flowchart LR
  paste[Markdown paste] --> gate{opCount}
  gate -->|under 500| one[One applyChangeOps]
  gate -->|500+| sliced[Chunked applyChangeOps + modal]
  one --> shard[Lunora mutator]
  sliced --> shard
  shard --> reload[Reload / resume]
  reload --> order[orderSiblings fan stitch]
  order --> rows[Correct sibling order]
```

## Test plan

- [x] `bun run test` (995 pass)
- [x] `bun run typecheck` / `typecheck:test` / `typecheck:worker` / `lint`
- [ ] Repro Jam paste on upgraded sync: multi-paragraph paste persists without refresh; order matches after reload
- [ ] Classic (non-Lunora) markdown paste still one undo / correct tree

**Needs manual check:** upgraded-sync multi-paragraph paste + reload order (Jam path).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multi-paragraph paste reliability after sync upgrades.
  * Prevented large-payload errors during paste operations.
  * Preserved pasted sibling order and prevented orphaned content from being scrambled after refresh.
  * Improved recovery when paste synchronization fails, including clearer error handling.
* **Tests**
  * Added coverage for corrupted sibling relationships and orphan subchains to ensure content order remains stable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
