### PR TITLE
docs: Update AGENTS.md

### DIFF
--- a/.changeset/fruity-regions-beg.md
+++ b/.changeset/fruity-regions-beg.md
@@ -1,0 +1,4 @@
+---
+---
+
+docs: rightsize AGENTS.md (not news)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,58 +6,43 @@ Keep this file brief. Put task-specific guidance behind a pointer.
 
 ## Gotchas
 
-- **Structural vs field writes.** Tree-shape changes (insert, indent, outdent, move, reparent, remove, undo restore, daily get-or-create) go through `runStructural`: one batch, overlay held until echo. Field edits (`setText`, `setKind`, `setIsTask`, toggles) stay a direct PATCH. Wrap at the call sites, not inside `mutations.ts`.
-- **A new `Node` field touches seven places:** `src/data/wire-schema.ts`, `src/data/schema.ts`, `makeNode()`, `withNodeDefaults` in `collection.ts`, a DO `ADD COLUMN` migration, `e2e/fixtures.ts`, and the R2 snapshot boundary in `worker/backup.ts`. Miss the fixtures and inbound-frame decode rejects every snapshot.
-- **Add a new side-collection to `KV_COLLECTIONS` in `worker/index.ts`.** The e2e kv mock accepts any name.
-- **Build nodes with `makeNode()`.** A schema default makes the field optional in the encoded type.
+- **Structural vs field writes.** Tree-shape changes go through `runStructural` at the call site, not inside `mutations.ts`. Field edits stay a direct PATCH.
+- **A new `Node` field touches seven places:** `src/data/wire-schema.ts`, `src/data/schema.ts`, `makeNode()`, `withNodeDefaults` in `collection.ts`, a DO `ADD COLUMN` migration, `e2e/fixtures.ts`, and the R2 snapshot boundary in `worker/backup.ts`. Miss the fixtures and inbound-frame decode rejects every snapshot. Build nodes with `makeNode()`.
+- **Add a new side-collection to `KV_COLLECTIONS` in `worker/index.ts`.**
 - **Read side-collections with `subscribeChanges` and `useSyncExternalStore`.** `useLiveQuery` hard-fails the `/` prerender. Readiness rides `toArrayWhenReady()`.
-- **The tree index mutates in place and notifies synchronously.** Read sibling state before you mutate. Multi-node mutations rebuild the index from the live collection between each step.
+- **The tree index mutates in place and notifies synchronously.** Read sibling state before you mutate.
 - **Read event-time values through the getters** (`getTreeIndex()`, `getViewRootId()`, `getViewIsHidden()`, `getViewFilter()`). Write view state in effects.
-- **`createAuth(env, requestOrigin)` is per request**, never a module singleton. The D1 binding exists only inside `fetch`.
-- **The `_shell.html` to `index.html` copy is load-bearing.** SPA mode emits `_shell.html`; Static Assets serves `index.html`.
-- **DO write atomicity is `ctx.storage.transactionSync()`.** Row writes, the seq bump, and the changelog go in one transaction. Frames broadcast only after a durable commit.
-- **Entitlement reads never call Stripe.** `getPlan(userId, env)` is one D1 query on `referenceId = user.id`, `status IN ('active','trialing')`. Free tier is no row. An operator-comped user is a hand-inserted active row with no Stripe ids.
-- **Keep the founding seat cap in `getCheckoutSessionParams`**, at checkout-creation time. Webhooks and `subscription.list()` resolve plans from that same list.
-- **Reference prices by lookup key**, not price-id env vars. `scripts/stripe-setup.ts` warns on mismatch and does not edit.
-- **A node renders in three places**, with three separate keymaps: `OutlineRow` / `useBulletKeymap`, `ZoomedTitle`'s inline `useHotkeys`, and `MiniNodeEditor`. Delegated pointers, `/`, and caret menus already reach all three. Keymaps and slots do not.
-- **`el.textContent` is not the source.** Folding tokens render `data-src` atoms. Read with `readSource(el)`. Caret offsets are SOURCE offsets through `getCaretOffset` / `setCaretOffset`.
-- **contentEditable text sync is manual.** Stored text writes to the DOM only when it differs.
-- **`OutlineEditor` and `SwitcherDialog` carry `"use no memo"`.** Keep the hand-tuned `memo` / `useMemo` on the contentEditable hot path.
-- **The visible-neighbor walk must mirror render visibility.**
-- **The `refs` registry maps a node id to its contentEditable span**; the zoomed title registers under `rootId`.
-- **Assert nesting through `data-parent-id` and `data-depth`.** The windowed list is flat.
+- **Entitlement reads never call Stripe.** `getPlan(userId, env)` is one D1 query. Keep the founding seat cap in `getCheckoutSessionParams`.
+- **A node renders in three places**, with three keymaps: `OutlineRow`, `ZoomedTitle`, `MiniNodeEditor`. Keymaps and slots do not share. The `refs` registry maps a node id to its contentEditable span; the zoomed title registers under `rootId`.
+- **`el.textContent` is not the source.** Read with `readSource(el)`. Caret offsets are SOURCE offsets. Stored text writes to the DOM only when it differs.
+- **`OutlineEditor` and `SwitcherDialog` carry `"use no memo"`.**
+- **The visible-neighbor walk must mirror render visibility.** Assert nesting through `data-parent-id` and `data-depth`.
 - **`rootId` is route-owned.** `routes/index.tsx` gives `null`; `routes/$nodeId.tsx` gives `nodeId`. The editor remounts per zoom via `key={nodeId}`.
