### PR TITLE
Fix live-node mutation reads and MCP error handling

### DIFF
--- a/.changeset/dotflowy-mcp-errors.md
+++ b/.changeset/dotflowy-mcp-errors.md
@@ -1,0 +1,5 @@
+---
+"dotflowy": patch
+---
+
+Handle MCP persistence failures as ToolError results and keep live-node index reads formatted.

--- a/src/data/mutations.ts
+++ b/src/data/mutations.ts
@@ -916,10 +916,7 @@ export function moveManyNodes(targetId: string | null, ids: string[]): number {
   let moved = 0;
   // `after` walks forward: start at the target's current last child, then each
   // successful move becomes the predecessor of the next.
-  const firstSiblings = childrenOf(
-    buildTreeIndex(getLiveNodes()),
-    targetId,
-  );
+  const firstSiblings = childrenOf(buildTreeIndex(getLiveNodes()), targetId);
   let after: string | null = firstSiblings.length
     ? firstSiblings[firstSiblings.length - 1]!.id
     : null;

--- a/src/data/mutations.ts
+++ b/src/data/mutations.ts
@@ -917,14 +917,14 @@ export function moveManyNodes(targetId: string | null, ids: string[]): number {
   // `after` walks forward: start at the target's current last child, then each
   // successful move becomes the predecessor of the next.
   const firstSiblings = childrenOf(
-    buildTreeIndex(nodesCollection.toArray),
+    buildTreeIndex(getLiveNodes()),
     targetId,
   );
   let after: string | null = firstSiblings.length
     ? firstSiblings[firstSiblings.length - 1]!.id
     : null;
   for (const id of ids) {
-    const index = buildTreeIndex(nodesCollection.toArray);
+    const index = buildTreeIndex(getLiveNodes());
     if (moveNode(index, id, targetId, after)) {
       moved++;
       after = id;
@@ -967,7 +967,7 @@ export function indentManyNodes(
     }
   }
 
-  const index = buildTreeIndex(nodesCollection.toArray);
+  const index = buildTreeIndex(getLiveNodes());
   // The run is contiguous, so the first root's prev sibling sits OUTSIDE it --
   // the node everything indents under. Absent => first child => can't indent.
   const targetId = index.byId.get(rootIds[0]!)?.prevSiblingId;
@@ -1025,7 +1025,7 @@ export function outdentManyNodes(rootIds: string[]): number {
     }
   }
 
-  const start = buildTreeIndex(nodesCollection.toArray);
+  const start = buildTreeIndex(getLiveNodes());
   const oldParentId = start.byId.get(rootIds[0]!)?.parentId;
   if (!oldParentId) return 0; // already top-level -> can't outdent
   const newParentId = start.byId.get(oldParentId)?.parentId ?? null;
@@ -1034,7 +1034,7 @@ export function outdentManyNodes(rootIds: string[]): number {
   // previously-moved one, so the run keeps its order at the new level.
   let after: string = oldParentId;
   for (const id of rootIds) {
-    const index = buildTreeIndex(nodesCollection.toArray);
+    const index = buildTreeIndex(getLiveNodes());
     if (moveNode(index, id, newParentId, after)) {
       moved++;
       after = id;
@@ -1130,7 +1130,7 @@ export function removeManyNodes(ids: string[]): void {
   }
 
   for (const id of ids) {
-    removeNode(buildTreeIndex(nodesCollection.toArray), id);
+    removeNode(buildTreeIndex(getLiveNodes()), id);
   }
 }
 

--- a/worker/mcp-tools.ts
+++ b/worker/mcp-tools.ts
@@ -115,9 +115,15 @@ const loadIndex = (store: OutlineStore): Effect.Effect<TreeIndex> =>
 const commit = (
   store: OutlineStore,
   ops: ReadonlyArray<ChangeOp>,
-): Effect.Effect<void> =>
-  Effect.promise(async () => {
-    if (ops.length) await store.applyBatch(ops);
+): Effect.Effect<void, ToolError> =>
+  Effect.tryPromise({
+    try: async () => {
+      if (ops.length) await store.applyBatch(ops);
+    },
+    catch: (error) =>
+      new ToolError({
+        reason: error instanceof Error ? error.message : String(error),
+      }),
   });
 
 /** Lift a planner's value-shaped failure into the tool error channel,
@@ -919,27 +925,17 @@ export const tools: ReadonlyArray<ToolDef> = [
         // since, so a reload would rebuild the identical tree (finding 6).
         const index = scaffold.index;
         const timestamp = yield* clock;
-        const plan = yield* Effect.try({
-          try: () => planAddToDaily(index, {
-            dateKey,
-            ...scaffold,
-            newNodeId: createId(),
-            text: input.text,
-            isTask: input.isTask ?? false,
-            kind: input.kind ?? null,
-            origin,
-            timestamp,
-          }),
-          catch: (error) => new ToolError({
-            reason: error instanceof Error ? error.message : String(error),
-          }),
+        const plan = planAddToDaily(index, {
+          dateKey,
+          ...scaffold,
+          newNodeId: createId(),
+          text: input.text,
+          isTask: input.isTask ?? false,
+          kind: input.kind ?? null,
+          origin,
+          timestamp,
         });
-        yield* Effect.tryPromise({
-          try: () => Promise.resolve(store.applyBatch(plan.ops)),
-          catch: (error) => new ToolError({
-            reason: error instanceof Error ? error.message : String(error),
-          }),
-        });
+        yield* commit(store, plan.ops);
         return `Added "${input.text}" to ${formatDayText(dateKey)} (node id: ${plan.nodeId}, daily note id: ${scaffold.dayId}).`;
       }),
   },

--- a/worker/mcp-tools.ts
+++ b/worker/mcp-tools.ts
@@ -919,17 +919,27 @@ export const tools: ReadonlyArray<ToolDef> = [
         // since, so a reload would rebuild the identical tree (finding 6).
         const index = scaffold.index;
         const timestamp = yield* clock;
-        const plan = planAddToDaily(index, {
-          dateKey,
-          ...scaffold,
-          newNodeId: createId(),
-          text: input.text,
-          isTask: input.isTask ?? false,
-          kind: input.kind ?? null,
-          origin,
-          timestamp,
+        const plan = yield* Effect.try({
+          try: () => planAddToDaily(index, {
+            dateKey,
+            ...scaffold,
+            newNodeId: createId(),
+            text: input.text,
+            isTask: input.isTask ?? false,
+            kind: input.kind ?? null,
+            origin,
+            timestamp,
+          }),
+          catch: (error) => new ToolError({
+            reason: error instanceof Error ? error.message : String(error),
+          }),
         });
-        yield* commit(store, plan.ops);
+        yield* Effect.tryPromise({
+          try: () => Promise.resolve(store.applyBatch(plan.ops)),
+          catch: (error) => new ToolError({
+            reason: error instanceof Error ? error.message : String(error),
+          }),
+        });
         return `Added "${input.text}" to ${formatDayText(dateKey)} (node id: ${plan.nodeId}, daily note id: ${scaffold.dayId}).`;
       }),
   },


### PR DESCRIPTION
Applies the two requested bug fixes: live-node mutation indexes and ToolError handling for add_to_today failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved batch move, indent, outdent, and removal operations to use the latest live data, ensuring accurate tree positioning.
  * Improved error handling when adding items to Today, providing consistent tool errors for planning and update failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->