### PR TITLE
Sit mobile spotlight focus just below the sticky header

### DIFF
--- a/.changeset/mobile-spotlight-scroll-top.md
+++ b/.changeset/mobile-spotlight-scroll-top.md
@@ -1,0 +1,5 @@
+---
+"dotflowy": patch
+---
+
+On a phone-sized screen, spotlight focus sits the lit line just under the sticky header instead of the vertical center, so the keyboard no longer covers it. Desktop centering is unchanged.

--- a/docs/adr/0060-spotlight-breathing-room.md
+++ b/docs/adr/0060-spotlight-breathing-room.md
@@ -76,7 +76,7 @@ back with every piece of machinery that made #340 heavy removed:
 - **No `visualViewport` resize handling.** The rect is read fresh per focus.
 
 **The modality split (reused from the dim, ADR 0033).** The dim eases on
-pointer focus and snaps on keyboard nav; centering rides the same
+pointer focus and snaps on keyboard nav; the align rides the same
 `spotlight-fade` modality class. A pointer jump eases ~200ms — a deliberate
 click can afford the travel. Keyboard takes a short ~120ms beat, so fast
 arrowing chases the caret without swimming; each new focus cancels the

--- a/docs/adr/0060-spotlight-breathing-room.md
+++ b/docs/adr/0060-spotlight-breathing-room.md
@@ -11,14 +11,16 @@ status: accepted
    outline floats near the vertical center of the viewport instead of hugging
    the header. The class carries NO CSS transition; the grow/collapse on
    toggle is the engine's breath tween (below).
-2. **Centering.** A focused list row slides to the vertical center of the
-   viewport. The zoomed page title (an `h2`, not a list row) centers too when
-   it holds the caret — focusing it is explicit intent, and the children come
-   back the moment a child is focused. Additionally, zooming into a node with
-   **no children** slides the title to center: a lone title at the top of an
-   empty page is exactly the "hugging the header" feeling breathing room
-   exists to fix. A zoom WITH children keeps the title at the top, because the
-   children are the content.
+2. **Alignment.** Desktop (≥768) slides a focused list row to the vertical
+   center of the visual viewport. Mobile (≤767, same gate as `useIsMobile`)
+   top-aligns it just below the sticky header so a soft keyboard does not
+   cover the caret (issue #347). The zoomed page title (an `h2`, not a list
+   row) takes the same align when it holds the caret — focusing it is
+   explicit intent, and the children come back the moment a child is focused.
+   Additionally, zooming into a node with **no children** slides the title
+   onto that align: a lone title at the top of an empty page is exactly the
+   "hugging the header" feeling breathing room exists to fix. A zoom WITH
+   children keeps the title at the top, because the children are the content.
 3. **The breath tween: padding and scroll animate as ONE thing.** On toggle,
    a single rAF tween drives the region's inline `padding-top` AND the window
    scroll in the same frames, so the row the user is anchored to stays glued
@@ -41,9 +43,9 @@ status: accepted
    knows the true first row (a DOM query finds the first _mounted_ row, which
    mid-scroll is a middle bullet), and an off-window first row rides the same
    pendingFocus mount-claim path a structural edit uses. The breath tween's
-   scroll delta centers whatever landed. Mounting with the mode already on
-   (page load) skips the animation and snaps to the steady state — an initial
-   render does not transition.
+   scroll delta uses the same align for whatever landed. Mounting with the
+   mode already on (page load) skips the animation and snaps to the steady
+   state — an initial render does not transition.
 5. **Disabling with no lit line scrolls to the top.** The menu path leaves no
    node in focus, and the collapsed padding would strand the viewport deep in
    the page — which reads as "lost": the breath tween collapses the pad and
@@ -78,9 +80,9 @@ pointer focus and snaps on keyboard nav; centering rides the same
 `spotlight-fade` modality class. A pointer jump eases ~200ms — a deliberate
 click can afford the travel. Keyboard takes a short ~120ms beat, so fast
 arrowing chases the caret without swimming; each new focus cancels the
-in-flight tween and retargets. Keyboard moves (Cmd+Shift+Up/Down) center the
+in-flight tween and retargets. Keyboard moves (Cmd+Shift+Up/Down) align the
 moved row explicitly: a move-up can reuse the DOM span, so focus never leaves