-- **The typed-error channel in Effect is the error model.** Read Effect v4 from `bunx opensrc path Effect-TS/effect-smol` (its `AGENTS.md` and `.patterns/` first), never `node_modules/effect/`. Search that cache with `grep` or Read. App code imports `effect` from npm.
-- **`kv-api.ts` must keep throwing.** TanStack DB rolls back on throw.
+- **The typed-error channel in Effect is the error model.** Read Effect v4 from `bunx opensrc path Effect-TS/effect-smol`, never `node_modules/effect/`. App code imports `effect` from npm. **`kv-api.ts` must keep throwing.**
 - **e2e runs on its own Vite server on port 3210.** Kill a zombie or set `E2E_PORT`. For a caret, set the Selection range directly. `toHaveText` normalizes whitespace.
 - **A perf guard asserts a countable invariant**, never a wall clock.
 - **When you add an MCP tool, update the ordered tool-name list in `worker/mcp.test.ts`.**
-- **`src/routeTree.gen.ts` is generated.** Never hand-edit or reformat it.
-- **Every PR adds a changeset fragment.** `bunx changeset --empty` when the PR is not news. `bun run release` is the only way to bump the version.
-- **After `bun add` of a React-importing package, clear `node_modules/.vite`** if the dev server dies on an invalid hook call.
-- **The Codex app rewrites `.codex/environments/environment.toml`** and drops comments. Put no load-bearing explanation there.
-- **`HANDOFF.md` is branch-local.** Commit it on the branch; delete it in the shipping PR. It must never reach `main`.
+- **After `bun add` of a React-importing package, clear `node_modules/.vite`** if the hook call dies.
+- **The Codex app rewrites `.codex/environments/environment.toml`** and drops comments.
+- **Session handoffs.** `HANDOFF.md` is branch-local. Commit it on the branch; delete it in the shipping PR. It must never reach `main`.
 - **Local dev is `bun run cf:dev` on port 8787.** `bun run dev` on :3000 has a broken database on Cam's machine.
-- **Lunora mutator patch, delete, and get must pass `expectedTable`.** Write through the per-table facade (`ctx.db.nodes.delete(...)`, `ctx.db.dailyIndex.patch(...)`). `ctx.db.asId(...)` is compile-time branding only.
-- **With Lunora on, read live nodes through `getLiveNodes()` and await `whenNodesSyncReady()`.** `nodesCollection.toArray` is `[]`; `toArrayWhenReady()` resolves instantly.
-- **`await tx.isPersisted.promise` does not make the mutator's own rows readable.** Subscribe and wait for the row.
-- **Vite proxies for `/api` and `/_lunora` need `ws: true`.** The string shorthand does not upgrade WebSockets.
-- **Capture a repeated incantation** in a `package.json` script or a config file. Reach for `scripts/*.ts` only when there is no config home.
+- **Lunora mutator patch, delete, and get must pass `expectedTable`.** Write through the per-table facade. `ctx.db.asId(...)` is compile-time branding only.
+- **Vite proxies for `/api` and `/_lunora` need `ws: true`.**
+- **Capture a repeated incantation** in a `package.json` script or a config file.
 
 ## Guardrails
 
 - **Grill first.** New plugin, route, seam, `Node` field, side-collection, or ADR-worthy behavior: read the matching ADRs, then ask the user to run `/grill-with-docs` (user-invoked only). If they waive it, hold the design against those ADRs by hand. An agent can invoke `/domain-modeling`, `/code-review`, `/security-review`, and `/ft-create-concise-pr`.
-- **There is no client-side data migration.** A localStorage import leaks one browser's outline into every account that signs in there.
+- **There is no client-side data migration.**
 - **Key the DO through `resolveUserId`**, never the email. The one exception is the owner-continuity bridge to `'default'`.
 - **The `/api` session check trusts the server session**, never a client-supplied id.
 - **The SSRF guard in `worker/unfurl.ts` revalidates every redirect hop.**
-- **Google is `disableSignUp: true`**, never `disableImplicitSignUp`. A client can waive the second with `requestSignUp: true`.
-- **Signup gates fail closed.** `SIGNUP_OPEN` must be the exact literal `"true"`. Admin routes return 404, not 401.
-- **Send all transactional email through `worker/email.ts`.** Park sends on `ctx.waitUntil` so timing stays uniform.
-- **Decode request bodies against Effect Schema.** Wire types derive from the schemas.
-- **The app is a pure static SPA.** The DO holds the data. Code that touches `nodesCollection` stays off the server and render pass.
-- **Lunora sync stays opt-in.** User-facing copy must not name Lunora. Frame it as an experimental sync option. Turning it off returns the last classic snapshot.
-- **Repo reality is the source of truth for the docs.** If `AGENTS.md` or `README.md` becomes false about a path, command, or tool, correct it in the same change. Ask first before changing policy, philosophy, or positioning.
+- **Google is `disableSignUp: true`**, never `disableImplicitSignUp`. Signup gates fail closed: `SIGNUP_OPEN` must be the exact literal `"true"`. Admin routes return 404.
+- **Send all transactional email through `worker/email.ts`.** Park sends on `ctx.waitUntil`.
+- **Decode request bodies against Effect Schema.**
+- **The app is a pure static SPA.** Code that touches `nodesCollection` stays off the server and render pass.
+- **Lunora sync stays opt-in.** User-facing copy must not name Lunora. Turning it off returns the last classic snapshot. Live-read and `isPersisted` landmines: [ADR 0058](./docs/adr/0058-lunora-replaces-custom-outline-sync.md).
+- **Documentation Freshness.** If `AGENTS.md` or `README.md` becomes false about a path, command, or tool, correct it in the same change. Ask first before changing policy, philosophy, or positioning.
 - **Run the app before calling an observable change done.** Drive it in `bun run cf:dev` or an e2e spec.
 
 ## Design
@@ -84,7 +69,7 @@ Plugin, seam, token, or kit UI: read [`docs/plugins.md`](./docs/plugins.md).
 
 ## Testing
 
-Testing or coverage: read [`CONTRIBUTING.md`](./CONTRIBUTING.md). `--workers=2` is the clean-signal full local run. e2e does not run in CI.
+Testing or coverage: read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
 
 ## Review
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,42 +6,20 @@ Keep this file brief. Put task-specific guidance behind a pointer.
 
 ## Gotchas
 
