### PR TITLE
MCP accepts the user's timezone on daily-note tools

### DIFF
--- a/.changeset/mcp-timezone-336.md
+++ b/.changeset/mcp-timezone-336.md
@@ -1,0 +1,5 @@
+---
+"dotflowy": minor
+---
+
+MCP daily-note tools now accept an optional `timeZone` so an omitted `date` resolves to the user's own today instead of UTC.

--- a/docs/adr/0026-agent-native-mcp-server.md
+++ b/docs/adr/0026-agent-native-mcp-server.md
@@ -79,7 +79,11 @@ for a single-user-instance posture; a consent screen is an easy later add (`oidc
 that defaults to UTC-today, and the tool description tells the agent to pass the user's local date —
 the Worker cannot know the user's timezone, and inventing one server-side would silently file
 late-evening captures under tomorrow. Same local-midnight philosophy as `localDateKey`, honestly
-delegated.
+delegated. (Amended 2026-08-09: `add_to_today` and `mirror_to_today` also take an optional `timeZone`
+IANA parameter — when `date` is omitted, "today" resolves in that zone via `Intl.DateTimeFormat`, the
+server twin of `localDateKey`; an explicit `date` still wins, and a malformed zone is a loud `isError`,
+never a silent UTC fallback. `add_subtree` and `import_opml` accept the same parameter but only reach
+the daily path when a `date` is given, so for them it is validated and ignored.)
 
 ## Considered and rejected
 
@@ -91,7 +95,8 @@ delegated.
   edit; move/indent/reorder can follow once real agent usage shows the need. (Move landed as
   `move_nodes` in [ADR 0027](./0027-mcp-move-nodes.md).)
 - **Deriving "today" server-side from a stored user timezone** — new schema + settings surface for
-  something the calling agent already knows better.
+  something the calling agent already knows better. (The 2026-08-09 amendment above keeps this
+  rejected: the timezone travels as a per-call parameter, never as stored per-user state.)
 
 ## Consequences
 

--- a/worker/mcp-tools.ts
+++ b/worker/mcp-tools.ts
@@ -142,7 +142,17 @@ const unwrap = <A>(result: A): Effect.Effect<Exclude<A, Error>, ToolError> =>
     ? Effect.fail(new ToolError({ reason: result.message }))
     : Effect.succeed(result as Exclude<A, Error>);
 
-const clock = Effect.sync(() => Date.now());
+/** The write-timestamp source. Mutable so tests can pin "now" (the pre-agreed
+ *  seam for deterministic timezone/day-boundary tests); production reads the
+ *  real clock on every call, exactly as before. */
+let clock: Effect.Effect<number, never> = Effect.sync(() => Date.now());
+
+/** Test seam: pin the clock to a fixed instant (or restore with `null`). The
+ *  daily tools resolve "today" from this, so timezone-boundary cases are
+ *  deterministic. */
+export const setClock = (now: number | null): void => {
+  clock = now == null ? Effect.sync(() => Date.now()) : Effect.succeed(now);
+};
 
 // --- Daily-index claims -------------------------------------------------------
 
@@ -253,21 +263,62 @@ const claimDailyScaffold = (
     return { containerId, yearId, monthId, weekId, dayId, keyByNodeId, index };
   });
 
-/** Resolve the tool's optional `date` input to a valid `YYYY-MM-DD` key. The
- *  default is the server's UTC today — tools advertise that callers should pass
- *  the user's local date, since the Worker can't know their timezone. */
+/** The calendar day a given instant falls on in a given IANA timezone — the
+ *  server-side twin of the client's `localDateKey`, for an arbitrary zone
+ *  instead of the browser's own. Uses the formatter rather than offset math so
+ *  DST and historical zone changes are the engine's problem, not ours. */
+const todayInZone = (now: number, timeZone: string): string => {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(new Date(now));
+  const get = (type: Intl.DateTimeFormatPartTypes) =>
+    parts.find((p) => p.type === type)?.value ?? "";
+  return `${get("year")}-${get("month")}-${get("day")}`;
+};
+
+/** Resolve the tool's optional `date` input to a valid `YYYY-MM-DD` key. An
+ *  explicit `date` wins outright. Otherwise "today" is the caller's local day
+ *  when a `timeZone` is given (matching `localDateKey` in the app), else UTC
+ *  today — tools advertise that callers should pass the user's local date, since
+ *  the Worker can't otherwise know their timezone. */
 const resolveDateKey = (
   date: string | null | undefined,
-): Effect.Effect<string, ToolError> =>
-  date == null
-    ? Effect.sync(() => new Date().toISOString().slice(0, 10))
-    : isValidDateKey(date)
+  timeZone: string | null | undefined,
+  now: number,
+): Effect.Effect<string, ToolError> => {
+  // Validate the timezone even when `date` wins: a typo'd zone is a caller bug
+  // worth surfacing, and it keeps `tools/list`'s promise that a bad value is
+  // refused rather than silently ignored.
+  if (timeZone != null) {
+    try {
+      // Throws RangeError for anything that isn't a real IANA zone name.
+      new Intl.DateTimeFormat("en", { timeZone });
+    } catch {
+      return Effect.fail(
+        new ToolError({
+          reason: `invalid timeZone "${timeZone}" — expected a real IANA name (e.g. America/New_York)`,
+        }),
+      );
+    }
+  }
+  if (date != null) {
+    return isValidDateKey(date)
       ? Effect.succeed(date)
       : Effect.fail(
           new ToolError({
             reason: `invalid date "${date}" — expected a real YYYY-MM-DD`,
           }),
         );
+  }
+  const key =
+    timeZone != null
+      ? todayInZone(now, timeZone)
+      : new Date(now).toISOString().slice(0, 10);
+  return Effect.succeed(key);
+};
 
 // --- Protection (ADR 0015, server-enforced) -----------------------------------
 // The daily container AND every intermediate calendar scaffold node (year,
@@ -363,6 +414,25 @@ const kindField = optional(
   }),
 );
 
+const dateField = optional(
+  Schema.String.annotate({
+    description:
+      "The day's date as YYYY-MM-DD. Pass the user's local date; defaults to today in UTC.",
+  }),
+);
+
+/** The caller's IANA timezone (e.g. "America/New_York", "Asia/Tokyo"). When the
+ *  `date` is omitted, "today" resolves in this timezone instead of UTC — so a
+ *  late-evening capture lands on the user's own calendar day. On the tools where
+ *  `date` is a required target selector (add_subtree / import_opml), it is
+ *  ignored unless `date` is present, and an explicit `date` always wins. */
+const timeZoneField = optional(
+  Schema.String.annotate({
+    description:
+      "The caller's IANA timezone (e.g. America/New_York, Asia/Tokyo). When `date` is omitted, today resolves in this timezone instead of UTC; an explicit date always wins.",
+  }),
+);
+
 const GetOutlineInput = Schema.Struct({
   nodeId: optional(
     Schema.String.annotate({
@@ -441,6 +511,12 @@ const AddSubtreeInput = Schema.Struct({
         "Add onto the daily note for this YYYY-MM-DD instead of a parent (pass the user's local date). Mutually exclusive with `parentId`.",
     }),
   ),
+  timeZone: optional(
+    Schema.String.annotate({
+      description:
+        "The caller's IANA timezone (e.g. America/New_York). Refines an omitted `date` on the daily path; ignored at the top level (no `date`), and an explicit `date` wins.",
+    }),
+  ),
   position: optional(
     Schema.Literals(["first", "last"]).annotate({
       description:
@@ -503,13 +579,6 @@ const MoveNodesInput = Schema.Struct({
   ),
 });
 
-const dateField = optional(
-  Schema.String.annotate({
-    description:
-      "The day's date as YYYY-MM-DD. Pass the user's local date; defaults to today in UTC.",
-  }),
-);
-
 const AddToTodayInput = Schema.Struct({
   text: Schema.String.annotate({
     description: "The bullet text to add to the daily note.",
@@ -521,6 +590,7 @@ const AddToTodayInput = Schema.Struct({
   ),
   kind: kindField,
   date: dateField,
+  timeZone: timeZoneField,
 });
 
 const MirrorNodeInput = Schema.Struct({
@@ -539,6 +609,7 @@ const MirrorToTodayInput = Schema.Struct({
     description: "The node to mirror onto the daily note.",
   }),
   date: dateField,
+  timeZone: timeZoneField,
 });
 
 // The OPML pair (ADR 0037). The document travels as a plain string — a
@@ -562,6 +633,12 @@ const ImportOpmlInput = Schema.Struct({
     Schema.String.annotate({
       description:
         "Import onto the daily note for this YYYY-MM-DD instead of a parent (pass the user's local date). Mutually exclusive with `parentId`.",
+    }),
+  ),
+  timeZone: optional(
+    Schema.String.annotate({
+      description:
+        "The caller's IANA timezone (e.g. America/New_York). Refines an omitted `date` on the daily path; ignored at the top level (no `date`), and an explicit `date` wins.",
     }),
   ),
   dryRun: optional(
@@ -778,7 +855,11 @@ export const tools: ReadonlyArray<ToolDef> = [
         // Daily path: claim the container + day ids atomically, then ensure-and-
         // append the forest under the day (position is ignored — always last).
         if (input.date != null) {
-          const dateKey = yield* resolveDateKey(input.date);
+          const dateKey = yield* resolveDateKey(
+            input.date,
+            input.timeZone,
+            timestamp,
+          );
           // Validate the forest BEFORE claiming any daily-index ids, so an empty
           // or over-cap forest can't leave orphan container/day mappings pointing
           // at nodes we never insert (ADR 0028 all-or-nothing).
@@ -931,12 +1012,13 @@ export const tools: ReadonlyArray<ToolDef> = [
     readOnly: false,
     handle: (input: typeof AddToTodayInput.Type, store, origin) =>
       Effect.gen(function* () {
-        const dateKey = yield* resolveDateKey(input.date);
+        const now = yield* clock;
+        const dateKey = yield* resolveDateKey(input.date, input.timeZone, now);
         const scaffold = yield* claimDailyScaffold(store, dateKey);
         // Reuse the index claimDailyScaffold already built -- only kv claims ran
         // since, so a reload would rebuild the identical tree (finding 6).
         const index = scaffold.index;
-        const timestamp = yield* clock;
+        const timestamp = now;
         const plan = planAddToDaily(index, {
           dateKey,
           ...scaffold,
@@ -985,12 +1067,13 @@ export const tools: ReadonlyArray<ToolDef> = [
     readOnly: false,
     handle: (input: typeof MirrorToTodayInput.Type, store, origin) =>
       Effect.gen(function* () {
-        const dateKey = yield* resolveDateKey(input.date);
+        const now = yield* clock;
+        const dateKey = yield* resolveDateKey(input.date, input.timeZone, now);
         const scaffold = yield* claimDailyScaffold(store, dateKey);
         // Reuse the index claimDailyScaffold already built -- only kv claims ran
         // since, so a reload would rebuild the identical tree (finding 6).
         const index = scaffold.index;
-        const timestamp = yield* clock;
+        const timestamp = now;
         const plan = yield* unwrap(
           planMirrorToDaily(index, {
             dateKey,
@@ -1047,7 +1130,11 @@ export const tools: ReadonlyArray<ToolDef> = [
 
         // Daily path (mirrors add_subtree's date targeting: always appends).
         if (input.date != null) {
-          const dateKey = yield* resolveDateKey(input.date);
+          const dateKey = yield* resolveDateKey(
+            input.date,
+            input.timeZone,
+            timestamp,
+          );
           if (dryRun) {
             // A dry run must not claim daily-index ids (a kv claim IS a write);
             // plan against a detached parent purely for the receipt's counts.

--- a/worker/mcp.test.ts
+++ b/worker/mcp.test.ts
@@ -16,6 +16,7 @@ import type { OutlineStore } from "./mcp-tools";
 
 import { makeNode } from "../src/data/tree";
 import { handleMcp } from "./mcp";
+import { setClock } from "./mcp-tools";
 
 // --- In-memory store fake -----------------------------------------------------
 
@@ -557,6 +558,144 @@ describe("MCP tools", () => {
     const mirror = [...fake.nodes.values()].find((n) => n.mirrorOf === "a1");
     expect(mirror?.parentId).toBe(dayId);
     expect(toolText(json)).toContain("Friday, July 3, 2026");
+  });
+
+  test("timeZone resolves an omitted date to the caller's local today (issue #336)", async () => {
+    setClock(new Date("2026-08-09T23:30:00Z").getTime());
+    try {
+      // 23:30 UTC is 08-10 in UTC but still 08-09 in America/Los_Angeles — the
+      // whole point: the capture belongs on the user's calendar day, not UTC's.
+      const fake = makeStore(fixture());
+      const json = await callTool(fake.store, "add_to_today", {
+        text: "captured",
+        timeZone: "America/Los_Angeles",
+      });
+      expect(json.result?.isError).toBeUndefined();
+      expect(fake.kv.has("2026-08-09")).toBe(true);
+      expect(fake.kv.has("2026-08-10")).toBe(false);
+      expect(toolText(json)).toContain("Sunday, August 9, 2026");
+
+      // East of UTC the same instant is already tomorrow.
+      const east = makeStore(fixture());
+      const eastJson = await callTool(east.store, "add_to_today", {
+        text: "captured",
+        timeZone: "Asia/Tokyo",
+      });
+      expect(eastJson.result?.isError).toBeUndefined();
+      expect(east.kv.has("2026-08-10")).toBe(true);
+      expect(east.kv.has("2026-08-09")).toBe(false);
+    } finally {
+      setClock(null);
+    }
+  });
+
+  test("timeZone steers the omitted-date default on add_to_today and mirror_to_today", async () => {
+    setClock(new Date("2026-08-09T23:30:00Z").getTime());
+    try {
+      // add_subtree / import_opml use `date` as a target SELECTOR (mutually
+      // exclusive with parentId), not an omitted-date default — so they only
+      // reach the daily path when `date` is present, where `date` wins and
+      // timeZone is validated-then-ignored. add_to_today and mirror_to_today
+      // genuinely default "today", and timeZone steers that.
+      const mir = makeStore(fixture());
+      const mirJson = await callTool(mir.store, "mirror_to_today", {
+        nodeId: "a1",
+        timeZone: "America/Los_Angeles",
+      });
+      expect(mirJson.result?.isError).toBeUndefined();
+      expect(mir.kv.has("2026-08-09")).toBe(true);
+      expect(mir.kv.has("2026-08-10")).toBe(false);
+    } finally {
+      setClock(null);
+    }
+  });
+
+  test("add_subtree / import_opml accept timeZone on the date path and validate it", async () => {
+    const sub = makeStore(fixture());
+    const subJson = await callTool(sub.store, "add_subtree", {
+      date: "2026-07-03",
+      timeZone: "America/Los_Angeles",
+      nodes: [{ text: "x" }],
+    });
+    expect(subJson.result?.isError).toBeUndefined();
+    expect(sub.kv.has("2026-07-03")).toBe(true);
+
+    const imp = makeStore(fixture());
+    const opml =
+      '<?xml version="1.0"?><opml version="2.0"><head></head><body>' +
+      '<outline text="one" /></body></opml>';
+    const impJson = await callTool(imp.store, "import_opml", {
+      date: "2026-07-03",
+      timeZone: "America/Los_Angeles",
+      opml,
+    });
+    expect(impJson.result?.isError).toBeUndefined();
+    expect(imp.kv.has("2026-07-03")).toBe(true);
+
+    // A malformed timeZone is refused even when `date` wins.
+    const bad = makeStore(fixture());
+    const badJson = await callTool(bad.store, "add_subtree", {
+      date: "2026-07-03",
+      timeZone: "bogus",
+      nodes: [{ text: "x" }],
+    });
+    expect(badJson.result?.isError).toBe(true);
+    expect(toolText(badJson)).toContain("IANA");
+    expect(bad.batches).toHaveLength(0);
+  });
+
+  test("an invalid timeZone is a loud isError, nothing written", async () => {
+    const fake = makeStore(fixture());
+    const json = await callTool(fake.store, "add_to_today", {
+      text: "x",
+      timeZone: "Not/AZone",
+    });
+    expect(json.result?.isError).toBe(true);
+    expect(toolText(json)).toContain("IANA");
+    expect(fake.batches).toHaveLength(0);
+    expect(fake.kv.has("container")).toBe(false);
+  });
+
+  test("an explicit date wins over timeZone (which is still validated)", async () => {
+    const fake = makeStore(fixture());
+    const json = await callTool(fake.store, "add_to_today", {
+      text: "x",
+      date: "2026-07-03",
+      timeZone: "America/Los_Angeles",
+    });
+    expect(json.result?.isError).toBeUndefined();
+    expect(fake.kv.has("2026-07-03")).toBe(true);
+    expect(toolText(json)).toContain("Friday, July 3, 2026");
+
+    // date wins, but a malformed timeZone alongside it is still refused.
+    const bad = makeStore(fixture());
+    const badJson = await callTool(bad.store, "add_to_today", {
+      text: "x",
+      date: "2026-07-03",
+      timeZone: "bogus",
+    });
+    expect(badJson.result?.isError).toBe(true);
+    expect(toolText(badJson)).toContain("IANA");
+    expect(bad.batches).toHaveLength(0);
+  });
+
+  test("tools/list exposes the timeZone field on all four daily tools", async () => {
+    const { store } = makeStore();
+    const json = (await (await rpc(store, "tools/list")).json()) as any;
+    const tool = (name: string) =>
+      json.result.tools.find((t: any) => t.name === name);
+    for (const name of [
+      "add_to_today",
+      "mirror_to_today",
+      "add_subtree",
+      "import_opml",
+    ]) {
+      const tz = tool(name).inputSchema.properties.timeZone;
+      expect(tz).toBeDefined();
+      // The field publishes as a nested anyOf [string, null]; its contract
+      // text rides inside the JSON, so assert on the serialized schema.
+      expect(JSON.stringify(tz)).toContain("timezone");
+    }
   });
 
   test("the daily container is protected from delete, blanking, and completing", async () => {

--- a/worker/mcp.test.ts
+++ b/worker/mcp.test.ts
@@ -561,10 +561,12 @@ describe("MCP tools", () => {
   });
 
   test("timeZone resolves an omitted date to the caller's local today (issue #336)", async () => {
-    setClock(new Date("2026-08-09T23:30:00Z").getTime());
+    setClock(new Date("2026-08-10T00:30:00Z").getTime());
     try {
-      // 23:30 UTC is 08-10 in UTC but still 08-09 in America/Los_Angeles — the
-      // whole point: the capture belongs on the user's calendar day, not UTC's.
+      // 00:30 UTC is already 08-10 in UTC but still 08-09 in
+      // America/Los_Angeles — the whole point: the capture belongs on the
+      // user's calendar day, not UTC's. (23:30Z on the 9th would leave UTC on
+      // the 9th too, so it could never detect a UTC fallback.)
       const fake = makeStore(fixture());
       const json = await callTool(fake.store, "add_to_today", {
         text: "captured",
@@ -590,7 +592,7 @@ describe("MCP tools", () => {
   });
 
   test("timeZone steers the omitted-date default on add_to_today and mirror_to_today", async () => {
-    setClock(new Date("2026-08-09T23:30:00Z").getTime());
+    setClock(new Date("2026-08-10T00:30:00Z").getTime());
     try {
       // add_subtree / import_opml use `date` as a target SELECTOR (mutually
       // exclusive with parentId), not an omitted-date default — so they only

--- a/worker/mcp.ts
+++ b/worker/mcp.ts
@@ -46,7 +46,8 @@ const SERVER_INFO = {
 const SERVER_INSTRUCTIONS =
   'Dotflowy is the user\'s personal outline (nested bullets; some are to-dos; daily notes live under a "Daily" container). ' +
   "Read with get_outline / search_nodes — every line carries the node id the write tools need. " +
-  "add_to_today and mirror_to_today are the fastest ways to put something on the user's daily note; pass the user's local date when you know it.";
+  "add_to_today and mirror_to_today are the fastest ways to put something on the user's daily note; " +
+  'pass `timeZone` (e.g. "America/New_York") so an omitted `date` resolves to the user\'s own today.';
 
 // JSON-RPC 2.0 error codes.
 const PARSE_ERROR = -32700;


### PR DESCRIPTION
## Summary

Agents can now tell the MCP server the user's timezone, so a late-evening capture lands on the user's own calendar day instead of UTC's. Fixes #336.

## Changes

1. `add_to_today` and `mirror_to_today` take an optional IANA `timeZone`; an omitted `date` now resolves "today" in that zone rather than UTC.
2. `add_subtree` and `import_opml` accept and validate the same field, but only reach the daily path when a `date` is given, so there it's validated then ignored.
3. A malformed timezone is a loud tool error (`isError`), never a silent UTC fallback; an explicit `date` always wins.
4. The clock is now an injectable seam (`setClock`) so the day-boundary tests are deterministic.
5. Server instructions and ADR 0026 record the new parameter and that the stored-timezone approach stays rejected.

## Test plan

- `bun run test` — 1029 pass, 0 fail
- `bun run typecheck` / `bun run typecheck:worker` / `bun run typecheck:test` — clean
- `bun run lint` — 0 warnings, 0 errors
- `bun run check:docs` — doc pointers OK
- New `worker/mcp.test.ts` cases: LA/Tokyo day-boundary divergence, invalid zone is a loud isError, `date` wins over `timeZone`, `tools/list` exposes the field on all four tools


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Daily operations now support optional IANA time zones when resolving omitted dates.
  * Explicit dates take precedence over time zone settings.
  * Invalid time zones return a clear error instead of defaulting to UTC.
  * Related import and subtree operations accept time zone information when dates are provided.
* **Documentation**
  * Updated server guidance to recommend supplying a time zone for automatic date resolution.
* **Tests**
  * Added coverage for time zone handling, validation, and date precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->