-and no `focusin` fires — the move commands schedule the centering themselves,
+and no `focusin` fires — the move commands schedule the align themselves,
 two frames out, and the focusin path covers every other focus change.
 `prefers-reduced-motion` snaps. The keyboard
 duration is one constant (`KEYBOARD_SLIDE_MS`); if 120ms ever feels slow, the
@@ -92,8 +94,9 @@ fix is that constant, not a redesign.
   the original complaint against #340; it is accepted here as the cost of the
   anchor, since the breathing room keeps short outlines — the common case —
   intact, and the dim keeps context legible.
-- No new tests. The behavior is a scroll delta and a tween; the e2e dim suite
-  covers the toggle lifecycle.
+- A unit test pins the mobile-top vs desktop-center scroll delta; e2e asserts
+  external scroll position on focusin and one non-focusin path (issue #347).
+  The dim suite still covers the toggle lifecycle.
 
 **Rejected alternatives.**
 

--- a/e2e/spotlight.spec.ts
+++ b/e2e/spotlight.spec.ts
@@ -227,4 +227,35 @@ test.describe("spotlight alignment — mobile", () => {
       })
       .toBeLessThan(ALIGN_PX);
   });
+
+  // Spotlight off: focusin does not scroll. Flip the same localStorage store
+  // the More-menu checkbox writes so enable-breath `grow()` is the only align.
+  test("enable-breath sits the lit row just below the sticky header", async ({
+    page,
+  }) => {
+    await seedOutline(page, tallTree());
+    await page.goto("/");
+    await expect(text(page, "n4")).toBeVisible({ timeout: 20_000 });
+    await text(page, "n4").evaluate((el) => el.focus());
+    await expect(text(page, "n4")).toBeFocused();
+    await expect(page.locator("body")).not.toHaveClass(/spotlight-on/);
+
+    await page.evaluate(() => {
+      window.localStorage.setItem("dotflowy:spotlight", "true");
+      window.dispatchEvent(
+        new StorageEvent("storage", { key: "dotflowy:spotlight" }),
+      );
+    });
+    await expect(page.locator("body")).toHaveClass(/spotlight-on/);
+    await expect(text(page, "n4")).toBeFocused();
+    await expect
+      .poll(
+        async () => {
+          const align = await rowAlign(page, "n4");
+          return align ? Math.abs(align.topGap) : Infinity;
+        },
+        { timeout: 15_000 },
+      )
+      .toBeLessThan(ALIGN_PX);
+  });
 });

--- a/e2e/spotlight.spec.ts
+++ b/e2e/spotlight.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test, type Page } from "@playwright/test";
 
-import { seedOutline, STANDARD_TREE } from "./fixtures";
+import { seedOutline, STANDARD_TREE, type SeedNode } from "./fixtures";
 
 // A node's OWN editable text span and its content row (the element that dims).
 const text = (page: Page, id: string) =>
@@ -18,7 +18,7 @@ async function loadWithSpotlight(page: Page, on: boolean) {
     });
   }
   await page.goto("/");
-  await expect(text(page, "alpha")).toBeVisible();
+  await expect(text(page, "alpha")).toBeVisible({ timeout: 20_000 });
 }
 
 // Spotlight focus mode (ADR 0033): while a bullet is focused, every other row