-- **Structural vs field writes.** Tree-shape changes go through `runStructural` at the call site, not inside `mutations.ts`. Field edits stay a direct PATCH.
-- **A new `Node` field touches seven places:** `src/data/wire-schema.ts`, `src/data/schema.ts`, `makeNode()`, `withNodeDefaults` in `collection.ts`, a DO `ADD COLUMN` migration, `e2e/fixtures.ts`, and the R2 snapshot boundary in `worker/backup.ts`. Miss the fixtures and inbound-frame decode rejects every snapshot. Build nodes with `makeNode()`.
-- **Add a new side-collection to `KV_COLLECTIONS` in `worker/index.ts`.**
-- **Read side-collections with `subscribeChanges` and `useSyncExternalStore`.** `useLiveQuery` hard-fails the `/` prerender. Readiness rides `toArrayWhenReady()`.
-- **The tree index mutates in place and notifies synchronously.** Read sibling state before you mutate.
-- **Read event-time values through the getters** (`getTreeIndex()`, `getViewRootId()`, `getViewIsHidden()`, `getViewFilter()`). Write view state in effects.
-- **Entitlement reads never call Stripe.** `getPlan(userId, env)` is one D1 query. Keep the founding seat cap in `getCheckoutSessionParams`.
-- **A node renders in three places**, with three keymaps: `OutlineRow`, `ZoomedTitle`, `MiniNodeEditor`. Keymaps and slots do not share. The `refs` registry maps a node id to its contentEditable span; the zoomed title registers under `rootId`.
-- **`el.textContent` is not the source.** Read with `readSource(el)`. Caret offsets are SOURCE offsets. Stored text writes to the DOM only when it differs.
-- **`OutlineEditor` and `SwitcherDialog` carry `"use no memo"`.**
-- **The visible-neighbor walk must mirror render visibility.** Assert nesting through `data-parent-id` and `data-depth`.
-- **`rootId` is route-owned.** `routes/index.tsx` gives `null`; `routes/$nodeId.tsx` gives `nodeId`. The editor remounts per zoom via `key={nodeId}`.
-- **The typed-error channel in Effect is the error model.** Read Effect v4 from `bunx opensrc path Effect-TS/effect-smol`, never `node_modules/effect/`. App code imports `effect` from npm. **`kv-api.ts` must keep throwing.**
-- **e2e runs on its own Vite server on port 3210.** Kill a zombie or set `E2E_PORT`. For a caret, set the Selection range directly. `toHaveText` normalizes whitespace.
-- **A perf guard asserts a countable invariant**, never a wall clock.
-- **When you add an MCP tool, update the ordered tool-name list in `worker/mcp.test.ts`.**
-- **After `bun add` of a React-importing package, clear `node_modules/.vite`** if the hook call dies.
-- **The Codex app rewrites `.codex/environments/environment.toml`** and drops comments.
-- **Session handoffs.** `HANDOFF.md` is branch-local. Commit it on the branch; delete it in the shipping PR. It must never reach `main`.
-- **Local dev is `bun run cf:dev` on port 8787.** `bun run dev` on :3000 has a broken database on Cam's machine.
-- **Lunora mutator patch, delete, and get must pass `expectedTable`.** Write through the per-table facade. `ctx.db.asId(...)` is compile-time branding only.
-- **Vite proxies for `/api` and `/_lunora` need `ws: true`.**
-- **Capture a repeated incantation** in a `package.json` script or a config file.
+- **Local dev is `bun run cf:dev` on port 8787.** `bun run dev` on :3000 has a broken database on Cam's machine. Why, and the rest of setup: [`CONTRIBUTING.md`](./CONTRIBUTING.md).
 
 ## Guardrails
 
 - **Grill first.** New plugin, route, seam, `Node` field, side-collection, or ADR-worthy behavior: read the matching ADRs, then ask the user to run `/grill-with-docs` (user-invoked only). If they waive it, hold the design against those ADRs by hand. An agent can invoke `/domain-modeling`, `/code-review`, `/security-review`, and `/ft-create-concise-pr`.
 - **There is no client-side data migration.**
 - **Key the DO through `resolveUserId`**, never the email. The one exception is the owner-continuity bridge to `'default'`.
-- **The `/api` session check trusts the server session**, never a client-supplied id.
+- **The `/api` session check trusts the server session.**
 - **The SSRF guard in `worker/unfurl.ts` revalidates every redirect hop.**
 - **Google is `disableSignUp: true`**, never `disableImplicitSignUp`. Signup gates fail closed: `SIGNUP_OPEN` must be the exact literal `"true"`. Admin routes return 404.
 - **Send all transactional email through `worker/email.ts`.** Park sends on `ctx.waitUntil`.
 - **Decode request bodies against Effect Schema.**
 - **The app is a pure static SPA.** Code that touches `nodesCollection` stays off the server and render pass.
-- **Lunora sync stays opt-in.** User-facing copy must not name Lunora. Turning it off returns the last classic snapshot. Live-read and `isPersisted` landmines: [ADR 0058](./docs/adr/0058-lunora-replaces-custom-outline-sync.md).
+- **Lunora sync stays opt-in.** User-facing copy must not name Lunora. Turning it off returns the last classic snapshot.
 - **Documentation Freshness.** If `AGENTS.md` or `README.md` becomes false about a path, command, or tool, correct it in the same change. Ask first before changing policy, philosophy, or positioning.
 - **Run the app before calling an observable change done.** Drive it in `bun run cf:dev` or an e2e spec.
 
@@ -61,7 +39,11 @@ New feature or design: `ls docs/adr/` and read the ADRs that match the surface. 
 
 ## Architecture
 
-Structure, data model, backend-swap: [`docs/architecture.md`](./docs/architecture.md). Setup and local dev: [`CONTRIBUTING.md`](./CONTRIBUTING.md).
+Structure, data model, new `Node` field, tree reads: [`docs/architecture.md`](./docs/architecture.md). **`rootId` is route-owned.** Setup and local dev: [`CONTRIBUTING.md`](./CONTRIBUTING.md).
+
+## Editor
+
+**A node renders in three places.** Caret, folding tokens, keymaps: [`docs/plugins.md`](./docs/plugins.md).
 
 ## Plugins
 
@@ -69,7 +51,19 @@ Plugin, seam, token, or kit UI: read [`docs/plugins.md`](./docs/plugins.md).
 
 ## Testing
 
-Testing or coverage: read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
+Testing or coverage: read [`CONTRIBUTING.md`](./CONTRIBUTING.md). **A perf guard asserts a countable invariant.**
+
+## Effect
+
+**The typed-error channel in Effect is the error model.** Opensrc path and `kv-api.ts` throw: [`CONTRIBUTING.md`](./CONTRIBUTING.md).
+
+## Billing
+
+Entitlements and checkout: [`CONTRIBUTING.md`](./CONTRIBUTING.md).
+
+## Lunora
+
+Experimental sync, live reads, `isPersisted`, `expectedTable`: [ADR 0058](./docs/adr/0058-lunora-replaces-custom-outline-sync.md).
 
 ## Review
 