@@ -66,6 +66,7 @@ test.describe("spotlight focus mode", () => {
     await expect(row(page, "bravo")).toHaveCSS("opacity", "0.3");
 
     // No caret -> `:has(.node-text:focus)` fails -> nothing is dimmed.
+    // SAFETY: activeElement is Element | null; HTMLElement is the blur target.
     await page.evaluate(() =>
       (document.activeElement as HTMLElement | null)?.blur(),
     );
@@ -84,7 +85,7 @@ test.describe("spotlight focus mode", () => {
     await page.goto("/alpha");
     const title = page.locator("h2.zoomed-title");
     const titleText = page.locator("h2.zoomed-title .node-text");
-    await expect(titleText).toBeVisible();
+    await expect(titleText).toBeVisible({ timeout: 20_000 });
 
     // Focus a child bullet -> the title dims like any parent, the child is full.
     await text(page, "alpha-1").click();
@@ -143,5 +144,87 @@ test.describe("spotlight header indicator", () => {
     await text(page, "alpha-1").click();
     await expect(text(page, "alpha-1")).toBeFocused();
     await expect(row(page, "bravo")).toHaveCSS("opacity", "1");
+  });
+});
+
+// Alignment (issue #347): desktop keeps the #344 center; mobile (≤767) sits the
+// row just below the sticky header. External scroll position only. A tall tree
+// is required on mobile so max-scroll does not clamp before the row can reach
+// the header (short outlines still clamp, same as desktop center).
+const ALIGN_PX = 8;
+
+function tallTree(): SeedNode[] {
+  const nodes: SeedNode[] = [];
+  let prev: string | null = null;
+  for (let i = 0; i < 30; i++) {
+    const id = `n${i}`;
+    nodes.push({
+      id,
+      parentId: null,
+      prevSiblingId: prev,
+      text: `Node ${i}`,
+    });
+    prev = id;
+  }
+  return nodes;
+}
+
+async function rowAlign(page: Page, nodeId: string) {
+  return page.evaluate((id) => {
+    const el = document.querySelector<HTMLElement>(`li[data-node-id="${id}"]`);
+    const header = document.querySelector("header");
+    const sticky =
+      header instanceof HTMLElement &&
+      header.parentElement instanceof HTMLElement &&
+      header.parentElement.classList.contains("sticky")
+        ? header.parentElement
+        : header;
+    if (!el || !(sticky instanceof HTMLElement)) return null;
+    const rect = el.getBoundingClientRect();
+    const viewTop = window.visualViewport?.offsetTop ?? 0;
+    const viewHeight = window.visualViewport?.height ?? window.innerHeight;
+    return {
+      topGap: rect.top - viewTop - sticky.getBoundingClientRect().height,
+      centerDelta: rect.top + rect.height / 2 - (viewTop + viewHeight / 2),
+    };
+  }, nodeId);
+}
+
+test.describe("spotlight alignment — desktop", () => {
+  test("focusin centers the lit row in the visual viewport", async ({
+    page,
+  }) => {
+    await loadWithSpotlight(page, true);
+    await text(page, "alpha-1").click();
+    await expect(text(page, "alpha-1")).toBeFocused();
+    await expect
+      .poll(async () => {
+        const align = await rowAlign(page, "alpha-1");
+        return align ? Math.abs(align.centerDelta) : Infinity;
+      })
+      .toBeLessThan(ALIGN_PX);
+  });
+});
+
+test.describe("spotlight alignment — mobile", () => {
+  test.use({ viewport: { width: 375, height: 700 } });
+
+  test("focusin sits the lit row just below the sticky header", async ({
+    page,
+  }) => {
+    await seedOutline(page, tallTree());
+    await page.addInitScript(() => {
+      window.localStorage.setItem("dotflowy:spotlight", "true");
+    });
+    await page.goto("/");
+    await expect(text(page, "n0")).toBeVisible({ timeout: 20_000 });
+    await text(page, "n4").click();
+    await expect(text(page, "n4")).toBeFocused();
+    await expect
+      .poll(async () => {
+        const align = await rowAlign(page, "n4");
+        return align ? Math.abs(align.topGap) : Infinity;
+      })
+      .toBeLessThan(ALIGN_PX);
   });
 });

--- a/src/data/spotlight.test.ts
+++ b/src/data/spotlight.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+
+import { centerScrollDelta } from "./spotlight";
+
+describe("centerScrollDelta", () => {
+  test("desktop centers the row in the visual viewport", () => {
+    // row top 400, height 40 → row center 420; view 0×800 → view center 400
+    expect(centerScrollDelta(400, 40, 0, 800)).toBe(20);
+  });
+
+  test("desktop with a visualViewport offset still centers", () => {
+    // row center 120; view top 50, height 600 → view center 350
+    expect(centerScrollDelta(100, 40, 50, 600)).toBe(-230);
+  });
+
+  test("desktop ignores sticky header height", () => {
+    expect(centerScrollDelta(400, 40, 0, 800, 56, false)).toBe(20);
+    expect(centerScrollDelta(400, 40, 0, 800, 56, false)).toBe(
+      centerScrollDelta(400, 40, 0, 800),
+    );
+  });
+
+  test("mobile top-aligns just below the sticky header", () => {
+    expect(centerScrollDelta(400, 40, 0, 800, 56, true)).toBe(344);
+  });
+
+  test("mobile subtracts visualViewport offset and header, not row height", () => {
+    expect(centerScrollDelta(100, 80, 50, 600, 56, true)).toBe(-6);
+  });
+});

--- a/src/data/spotlight.ts
+++ b/src/data/spotlight.ts
@@ -15,12 +15,15 @@
  *     no focus listeners, no generated stylesheet, no tree walk. Single-node
  *     lighting is exactly what `:focus-within` expresses, and "dim only while a
  *     caret is in the outline" is exactly `:has(:focus)`, so CSS does both.
- *  3. Centering (ADR 0060): a focused list row slides to the vertical center of
- *     the viewport. Same modality split as the dim -- a pointer jump eases
- *     (~200ms), keyboard nav takes a short 120ms beat so fast arrowing never
- *     swims. One rAF tween, cancelled and retargeted by the next focus. No
- *     virtualizer padding wells and no compensating scrolls: edge rows clamp,
- *     and the breathing-room padding (also ADR 0060) lives in OutlineEditor.
+ *  3. Alignment (ADR 0060): a focused list row slides into place. Desktop
+ *     (≥768) centers it in the visual viewport. Mobile (≤767, same gate as
+ *     `useIsMobile`) top-aligns it just below the sticky header so a soft
+ *     keyboard does not cover the caret. Same modality split as the dim -- a
+ *     pointer jump eases (~200ms), keyboard nav takes a short 120ms beat so
+ *     fast arrowing never swims. One rAF tween, cancelled and retargeted by
+ *     the next focus. No virtualizer padding wells and no compensating
+ *     scrolls: edge rows clamp, and the breathing-room padding (also ADR
+ *     0060) lives in OutlineEditor.
  *  4. The breathing-room grow/collapse on toggle (ADR 0060): ONE tween drives
  *     the region's inline padding AND the window scroll in the same frames,
  *     so the anchored row stays glued to the screen. Two separate animations
@@ -201,14 +204,51 @@ function animateBreath(
   );
 }
 
-/** Distance to scroll so a row sits at the vertical center of the viewport. */
+/**
+ * Distance to scroll so a row lands on the spotlight align.
+ * Desktop: vertical center of the visual viewport.
+ * Mobile: top of the visual viewport, just below the sticky header.
+ */
 export function centerScrollDelta(
   rowTop: number,
   rowHeight: number,
   viewTop: number,
   viewHeight: number,
+  stickyHeaderPx = 0,
+  topAlign = false,
 ): number {
+  if (topAlign) return rowTop - viewTop - stickyHeaderPx;
   return rowTop + rowHeight / 2 - (viewTop + viewHeight / 2);
+}
+
+/** Same gate as `useIsMobile` (`max-width: 767px`). Not the React hook. */
+function isMobileViewport(): boolean {
+  return window.matchMedia("(max-width: 767px)").matches;
+}
+
+/** `headerRef` is the sticky wrapper around `<header>` (plus subheader chrome). */
+function stickyHeaderHeight(): number {
+  const header = document.querySelector("header");
+  if (!(header instanceof HTMLElement)) return 0;
+  const sticky = header.parentElement;
+  const el =
+    sticky instanceof HTMLElement && sticky.classList.contains("sticky")
+      ? sticky
+      : header;
+  return el.getBoundingClientRect().height;
+}
+
+function alignScrollDelta(rowTop: number, rowHeight: number): number {
+  const viewTop = window.visualViewport?.offsetTop ?? 0;
+  const viewHeight = window.visualViewport?.height ?? window.innerHeight;
+  return centerScrollDelta(
+    rowTop,
+    rowHeight,
+    viewTop,
+    viewHeight,
+    stickyHeaderHeight(),
+    isMobileViewport(),
+  );
 }
 
 /** Zoomed title is an h2, not a list row. Focusing it is explicit intent, so
@@ -248,15 +288,14 @@ const onFocusIn = (e: FocusEvent) => {
  * view (see `animateBreath`).
  */
 
-/** Scroll `el` to the vertical center of the viewport. No-op when the engine
- *  is off, the breath tween is running, or the element has no box yet. */
+/** Scroll `el` onto the spotlight align (center on desktop, just below the
+ *  sticky header on mobile). No-op when the engine is off, the breath tween
+ *  is running, or the element has no box yet. */
 export function centerElement(el: HTMLElement, ms: number): void {
   if (!installed || breathAnimating || !el.isConnected) return;
   const rect = el.getBoundingClientRect();
   if (rect.height === 0) return;
-  const viewTop = window.visualViewport?.offsetTop ?? 0;
-  const viewHeight = window.visualViewport?.height ?? window.innerHeight;
-  slideBy(centerScrollDelta(rect.top, rect.height, viewTop, viewHeight), ms);
+  slideBy(alignScrollDelta(rect.top, rect.height), ms);
 }
 
 /** Center a target after a navigation (e.g. zooming into a childless node).
@@ -324,15 +363,9 @@ export function installSpotlight(animate = true): void {
     let delta = 0;
     if (row) {
       const rect = row.getBoundingClientRect();
-      const viewTop = window.visualViewport?.offsetTop ?? 0;
-      const viewHeight = window.visualViewport?.height ?? window.innerHeight;
       // Where the row lands once the pad has grown above it -- from where the
-      // flight actually starts, not from zero.
-      delta =
-        rect.top +
-        (breathPad() - padFrom) +
-        rect.height / 2 -
-        (viewTop + viewHeight / 2);
+      // flight actually starts, not from zero. Same align fork as focusin.
+      delta = alignScrollDelta(rect.top + (breathPad() - padFrom), rect.height);
     }
     animateBreath(padFrom, breathPad(), delta);
   };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On phone-sized screens, spotlight focus parks the lit line just under the sticky header so the keyboard no longer covers it. Desktop centering stays the same.

Fixes #347

## Changes

1. Mobile (≤767) spotlight focus sits just below the sticky header instead of vertical center.
2. The same top-align applies on focusin, mutation, childless zoom, and enable-breath.
3. Desktop (≥768) still uses the existing visual-viewport center formula.
4. Unit and e2e tests pin the mobile-top vs desktop-center delta, including a non-focusin enable-breath seam.
5. ADR 0060 records the mobile top-align fork.

**Start here:** change 1 — header height is live-measured from the sticky chrome, not a constant. Short outlines still clamp at max-scroll, same as desktop center.

## Screenshots

Desktop (≥768) still centers the lit row:

[Desktop spotlight still centers the focused row](https://cursor.com/agents/bc-ed94552b-74cb-4828-a9ec-b215117eb57c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fspotlight-desktop-center.png)

Mobile (375px) sits the lit row just below the sticky header:

[Mobile spotlight sits the focused row just below the sticky header](https://cursor.com/agents/bc-ed94552b-74cb-4828-a9ec-b215117eb57c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fspotlight-mobile-top.png)

## Test plan

- `bun run lint` — exit 0 (pre-existing react/* warnings only; 0 errors)
- `bun run typecheck` — `tsc --noEmit`, exit 0
- `bun run typecheck:test` — exit 0
- `bun run test` — 1037 pass, 0 fail
- `bunx playwright test e2e/spotlight.spec.ts --workers=1` — 11 passed, including desktop center, mobile focusin, and mobile enable-breath


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed94552b-74cb-4828-a9ec-b215117eb57c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed94552b-74cb-4828-a9ec-b215117eb57c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved spotlight scrolling on phone-sized screens so the focused line appears directly below the sticky header and remains visible above the on-screen keyboard.
  - Preserved centered spotlight positioning on desktop screens.
  - Updated spotlight movement during breathing-room expansion to follow the same responsive alignment behavior.

- **Tests**
  - Added coverage for desktop centering, mobile header-aware positioning, viewport offsets, and end-to-end spotlight alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->