@@ -81,12 +75,7 @@ Version bump or changelog: [ADR 0046](./docs/adr/0046-changelog-and-release-vers
 
 ## Landing
 
-Landing site (`landing/`, dotflowy.com): Geist only, no mono. Accents match the app palette. Feature bullets stay vertical on desktop. Keep "Workflowy alternative" out of the H1 and the footer brand row.
-
-## Preferences
-
-- Once the approach is agreed, pick the best reasonable option and proceed. If the target worktree is unclear, ask.
-- Icons: free MIT Hugeicons (`@hugeicons/react`, `@hugeicons/core-free-icons`) at default stroke.
+Landing site (`landing/`, dotflowy.com): Geist only, no mono. Accents match the app palette. Feature bullets stay vertical on desktop. Keep "Workflowy alternative" out of the H1 and the footer brand row. Icons in the app: free MIT Hugeicons (`@hugeicons/react`, `@hugeicons/core-free-icons`) at default stroke.
 
 ## Tooling
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,10 +6,9 @@ change" guide. Two companion docs go deeper:
 - **[`README.md`](./README.md)** — what Dotflowy is, at a glance. Read it
   first, then **[`docs/architecture.md`](./docs/architecture.md)** for the data
   model, the sync design, and the project layout.
-- **[`AGENTS.md`](./AGENTS.md)** (symlinked as `CLAUDE.md`) — the per-feature
-  rules and gotchas. It's written for coding agents but it's the canonical
-  reference for _why_ the code is shaped the way it is. Read the section that
-  covers whatever you're touching before you touch it.
+- **[`AGENTS.md`](./AGENTS.md)** (symlinked as `CLAUDE.md`) — always-on
+  identity, guardrails, and pointers. Task landmines live in the doc each
+  pointer names.
 
 ## Prerequisites
 
@@ -73,6 +72,11 @@ bun run dev      # vite (:3000) + wrangler (:8787) together; HMR for the UI
 Open http://localhost:3000. Vite gives you HMR; the Worker reloads on its own
 edits. This is the loop for almost all work. `bun run dev:api` + `bun run dev:web`
 still exist if you want the two servers in separate terminals with isolated logs.
+
+On Cam's machine `bun run dev` on :3000 has a broken database. Agents use
+`bun run cf:dev` on :8787 (one origin, closer to prod). Vite proxies for `/api`
+and `/_lunora` need `ws: true` — the string shorthand does not upgrade WebSockets
+(`vite.config.ts` already sets this).
 
 ### Sign in
 
@@ -143,6 +147,12 @@ guard — `STRIPE_SECRET_KEY=sk_live_… bun scripts/stripe-setup.ts --live` —
 also registers the `app.dotflowy.com` webhook endpoint and prints the `whsec_…`
 signing secret once (feed it to `wrangler secret put STRIPE_WEBHOOK_SECRET`).
 
+Entitlement reads never call Stripe. `getPlan(userId, env)` is one D1 query on
+`referenceId = user.id`, `status IN ('active','trialing')`. Free tier is no
+row. An operator-comped user is a hand-inserted active row with no Stripe ids.
+Keep the founding seat cap in `getCheckoutSessionParams` at checkout-creation
+time. Webhooks and `subscription.list()` resolve plans from that same list.
+
 ## Before you open a PR
 
 Run the full gate. These mirror CI — except `bun run test:e2e`, which is
@@ -159,13 +169,12 @@ bun run test:e2e        # playwright (chromium) — behavior/integration
 bunx changeset          # describe your change for the changelog (see below)
 ```
 
-Then **run the app**: before calling an observable change done, drive it in the
-running app (`bun run dev`) — or exercise it through an e2e spec — and confirm
-the behavior. Green gates are necessary, not sufficient (see _Run the app
-before declaring done_ in `AGENTS.md`). Skip only for changes with no runtime
-surface (docs, types, tooling).
+Then **run the app**: before calling an observable change done, drive it in
+`bun run cf:dev` — or exercise it through an e2e spec — and confirm the
+behavior. Green gates are necessary, not sufficient. Skip only for changes with
+no runtime surface (docs, types, tooling).
 
-Rules of thumb, expanded in `AGENTS.md`:
+Rules of thumb:
 
 - **Every PR carries a changeset.** `bunx changeset` writes a fragment saying what
   changed and how loudly — `major` when a reader has to _do_ something, `minor` for
@@ -183,40 +192,51 @@ Rules of thumb, expanded in `AGENTS.md`:
   maximum-determinism local run; `--workers=2` is the clean-signal full run
   before a PR. **e2e does not run in CI** — Playwright is a local pre-PR gate,
   so running it here is what stands in for a CI check. A parallel-contention
-  flake isn't a real failure.
+  flake isn't a real failure. e2e runs on its own Vite server on port 3210;
+  kill a zombie or set `E2E_PORT`. For a caret, set the Selection range
+  directly. `toHaveText` normalizes whitespace. **A perf guard asserts a
+  countable invariant**, never a wall clock.
 - **react-doctor is an occasional manual audit, not a gate** — its accepted
   editor false-positives (the deliberately kept manual memos) are known noise
   on every run, so it stays out of the recurring validation set.
-- **Shipping a multi-session branch? Delete `HANDOFF.md`** — it's transient
-  branch-local build state (see _Session handoffs_ in `AGENTS.md`) and must not
-  reach `main`.
+- **Session handoffs.** `HANDOFF.md` is transient branch-local build state.
+  Commit it on the branch; delete it in the shipping PR. It must not reach
+  `main`.
 - **`src/routeTree.gen.ts` is generated** — never hand-edit. After adding or
   renaming a file in `src/routes/`, run `bun run dev` once to regenerate it.
-- If you change a documented fact (a command, a path, repo structure), fix the
-  affected doc (`AGENTS.md` and/or `README.md`) in the same change. See
-  _Documentation Freshness_ in `AGENTS.md`.
+- **Documentation Freshness.** If you change a documented fact (a command, a
+  path, repo structure), fix the affected doc (`AGENTS.md` and/or `README.md`)
+  in the same change. Ask first before changing policy, philosophy, or
+  positioning.
 - **PR descriptions follow the snapshot template** in
   `.agents/skills/ft-create-concise-pr/SKILL.md` (agents: run
   `/ft-create-concise-pr`) — one consistent, skimmable shape for every review.
 
 ## Conventions worth knowing
 
-`AGENTS.md` is the full reference; the headlines:
-
 - **Skills first.** Before substantial work, run `bunx @tanstack/intent@latest list`
-  and load a matching skill if one fits (see the top of `AGENTS.md`).
-- **Effect v4 source comes via opensrc** — `bunx opensrc path Effect-TS/effect-smol`
-  prints a machine-global cached copy (`bun run setup` pre-warms it). Read from it,
-  never import from it; app/worker code imports `effect` from npm. Read the fetched
-  repo's `AGENTS.md` before writing Effect.
+  and load a matching skill if one fits (see the Skill Loading block in
+  `AGENTS.md`).
+- **The typed-error channel in Effect is the error model.** Effect v4 source
+  comes via opensrc — `bunx opensrc path Effect-TS/effect-smol` prints a
+  machine-global cached copy (`bun run setup` pre-warms it). Read from it,
+  never import from it; app/worker code imports `effect` from npm. Read the
+  fetched repo's `AGENTS.md` before writing Effect. `kv-api.ts` must keep
+  throwing — TanStack DB rolls back on throw.
 - **Plugins** live in `src/plugins/<name>/`; adding a feature is a folder plus one
   line in `src/plugins/index.ts` ([ADR 0001](./docs/adr/0001-plugin-architecture.md)).
-- **Structural edits are atomic; field edits are direct.** Any tree-shape
-  mutation goes through `runStructural` (one batch, echo-held); single-field edits
-  stay direct ([ADR 0009](./docs/adr/0009-atomic-structural-writes.md)).
+- **Structural edits are atomic; field edits are direct.** Tree-shape changes
+  go through `runStructural` at the call site, not inside `mutations.ts`.
+  Field edits stay a direct PATCH ([ADR 0009](./docs/adr/0009-atomic-structural-writes.md)).
 - **Load-bearing decisions are ADRs** in `docs/adr/`, numbered sequentially. A
   decision earns one when it's hard to reverse and surprising without context;
   otherwise the code is the doc.
+- **After `bun add` of a React-importing package**, clear `node_modules/.vite`
+  if the dev server dies on an invalid hook call.
+- **The Codex app rewrites `.codex/environments/environment.toml`** and drops
+  comments. Put no load-bearing explanation there.
+- **Capture a repeated incantation** in a `package.json` script or a config
+  file. Reach for `scripts/*.ts` only when there is no config home.
 
 ## Deploying
 

--- a/README.md
+++ b/README.md
@@ -61,16 +61,16 @@ you deploy. [`CONTRIBUTING.md`](./CONTRIBUTING.md) has the full setup guide.
 
 ## Documentation
 
-| Doc                                      | What's in it                                                                                               |
-| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| [Architecture](./docs/architecture.md)   | The data model, persistence + sync design, the plugin system, the stack, and the project layout            |
-| [Deploying](./docs/deploying.md)         | Self-hosting on Cloudflare Workers, auth + signup configuration                                            |
-| [Agents (MCP)](./docs/mcp.md)            | Connecting AI agents to your outline over the Model Context Protocol                                       |
-| [Keyboard shortcuts](./docs/keyboard.md) | The full key reference                                                                                     |
-| [`CONTRIBUTING.md`](./CONTRIBUTING.md)   | Setup, the dev loops, the pre-PR check matrix, repo conventions                                            |
-| [`AGENTS.md`](./AGENTS.md)               | Per-feature rules and gotchas — written for coding agents, canonical for _why_ the code is shaped this way |
-| [`docs/adr/`](./docs/adr/)               | One decision record per load-bearing choice                                                                |
-| [`CHANGELOG.md`](./CHANGELOG.md)         | What's new, release by release                                                                             |
+| Doc                                      | What's in it                                                                                    |
+| ---------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| [Architecture](./docs/architecture.md)   | The data model, persistence + sync design, the plugin system, the stack, and the project layout |
+| [Deploying](./docs/deploying.md)         | Self-hosting on Cloudflare Workers, auth + signup configuration                                 |
+| [Agents (MCP)](./docs/mcp.md)            | Connecting AI agents to your outline over the Model Context Protocol                            |
+| [Keyboard shortcuts](./docs/keyboard.md) | The full key reference                                                                          |
+| [`CONTRIBUTING.md`](./CONTRIBUTING.md)   | Setup, the dev loops, the pre-PR check matrix, repo conventions                                 |
+| [`AGENTS.md`](./AGENTS.md)               | Always-on identity, guardrails, and pointers for coding agents                                  |
+| [`docs/adr/`](./docs/adr/)               | One decision record per load-bearing choice                                                     |
+| [`CHANGELOG.md`](./CHANGELOG.md)         | What's new, release by release                                                                  |
 
 ## License
 

--- a/docs/adr/0001-plugin-architecture.md
+++ b/docs/adr/0001-plugin-architecture.md
@@ -5,7 +5,7 @@ registry in `src/plugins/`, _not_ runtime-loaded. `code`, `links`, `tags`, `todo
 `route-bible` are themselves plugins, so the core carries no feature-specific branches. A plugin
 registers into a fixed, finite set of **seams** (inline tokens, delegated clicks, `/` commands,
 keymap, row/header slots, view transforms, caret menus, paste/autoformat, side-collections, search
-providers). The live seam map and current owners are the Plugins section of `AGENTS.md`; this is
+providers). The live seam map and current owners are [`docs/plugins.md`](../plugins.md); this is
 the design rationale.
 
 **Two-tier data ownership is the load-bearing rule.** The decider: _does any core view-transform

--- a/docs/adr/0058-lunora-replaces-custom-outline-sync.md
+++ b/docs/adr/0058-lunora-replaces-custom-outline-sync.md
@@ -49,6 +49,13 @@ A read straight through the await therefore reports a failure for a write that l
 - **The claim path fails DANGEROUSLY, not merely loudly.** `claimTx` falls back to the local candidate id when the row reads as missing, so a read inside the window reports a WIN to a caller that lost the claim. `claimScaffoldNode` then calls `setMapping(key, winner)` unconditionally, which under Lunora patches `nodeId` blindly — so the false win overwrites the real winner's mapping on every other device.
 - **The wait NARROWS that window; it does not close it.** A stall past the timeout (backgrounded tab, reconnect, slow socket) still produces the false win. Closing it needs a server-authoritative read, which is follow-up work. Until then the timeout path reports to Sentry, because a rare silent corruption is harder to find than a routine one. It reports in PROD, not just DEV: every trigger is a production condition, so a DEV-only warn would be silent exactly where the hazard lives. `captureException` and not `captureMessage`, since the errors-only posture (#227) is deliberate and an unresolvable claim is an error. The payload carries a day key and two opaque ids, so no outline text rides along.
 
+## Mutator writes (locked)
+
+**Patch, delete, and get must pass `expectedTable`.** Write through the per-table
+facade (`ctx.db.nodes.delete(...)`, `ctx.db.dailyIndex.patch(...)`).
+`ctx.db.asId(...)` is compile-time branding only — it does not scope the runtime
+lookup. Unscoped patch/delete resolve the id across tables.
+
 ## Identity / e2e / kv (locked)
 
 - **Identity:** product Better Auth stays the session authority (MCP OAuth, Stripe, invite/Turnstile). Lunora `resolveIdentity` reads that session — do **not** run a second `@lunora/auth` signup stack in the main app.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,8 +1,8 @@
 # Architecture
 
-How Dotflowy stores, syncs, and renders an outline. This is the human-facing
-overview; per-feature rules and gotchas live in [`AGENTS.md`](../AGENTS.md), and
-each load-bearing decision has a full write-up in [`docs/adr/`](./adr/).
+How Dotflowy stores, syncs, and renders an outline. Agent pointers live in
+[`AGENTS.md`](../AGENTS.md). Each load-bearing decision has a write-up in
+[`docs/adr/`](./adr/).
 
 ## The shape of the system
 
@@ -45,6 +45,30 @@ the structural operations — insert, indent / outdent, the fused `moveNode`
 (drag reorder + reparent), move up / down, delete — plus the field setters
 (text, task, completed, collapsed, bookmark). Each preserves the linked-list
 invariant.
+
+### Adding a Node field
+
+A new field touches seven places: `src/data/wire-schema.ts`, `src/data/schema.ts`,
+`makeNode()`, `withNodeDefaults` in `collection.ts`, a DO `ADD COLUMN` migration,
+`e2e/fixtures.ts`, and the R2 snapshot boundary in `worker/backup.ts`. Miss the
+fixtures and inbound-frame decode rejects every snapshot. Build nodes with
+`makeNode()` — a schema default makes the field optional in the encoded type
+([ADR 0003](./adr/0003-no-schema-defaults.md)).
+
+### Reading the tree
+
+The tree index mutates in place and notifies synchronously. Read sibling state
+before you mutate. Multi-node mutations rebuild the index from the live
+collection between each step.
+
+Read event-time values through the getters (`getTreeIndex()`, `getViewRootId()`,
+`getViewIsHidden()`, `getViewFilter()`). Write view state in effects.
+
+Read side-collections with `subscribeChanges` and `useSyncExternalStore`.
+`useLiveQuery` hard-fails the `/` prerender. Readiness rides `toArrayWhenReady()`.
+
+`rootId` is route-owned: `routes/index.tsx` gives `null`; `routes/$nodeId.tsx`
+gives `nodeId`. The editor remounts per zoom via `key={nodeId}`.
 
 ### Why flat, not nested
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -23,3 +23,8 @@ fidelity-degradation tally) — `dryRun: true` previews that receipt without
 writing; `export_opml` mirrors `get_outline` scoping and returns the raw OPML
 string. Both are capped at 5,000 nodes and reject rather than truncate — a
 full Workflowy migration belongs in the app UI.
+
+## Adding a tool
+
+When you add an MCP tool, update the ordered tool-name list in
+`worker/mcp.test.ts`. The test asserts the registry order, not just presence.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -33,3 +33,24 @@ Feature → seams: **code** A · **links** A+B+C+I+K · **node-links** A(widget)
 **Still core-wired (deliberately, awaiting future seams):** fade-inheritance (`faded`/`ancestorCompleted`) and Backspace-on-the-checkbox demotion still read `completed`/`isTask` in `OutlineRow`; the bullet-vs-paragraph glyph reads `kind` there too (core's own field, ADR 0045); the `/` palette still runs `useSlashMenu` (only its command _list_ is registry-driven).
 
 **Constraints when touching this:** keep token `render` output byte-stable (the `decorate` cache compares strings) and allocation-light (runs per keystroke); never hand the core raw HTML (return `El`/`WidgetEl`); don't reintroduce N separate token scans. **Shared token helpers live in `src/plugins/token-kit.ts`** (`isRevealed` fold/reveal predicate, verbatim-match-or-drop write-back, `spliceToken` re-export) — use them, don't re-copy the predicate; `spliceToken` itself lives in the dependency-free `token-splice.ts` so worker-reachable data modules can import it without dragging DOM types into the Workers tsconfig. **Plugin UI comes from `src/plugins/kit.ts`** — the curated shadcn surface a Lane-A plugin may use (ADR 0031); a plugin importing `@/components/ui/*` directly is an oxlint error (`no-restricted-imports` override on `src/plugins/**`). Add a component to the kit when a plugin needs it; there is no plugin `styles` seam (style via Tailwind utilities on your `El`/JSX).
+
+Add a new side-collection to `KV_COLLECTIONS` in `worker/index.ts`. The e2e kv mock accepts any name.
+
+## Editor render paths
+
+**A node renders in three places**, with three keymaps: `OutlineRow` /
+`useBulletKeymap`, `ZoomedTitle`'s inline `useHotkeys`, and `MiniNodeEditor`.
+Delegated pointers, `/`, and caret menus already reach all three. Keymaps and
+slots do not. The `refs` registry maps a node id to its contentEditable span;
+the zoomed title registers under `rootId`.
+
+`el.textContent` is not the source. Folding tokens render `data-src` atoms.
+Read with `readSource(el)`. Caret offsets are SOURCE offsets through
+`getCaretOffset` / `setCaretOffset` ([ADR 0005](./adr/0005-rich-links-source-offset-caret.md)).
+Stored text writes to the DOM only when it differs.
+
+`OutlineEditor` and `SwitcherDialog` carry `"use no memo"`. Keep the hand-tuned
+`memo` / `useMemo` on the contentEditable hot path.
+
+The visible-neighbor walk must mirror render visibility. Assert nesting through
+`data-parent-id` and `data-depth` — the windowed list is flat.

--- a/docs/runbooks/offsite-backup-r2.md
+++ b/docs/runbooks/offsite-backup-r2.md
@@ -100,7 +100,7 @@ losses or anything that outlived the PITR window.
   shared `NodeSchema`; when a new required `Node` field lands, the snapshot
   boundary needs a backfill (or a `SNAPSHOT_VERSION` bump) or every pre-change
   snapshot in the 90-day depth becomes unrestorable — this is on the
-  new-`Node`-field checklist in AGENTS.md.
+  new-`Node`-field checklist in `docs/architecture.md`.
 
 ## Local dev / verification
 

--- a/e2e/date-token.spec.ts
+++ b/e2e/date-token.spec.ts
@@ -54,7 +54,7 @@ async function load(page: Page) {
 }
 
 /** Place the caret at the end of a bullet via the Selection API (a plain click
- *  can land on a chip or past the text -- see AGENTS.md). */
+ *  can land on a chip or past the text -- see CONTRIBUTING.md). */
 async function caretAtEnd(page: Page, id: string) {
   await text(page, id).evaluate((el) => {
     (el as HTMLElement).focus();

--- a/e2e/lunora-daily-commands.spec.ts
+++ b/e2e/lunora-daily-commands.spec.ts
@@ -87,7 +87,7 @@ async function expectNoToast(page: Page, re: RegExp): Promise<void> {
 
 /** Put the caret at the end of a bullet through the Selection API. `.click()`
  *  can land on a chip or past the text, and macOS Chromium's Home/End/arrow
- *  keys are unreliable in a contentEditable (AGENTS.md). */
+ *  keys are unreliable in a contentEditable (CONTRIBUTING.md). */
 async function caretAtEnd(page: Page, id: string): Promise<void> {
   await text(page, id).evaluate((el) => {
     (el as HTMLElement).focus();

--- a/e2e/markdown-paste.spec.ts
+++ b/e2e/markdown-paste.spec.ts
@@ -50,7 +50,7 @@ async function pasteInto(locator: Locator, plain: string) {
 }
 
 /** Focus a bullet and put the caret at source offset `col` (arrows and Home/End
- *  are unreliable in macOS Chromium contentEditable -- see AGENTS.md). */
+ *  are unreliable in macOS Chromium contentEditable -- see CONTRIBUTING.md). */
 async function caretAt(page: Page, id: string, col: number) {
   await text(page, id).evaluate((el, target) => {
     el.focus();

--- a/e2e/node-links.spec.ts
+++ b/e2e/node-links.spec.ts
@@ -34,7 +34,7 @@ async function load(page: Page) {
 }
 
 /** Focus a bullet and place the caret at the end of its text via the Selection
- *  API (a plain click can land on a chip or past the text -- see AGENTS.md). */
+ *  API (a plain click can land on a chip or past the text -- see CONTRIBUTING.md). */
 async function caretAtEnd(page: Page, id: string) {
   await text(page, id).evaluate((el) => {
     (el as HTMLElement).focus();

--- a/e2e/paragraph.spec.ts
+++ b/e2e/paragraph.spec.ts
@@ -12,7 +12,7 @@ import { seedOutline, type SeedNode } from "./fixtures";
 //
 // Every command here runs from an EMPTY bullet, so the `/` palette opens at
 // offset 0 and no caret helper is needed (Home/End and `.click()` on text are
-// unreliable in macOS Chromium contentEditable -- see AGENTS.md).
+// unreliable in macOS Chromium contentEditable -- see CONTRIBUTING.md).
 
 const MOD = process.platform === "darwin" ? "Meta" : "Control";
 

--- a/e2e/slash-menu-scroll.spec.ts
+++ b/e2e/slash-menu-scroll.spec.ts
@@ -9,7 +9,7 @@ const text = (page: Page, id: string) =>
  * One round-trip read of the open menu. Geometry lives here (not in locators)
  * because the invariants are COUNTABLE -- an integer scroll offset and a rect
  * containment -- which read identically on any hardware, unlike a wall clock.
- * See AGENTS.md "A perf guard asserts a countable invariant".
+ * See CONTRIBUTING.md "A perf guard asserts a countable invariant".
  */
 async function menuState(page: Page) {
   return page.evaluate(() => {

--- a/src/components/OutlineEditor.tsx
+++ b/src/components/OutlineEditor.tsx
@@ -1217,8 +1217,8 @@ interface ZoomNavigationArgs {
  * Zoom navigation: the shared-element morph between a node's title and list-item
  * roles, Cmd+, zoom-out, and the focus landing after a navigation. Returns the
  * stable `navigateZoom` and the current pivot id. The mount-only effects rely on
- * the editor remounting per zoom view (its `key={nodeId}`; see AGENTS.md
- * "`rootId` is route-owned").
+ * the editor remounting per zoom view (its `key={nodeId}`; see
+ * docs/architecture.md "`rootId` is route-owned").
  */
 function useZoomNavigation({
   rootId,
@@ -2101,7 +2101,7 @@ function ZoomedTitle({
   // Plugin slots for the zoomed title (Seam F) plus the two core decorations
   // (protected lock, mirror badge), in ONE list -- the same composition as
   // OutlineRow's `row:before-text`, so the two render paths can't drift (see
-  // AGENTS.md "A node renders in three places"). Mirrors OutlineRow's order: slots,
+  // docs/plugins.md "A node renders in three places"). Mirrors OutlineRow's order: slots,
   // then the lock, then the badge.
   const beforeTextSlots: SlotSpec[] = [
     ...slotsAt("title:before-text"),
@@ -2147,7 +2147,7 @@ function ZoomedTitle({
   // The `/` palette (Seam C) on the zoomed title too, mirroring OutlineRow --
   // so `/delete`, `/paragraph`, Move, Mirror, and every plugin `/` command work
   // whether the node is a list bullet or the page title (the two-render-paths
-  // rule; see AGENTS.md "A node renders in three places"). The title keymap below
+  // rule; see docs/plugins.md "A node renders in three places"). The title keymap below
   // is gated on `!slash.isOpen` so the menu's Enter/Arrow/Escape win while it's
   // open, exactly as OutlineRow gates useBulletKeymap.
   const slash = useSlashMenu({

--- a/src/components/quick-add.tsx
+++ b/src/components/quick-add.tsx
@@ -173,7 +173,7 @@ export interface MiniEditorHandle {
 }
 
 /** The contentEditable capture surface for ONE node. A curated, text-authoring
- *  fork of `OutlineEditor`'s `ZoomedTitle` (AGENTS.md "A node renders in three
+ *  fork of `OutlineEditor`'s `ZoomedTitle` (docs/plugins.md "A node renders in three
  *  places"): it calls the SAME shared decorate/caret/slash/menu primitives,
  *  but wires NO structural nav and a filtered `/` palette. `onText`
  *  is born-aware (creates the node on the first non-empty input, possibly async
@@ -184,7 +184,7 @@ export interface MiniEditorHandle {
  *  `ZoomedTitle`'s contentEditable wiring (onInput/onPaste/onCopy/onCut/onFocus/
  *  onBlur/onKeyDown + the slash/menus engines + the caret-reveal watcher + the
  *  `*:before-text` node slots -- the THIRD render path for a node's decorations,
- *  AGENTS.md "A node renders in three places"). The duplication is accepted rather
+ *  docs/plugins.md "A node renders in three places"). The duplication is accepted rather
  *  than extracting a shared hook (that would touch the outline's hot path for one
  *  consumer). When you change caret/decorate/menu/slot behavior in ZoomedTitle,
  *  mirror it here (and vice versa). Two DELIBERATE divergences from the title:

--- a/src/data/kv-api.ts
+++ b/src/data/kv-api.ts
@@ -14,7 +14,7 @@
  * promise, not an Effect value. The throw is now Effect-backed, not hand-rolled.
  *
  * Same-origin, so the Better Auth session cookie rides along automatically. See
- * AGENTS.md "typed-error channel in Effect" and ADR 0012.
+ * CONTRIBUTING.md "typed-error channel in Effect" and ADR 0012.
  */
 
 import { kvDeleteE, kvFetchE, kvPutE, runPromise } from "./kv-client-effect";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Always-on agent docs are a router: identity, universal guardrails, and leading-word pointers. Task landmines live in the doc each pointer names, so a billing or caret session does not train the harness to ignore the whole file.

## Changes

1. Agents stop paying always-on tokens for commands CONTRIBUTING and the ADRs already name.
2. Lunora `getLiveNodes` / `isPersisted` landmines sit behind ADR 0058 instead of every session.
3. Empty changeset: this PR is not news.
4. Editor, Node-field, e2e, billing, Effect, and Lunora `expectedTable` landmines move into `docs/architecture.md`, `docs/plugins.md`, `CONTRIBUTING.md`, ADR 0058, and `docs/mcp.md`.
5. Code comments cite those homes instead of `AGENTS.md` headings.

## Test plan

- `bun run check:docs` — Doc pointers OK (79 docs, 403 source files, 59 ADRs)
- Cited phrases still present in `AGENTS.md` as pointer lead-ins
- `CLAUDE.md` remains a symlink to `AGENTS.md`
- Line count: 164 → 138 (79 unique + 59 tool-owned marker lines)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f195701-b6c0-456d-8aef-1f25c296cb3b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f195701-b6c0-456d-8aef-1f25c296cb3b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

